### PR TITLE
Add product/app-namer skill: App Store name generation + validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Four repos, four layers — use one or all:
 
 | Layer | Repo | What it is |
 |---|---|---|
-| Knowledge | **claude-code-apple-skills** ← you are here | 139 skills — how to build right |
+| Knowledge | **claude-code-apple-skills** ← you are here | 140 skills — how to build right |
 | Workflow | [SwiftShip](https://github.com/rshankras/SwiftShip) | 33 /apple:* commands — spec-driven idea → App Store |
 | Action | [indie-app-autopilot](https://github.com/rshankras/indie-app-autopilot) | 7 agents — GitHub issue → App Store |
 | Integration | [asc-metadata-mcp](https://github.com/rshankras/asc-metadata-mcp) | 65+ MCP tools — live App Store Connect API |
@@ -20,7 +20,7 @@ Four repos, four layers — use one or all:
 | Category | Skills | Purpose |
 |----------|--------|---------|
 | **Generators** | 62 | Production-ready code for common features |
-| **Product** | 13 | Idea discovery to App Store workflow |
+| **Product** | 14 | Idea discovery to App Store workflow |
 | **iOS** | 9 | Code review, UI review, navigation, iPad, migration, accessibility, simulator/device runs |
 | **macOS** | 8 | Tahoe APIs, SwiftData, AppKit bridge |
 | **Testing** | 8 | TDD workflows, test infrastructure, snapshot tests |
@@ -43,7 +43,7 @@ Four repos, four layers — use one or all:
 | **Release Review** | 1 | Pre-release audit checklists |
 | **Shared** | 2 | Meta-skills for creating (`skill-creator`) and auditing (`skill-auditor`) skills |
 
-**Total: 139 skills across 23 categories** (category index files not counted)
+**Total: 140 skills across 23 categories** (category index files not counted)
 
 ## Quick Start
 
@@ -76,7 +76,7 @@ cp -r claude-code-apple-skills/skills ~/.claude/skills/
 skills/
 ├── ios/                    # iOS code review, UI review, planning, navigation, iPad, migration, accessibility, device runs (CLI)
 ├── macos/                  # macOS patterns, Tahoe APIs, SwiftData
-├── product/                # Idea to App Store workflow (13 skills)
+├── product/                # Idea to App Store workflow (14 skills)
 ├── generators/             # Code generators (62 skills)
 │   ├── logging-setup/
 │   ├── analytics-setup/

--- a/skills/product/SKILL.md
+++ b/skills/product/SKILL.md
@@ -33,6 +33,13 @@ Brainstorm and rank app ideas via 5 lenses.
 - Feasibility filtering and scoring
 - Ranked shortlist of 3-5 ideas with `next_step` commands
 
+**app-namer/**
+Turn a chosen idea into validated, App-Store-ready name candidates.
+- Branded vs. descriptive vs. hybrid archetypes, paired with a subtitle
+- App Store display rules (30-char limit, Home-Screen truncation, name/subtitle interplay)
+- Validation gauntlet: App Store Connect name, trademark knockout, domain/.app, social handle, linguistic safety
+- Ranked shortlist with scores and a "reserve now" action; feeds `app-store/keyword-optimizer`
+
 ### Discovery & Validation
 
 **product-agent/**
@@ -138,7 +145,8 @@ Product development workflow guide.
 1. Use `idea-generator/` to brainstorm and rank ideas
 2. Pick top idea from shortlist
 3. Run `product-agent/` to validate the idea
-4. Continue with market research and specs
+4. Run `app-namer/` to name it and reserve the App Store name
+5. Continue with market research and specs
 
 **User has new app idea:**
 1. Use `product-agent/` for initial validation

--- a/skills/product/WORKFLOW.md
+++ b/skills/product/WORKFLOW.md
@@ -202,6 +202,7 @@ ProductAgent provides a complete "Idea to App Store" workflow through a combinat
 | Phase | How to Activate | Output |
 |-------|-----------------|--------|
 | Idea Discovery | Say "I don't know what to build" or "give me app ideas" | idea-shortlist.json |
+| App Naming | Say "name my app" or "what should I call it" | app-name-shortlist.json |
 | Product Planning | Say "validate this idea" or "should I build..." | product-plan-*.md |
 | Competitive Analysis | Say "analyze competitors" or "competitive analysis" | competitive-analysis.md |
 | Market Research | Say "market research" or "market sizing" | market-research.md |
@@ -218,6 +219,7 @@ ProductAgent provides a complete "Idea to App Store" workflow through a combinat
 ```
 project/
 ├── product-plan-*.md              # Product development plan (from CLI)
+├── app-name-shortlist.json        # Validated name candidates (from app-namer)
 ├── competitive-analysis.md        # Competitive analysis (from skill)
 ├── market-research.md             # Market research (from skill)
 └── docs/

--- a/skills/product/app-namer/SKILL.md
+++ b/skills/product/app-namer/SKILL.md
@@ -1,0 +1,257 @@
+---
+name: app-namer
+description: Turn an app idea into validated, App-Store-ready name candidates. Use when the user says "name my app", "what should I call it", "app name ideas", "help me name this app", "is this name available", or needs to pick a brandable, ownable name before reserving it in App Store Connect.
+allowed-tools: [Read, Write, WebSearch, WebFetch, AskUserQuestion]
+---
+
+# App Namer Skill
+
+Takes an app idea or one-liner and produces a ranked shortlist of 5-8 **validated** name candidates — not random brainstorming. Each candidate is generated from a naming archetype, paired with a subtitle, checked against App Store display rules, and run through an availability gauntlet (App Store Connect name, trademark, domain, handle) before it's recommended.
+
+The output is a name you can reserve in App Store Connect today, with the keyword work already aligned to feed the `app-store/keyword-optimizer` skill.
+
+## When This Skill Activates
+
+Use this skill when the user:
+- Has an app idea but no name ("what should I call it?")
+- Wants name ideas or a naming brainstorm for a specific app
+- Needs to know if a name is available / safe to use
+- Is about to create the app record in App Store Connect and needs to reserve a name
+- Wants to rename an existing app and needs ownable, ASO-smart options
+- Picked an idea from `idea-generator` and needs the name before writing the PRD
+
+**No app idea yet?** Run `product/idea-generator` first, then come back with the chosen idea.
+
+**Already have a locked name and just want ASO?** Skip this skill — go to `app-store/keyword-optimizer`.
+
+## Reference Files
+
+Before generating names, load both reference files:
+
+| File | Purpose |
+|------|---------|
+| **naming-strategies.md** | The 3 archetypes, naming techniques, App Store display mechanics (30-char limit, home-screen truncation, name/subtitle interplay), good/bad examples |
+| **validation-checklist.md** | The knockout gauntlet — App Store Connect name availability, trademark sanity check, domain/.app, social handles, linguistic safety |
+
+## What This Skill Does
+
+```
+Idea/positioning
+   ↓  elicit
+Naming brief (what it does, who it's for, personality, scope ceiling)
+   ↓  generate across archetypes
+20-40 raw candidates (branded / descriptive / hybrid)
+   ↓  filter (pronounce, spell, truncate, confusability)
+8-12 survivors
+   ↓  pair with subtitle + score
+Ranked candidates with name + subtitle + display preview
+   ↓  validate (ASC name / trademark / domain / handle)
+5-8 validated candidates
+   ↓
+Recommendation + "reserve now" action
+```
+
+## The Naming Process
+
+### Step 1: Build the Naming Brief
+
+If the user hasn't given enough context, gather it with AskUserQuestion. You need:
+
+| Field | Why it matters |
+|-------|----------------|
+| **One-liner** | What the app does in one sentence — drives descriptive/hybrid candidates |
+| **Target user** | Tone calibration (pro tool vs. playful consumer app) |
+| **Personality** | Serious, playful, minimal, premium, technical? Sets the archetype mix |
+| **Category** | App Store category — affects trademark class and competitor naming norms |
+| **Scope ceiling** | Will it stay single-purpose or grow? A too-descriptive name boxes you in |
+| **Existing brand** | Company/developer name, existing app family to stay consistent with |
+
+If the user gives a one-liner and nothing else, infer sensible defaults, **state your assumptions**, and proceed — don't block on a full questionnaire.
+
+### Step 2: Generate Across Archetypes
+
+Generate 20-40 raw candidates spread across the three archetypes (see **naming-strategies.md** for each technique and examples):
+
+1. **Branded / invented** — coined, ownable, zero literal meaning (Spotify, Halide, Bevel, Bear)
+2. **Descriptive** — says what it does, carries a keyword (Sleep Cycle, PDF Expert, Pocket Casts)
+3. **Hybrid / suggestive** — a real or twisted word that evokes the benefit (Streaks, Overcast, Carrot Weather, Drafts)
+
+Aim for roughly **40% hybrid, 30% branded, 30% descriptive** for a typical indie app — hybrid names tend to win because they're ownable *and* memorable, with the descriptive keyword pushed into the subtitle.
+
+Use the techniques in **naming-strategies.md**: real words, compounds, portmanteaus, prefix/suffix, dropped vowels, foreign words, metaphors.
+
+### Step 3: Filter Hard and Fast
+
+Kill any candidate that fails a basic filter before spending effort scoring it:
+
+- ❌ Can't be pronounced correctly on first read
+- ❌ Can't be spelled correctly after hearing it once (the "radio test")
+- ❌ (iOS) Doesn't read cleanly when truncated to ~12 characters on the Home Screen — relaxes for Mac apps (see naming-strategies.md)
+- ❌ Confusable with a major existing app (Notes, Notion, Things, etc.)
+- ❌ Purely generic/descriptive with no distinctiveness (un-trademarkable)
+- ❌ Produces an ugly bundle ID or has awkward casing
+
+Target 8-12 survivors going into scoring.
+
+### Step 4: Pair With a Subtitle
+
+For each survivor, write the `Name — Subtitle` pairing the way it appears on the App Store. This is where the ASO strategy lives:
+
+```
+[Brand Name] — [Descriptive keyword phrase]
+
+Halide — Pro Camera
+Streaks — Habit Tracker
+Bear — Markdown Notes
+```
+
+The **name** carries the brand; the **subtitle** carries the searchable keywords. This means a branded/hybrid name doesn't need to be descriptive — the subtitle does that job. Both are 30-char fields and both are indexed. (See `app-store/keyword-optimizer` for full keyword allocation.)
+
+### Step 5: Score Each Candidate
+
+Score each candidate 1-10 on six dimensions:
+
+| Dimension | WEAK (1-3) | STRONG (4-7) | EXCELLENT (8-10) |
+|-----------|------------|--------------|------------------|
+| **Memorability** | Forgettable, generic | Distinctive | Sticky, instantly recalled |
+| **Clarity/Fit** | Misleading or opaque | Evokes the benefit (with subtitle) | Name+subtitle = instant understanding |
+| **Availability** | Name & domain taken, TM conflict | Domain workaround, name free | Name + .com/.app + clean TM headroom |
+| **ASO Value** | Dead keyword-wise | Subtitle carries keywords | Brandable + subtitle owns a keyword |
+| **Pronounce/Spell** | Fails radio test | Minor ambiguity | Say it once, spell it right, Siri-safe |
+| **Scalability** | Boxed into v1 scope | Some room | Grows with the product |
+
+**Overall = weighted average**, with **Availability and Memorability weighted 1.5×** (an unavailable name scores zero regardless of how clever it is).
+
+### Step 6: Validate the Top Candidates
+
+Run the top 5-8 through the gauntlet in **validation-checklist.md**. For each, record status as `available` / `taken` / `conflict` / `unchecked`:
+
+1. **App Store name** — exact-name search on the App Store; reserve in App Store Connect if clear
+2. **Trademark knockout** — USPTO/EUIPO + web search in the software class (not legal clearance)
+3. **Domain** — `.com`, then `.app`, then `get-/try-/use-` prefixes
+4. **Social handle** — consistent handle across X / Instagram (nice-to-have)
+5. **Linguistic safety** — no bad meanings in top ASO markets, Siri-pronounceable
+
+Use WebSearch/WebFetch to check what's checkable (existing App Store apps, trademark databases, domain registrars). For anything you can't verify, mark it `unchecked` and tell the user exactly how to check — **never report a name as available if you didn't verify it.**
+
+### Step 7: Recommend and Reserve
+
+Present the ranked shortlist, then make a single clear recommendation. End with the action: **reserve the winning name in App Store Connect now** — App Store names are unique and first-come, so a name that's available today can be gone tomorrow.
+
+## Output Structure
+
+```json
+{
+  "naming_brief": {
+    "one_liner": "On-device app that turns leftover ingredients into recipe suggestions",
+    "target_user": "Home cooks who want to reduce food waste",
+    "personality": "warm, simple, a little playful",
+    "category": "Food & Drink",
+    "scope_ceiling": "could expand to meal planning and grocery lists",
+    "assumptions": ["No existing brand to match", "iOS-first, US market primary"]
+  },
+  "shortlist": [
+    {
+      "rank": 1,
+      "name": "Larder",
+      "archetype": "hybrid",
+      "name_subtitle": "Larder — Recipes From Leftovers",
+      "char_counts": { "name": 6, "subtitle": 30 },
+      "home_screen_preview": "Larder",
+      "rationale": "Evokes the source (what's in your larder) without being literal about recipes; warm, short, and far more ownable than the generic 'Pantry'; subtitle carries the 'recipes' + 'leftovers' keywords.",
+      "scores": {
+        "memorability": 8,
+        "clarity_fit": 8,
+        "availability": 9,
+        "aso_value": 8,
+        "pronounce_spell": 9,
+        "scalability": 9
+      },
+      "overall_score": 8.4,
+      "validation": {
+        "app_store_name": "no live 'Larder' recipe app found — verify in ASC New App and reserve",
+        "trademark": "unchecked — run USPTO TESS for 'Larder' in Class 9/42 before committing",
+        "domain": "larder.com taken; larder.app available — recommended buy",
+        "handle": "@larder taken; @larderapp available",
+        "linguistic": "clean in EN/ES/DE/JA; Siri-safe"
+      },
+      "risks": "Slightly less self-explanatory than 'Pantry' on its own — the subtitle does the clarifying. Confirm the trademark knockout before reserving."
+    }
+  ],
+  "filtered_out": [
+    { "name": "Pantry", "reason": "Too generic to own — App Store name and pantry.com almost certainly taken, un-trademarkable" },
+    { "name": "LeftoverChef", "reason": "Two-word compound truncates badly on Home Screen; 'Chef' is crowded and trademark-risky" },
+    { "name": "Fridgify", "reason": "Cute but fails the radio test — users will spell it 'Fridgefy'/'Fridgi'" }
+  ],
+  "recommendation": "Lead with Rank 1 if a clean App Store variant clears reservation; otherwise Rank 2. Reserve the winner in App Store Connect immediately, then run app-store/keyword-optimizer to lock the subtitle and keyword field.",
+  "next_step": "Reserve the name in App Store Connect → run keyword-optimizer for subtitle + 100-char keywords → feed the name into prd-generator"
+}
+```
+
+## End-to-End Example
+
+**Brief:** "A minimalist iOS app that tracks daily water intake with a single tap. For health-conscious people who find existing trackers cluttered. Personality: clean, calm, premium. Stays single-purpose."
+
+**Generate (sample of ~30):**
+- *Branded:* Drift, Sip, Wello, Aqo, Nim
+- *Descriptive:* Water Daily, Hydrate, Daily Water, Intake
+- *Hybrid:* Gulp, Tide, Droplet, Wave, Brim, Flow
+
+**Filter:** Drop "Intake" (generic, taken), "Hydrate" (crowded, hard to own), "Aqo" (fails spell test).
+
+**Pair + score top survivors:**
+
+| Name | Pairing | Memorable | Avail. | ASO | Overall |
+|------|---------|-----------|--------|-----|---------|
+| Brim | Brim — Water Tracker | 8 | 7 | 7 | 7.6 |
+| Sip | Sip — Daily Water | 9 | 5 | 7 | 7.2 |
+| Droplet | Droplet — Hydration | 7 | 6 | 8 | 7.0 |
+
+**Validate (top 3):** "Sip" — App Store name almost certainly taken (very common), sip.com taken. "Brim" — exact App Store name worth checking, brim.app likely available, no obvious TM conflict in Class 9. "Droplet" — used by DigitalOcean (TM risk in software).
+
+**Recommendation:** "Go with **Brim — Water Tracker**. It's short (stands alone on the Home Screen), calm and ownable, almost certainly clears the App Store name, and `brim.app` is available. Avoid Droplet (DigitalOcean trademark in software). Reserve 'Brim' in App Store Connect now, then run keyword-optimizer to fill the subtitle and keyword field around 'water, hydration, drink, reminder.'"
+
+## Integration With Other Skills
+
+```
+product/idea-generator        → pick an idea
+        ↓
+product/app-namer (THIS SKILL) → name it + reserve it
+        ↓
+app-store/keyword-optimizer    → lock subtitle + 100-char keywords around the name
+        ↓
+product/prd-generator          → [App Name] is now filled in
+        ↓
+generators/app-icon-generator  → icon that matches the name's personality
+```
+
+The name you pick here is the highest-weighted ASO field and a permanent brand decision — it flows into the keyword strategy, the PRD, the icon, and the bundle ID. Get it right before you build.
+
+## When NOT to Use This Skill
+
+- **No idea yet** — run `idea-generator` first
+- **Name is already locked** — go to `keyword-optimizer` for ASO
+- **You need the legal clearance** — this skill does a *knockout* search, not trademark clearance; consult an attorney before filing
+- **Renaming a high-traffic live app** — renaming resets branded search equity; see `keyword-optimizer/existing-app-strategy.md` before changing a name that's working
+
+## Deliverables
+
+At the end of this skill you should have:
+
+- [ ] Naming brief captured (one-liner, user, personality, category, scope, assumptions)
+- [ ] Candidates generated across all three archetypes
+- [ ] Filtered down with reasons (pronounce/spell/truncate/confusability)
+- [ ] Each finalist paired as `Name — Subtitle` with char counts ≤ 30
+- [ ] Home-screen truncation preview for each
+- [ ] Scored on all six dimensions, ranked by weighted overall
+- [ ] Top candidates run through the validation gauntlet with status flags
+- [ ] One clear recommendation + the "reserve in App Store Connect now" action
+- [ ] `next_step` pointing to keyword-optimizer and prd-generator
+
+## Output File Location
+
+Save results to `app-name-shortlist.json` (project root), using the Output Structure above.
+
+---
+
+**Generate wide, filter hard, validate before you fall in love.** The best app name is short, ownable, spellable, available today, and lets the subtitle do the keyword work.

--- a/skills/product/app-namer/naming-strategies.md
+++ b/skills/product/app-namer/naming-strategies.md
@@ -1,0 +1,155 @@
+# Naming Strategies & App Store Display Mechanics
+
+Reference for the `app-namer` skill: the three archetypes, generation techniques, and the App Store rules that constrain every name.
+
+## The Three Archetypes
+
+Every app name sits on a spectrum from "pure brand" to "pure description." Pick the mix deliberately.
+
+### 1. Branded / Invented
+
+A coined word with no inherent meaning. You build the meaning through the product.
+
+**Examples:** Spotify, Halide, Bevel, Bear, Things, Fantastical, Tot, Bumpr, Reeder
+
+| Pros | Cons |
+|------|------|
+| Fully ownable and trademarkable | Zero keyword value on its own |
+| App Store name almost always available | Requires marketing to build meaning |
+| Distinctive, no competitor confusion | Slower organic discovery early on |
+| Room to expand scope later | Harder to "get" at a glance |
+
+**Best when:** the app is a long-term brand, the category is crowded with descriptive names, or personality matters more than instant clarity.
+
+### 2. Descriptive
+
+The name says what the app does.
+
+**Examples:** Sleep Cycle, PDF Expert, Pocket Casts, Weather Line, Just Press Record, Day One
+
+| Pros | Cons |
+|------|------|
+| Instant clarity — no explanation needed | Hard or impossible to trademark |
+| Carries a real ASO keyword in the name | Generic, blends into the category |
+| Lower marketing burden | Exact name usually already taken |
+| | Boxes you in if scope grows |
+
+**Best when:** single-purpose utility, ASO-driven discovery is the whole strategy, and you don't need brand defensibility.
+
+### 3. Hybrid / Suggestive (usually the winner)
+
+A real or twisted word that *evokes* the benefit without literally describing it.
+
+**Examples:** Streaks, Overcast, Carrot Weather, Drafts, Craft, Bumpr, Flighty, Dark Noise, Mela
+
+| Pros | Cons |
+|------|------|
+| Ownable *and* evocative | Needs a subtitle/tagline to fully land |
+| Usually trademarkable | Moderate (not instant) clarity |
+| Memorable, distinctive | |
+| Room to grow beyond v1 | |
+
+**Best when:** almost always, for indie App Store apps. The hybrid name carries the brand; the **subtitle carries the descriptive keywords**. `Flighty — Live Flight Tracker`, `Mela — Recipe Manager`, `Streaks — Habit Tracker`.
+
+### Default Recommendation
+
+For a typical indie app, lead with a **hybrid name + descriptive subtitle**. You get the ownability of a brand and the discoverability of a descriptor, split across the two 30-char fields that Apple indexes.
+
+## Generation Techniques
+
+Use these to produce raw candidates. Mix techniques across archetypes.
+
+| Technique | How | Examples |
+|-----------|-----|----------|
+| **Real word, repurposed** | Take an everyday word that evokes the feeling | Bear, Craft, Tide, Halide, Overcast |
+| **Compound** | Fuse two short words | Pocket Casts, Dark Noise, Day One |
+| **Portmanteau** | Blend two words into one | Instagram (instant+telegram), Pinterest |
+| **Prefix / suffix** | Add -ly, -ify, -kit, -io, get-, try- | Calmly, Notify, get-, Flighty |
+| **Dropped vowels / respelling** | Tweak spelling for ownability (use with care — radio-test it) | Flickr, Tumblr, Lyft |
+| **Metaphor** | Name the concept the app stands for | Carrot (snark), Streaks, Anchor |
+| **Foreign word** | A fitting word from another language | Mela (apple, Italian), Bevel |
+| **Person / character** | A name that gives the app a persona | Carrot, Hazel, Bear |
+| **Short + punchy** | One syllable, 3-5 letters, maximum ownability | Sip, Tot, Bear, Tide, Brim |
+
+## App Store Display Mechanics (Hard Constraints)
+
+These are non-negotiable platform rules. Every candidate must respect them.
+
+### The 30-Character Name Limit
+
+- The **App Name is capped at 30 characters** and is both the displayed name *and* the single highest-weighted ASO ranking field.
+- The **Subtitle is a separate 30-character field**, also indexed, shown directly under the name.
+- Apple indexes words from the name **and** subtitle (and the 100-char keyword field). See `app-store/keyword-optimizer` for full allocation and cross-field deduplication.
+
+### Home-Screen Truncation (the missed one)
+
+Under the icon on the Home Screen, iOS shows only about **11-12 characters** before truncating with an ellipsis (it's proportional width, not a hard count — wide letters truncate sooner).
+
+```
+✅ "Fantastical" (11)  → shows fully
+✅ "Halide" (6)        → shows fully
+⚠️ "Carrot Weather"   → shows "Carrot Weat…" (the brand word still reads)
+❌ "Productivity Pro"  → shows "Productivit…" (useless)
+```
+
+**Rule:** the standalone part of the name — everything *before* a `—` or `:` separator — should read cleanly when truncated to ~12 characters. This is why short brand words win: `Bear`, `Things`, `Drafts` need no truncation at all.
+
+**On macOS this rule relaxes.** A Mac app's name lives in the menu bar (usually an icon, no text), Launchpad, the Applications folder, the Dock tooltip, and the Mac App Store — there's no Home-Screen icon with iOS's tight ~12-character cutoff. Launchpad and Finder truncate, but far more generously. So for a Mac app, treat length as a soft preference (short still wins for memorability), not a hard limit — don't reject an otherwise strong 8-14 character name on truncation grounds alone.
+
+### What the Name May NOT Contain
+
+Apple rejects or forces changes for:
+- ❌ Another app's name or a trademark you don't own
+- ❌ Prices or pricing terms ("Free", "$2.99")
+- ❌ "for iPhone", "for iPad", "for Apple Watch", or platform names
+- ❌ "best", "#1", or unverifiable superlatives
+- ❌ Emoji or decorative special characters
+- ❌ Misleading terms (functionality the app doesn't have)
+
+### Bundle ID Implications
+
+The bundle identifier (reverse-DNS, e.g. `com.yourcompany.brim`) is **permanent** and set once. It's independent of the display name, but a clean name yields a clean bundle ID, product name, and Xcode scheme.
+
+- ✅ "Brim" → `com.company.brim` (clean)
+- ⚠️ "Carrot Weather" → `com.company.carrotweather` (fine, just longer)
+- ❌ "My App!! 2.0" → forces an awkward sanitized identifier
+
+Quick check: lowercase the name, strip spaces and punctuation — does it still look like a clean identifier?
+
+## The Radio Test, Siri Test, and Confusability
+
+Three quick gut-checks every finalist must pass:
+
+1. **Radio test** — say the name out loud once. Can someone spell it correctly without seeing it? (`Flickr` fails; `Bear` passes.)
+2. **Siri test** — "Hey Siri, open ___." Is it pronounceable and distinct enough that a voice assistant won't mishear it? Avoid names that collide with common words or other app names.
+3. **Confusability** — is it one letter or one sound away from a major app (Notes, Notion, Things, Bear, Halide)? If users could type a competitor's name by mistake, drop it.
+
+## Good vs. Bad Naming Patterns
+
+#### ✅ Good
+
+```
+Streaks — Habit Tracker
+  Hybrid brand (evocative, ownable, short), descriptive keyword in subtitle,
+  no truncation, trademarkable, Siri-safe.
+
+Flighty — Live Flight Tracker
+  Invented-ish brand with personality, subtitle owns "flight tracker",
+  clean bundle ID (com.x.flighty).
+```
+
+#### ❌ Bad
+
+```
+Best Habit Tracker Pro 2026
+  "Best" is puffery (rejection risk), no brand, truncates to "Best Habit…",
+  un-trademarkable, blends into 500 identical names.
+
+Habitz
+  Cute respelling fails the radio test (users type "Habits"),
+  hands the traffic to the correctly-spelled competitor.
+```
+
+#### Why it matters
+
+The name is the most permanent, highest-leverage decision in the app's marketing. It's the #1 ASO field, the Home-Screen label, the brand you'll say on podcasts, and the bundle ID you can never change. A name that's ownable, spellable, and short pays compounding dividends; a clever-but-unspellable one leaks every install to a competitor.

--- a/skills/product/app-namer/validation-checklist.md
+++ b/skills/product/app-namer/validation-checklist.md
@@ -1,0 +1,103 @@
+# Name Validation Gauntlet
+
+Reference for the `app-namer` skill. A clever name is worthless if it's taken, trademarked, or has no home online. Run every finalist through these five checks **before recommending it**. Record each as `available` / `taken` / `conflict` / `unchecked`.
+
+> **Never report a name as "available" you didn't actually verify.** If you can't check something, mark it `unchecked` and tell the user the exact step to run. A false "it's free!" leads to a wasted brand investment.
+
+## 1. App Store Name Availability (the #1 blocker)
+
+App Store app names are **unique across the entire App Store** and assigned first-come.
+
+### How it works
+- You reserve a name by **creating the app record in App Store Connect** (you can create the record and reserve the name *without* submitting a build).
+- A reserved-but-unused name still blocks everyone else. Apple may reclaim a name not used within a period, and holds names from removed apps for a while before releasing them — so "no app by that name exists today" does **not** guarantee it's free to reserve.
+- The name only needs to be unique; you can differentiate with a separator + subtitle (`Pantry:` vs `Pantry`) if the bare word is taken.
+
+### How to check
+1. **Exact-name search on the App Store** (WebSearch / App Store) — is there a live app with that exact name? If yes, it's taken.
+2. **Definitive check:** the user opens App Store Connect → **Apps → (+) New App** → types the name. ASC immediately says whether it's available to reserve. This is the only authoritative check.
+
+### Action
+As soon as a name passes scoring and has no obvious conflict, tell the user to **reserve it in App Store Connect now**. Names disappear; reservation is free and doesn't commit you to shipping.
+
+## 2. Trademark Knockout Search
+
+This is a **knockout search** (catch obvious conflicts), **not legal clearance**. State that plainly.
+
+> ⚠️ Not legal advice. A clean knockout search reduces risk; it does not clear you to file or guarantee no conflict. Consult a trademark attorney before registering a mark or investing heavily in a brand.
+
+### What to search
+- **USPTO** — `tmsearch.uspto.gov` for live US marks. Focus on the software classes:
+  - **Class 9** — downloadable software / mobile apps
+  - **Class 42** — SaaS / software-as-a-service
+- **EUIPO** — `euipo.europa.eu` eSearch for EU marks (if targeting Europe)
+- **Plain web + App Store search** — an existing well-known brand in your space is a common-law risk even without a registration
+
+### How to read results
+| Finding | Verdict |
+|---------|---------|
+| Identical mark, same/related class (software) | 🔴 Conflict — drop it |
+| Confusingly similar mark in software | 🟠 Risk — get attorney input |
+| Same word, unrelated class (e.g. a snack brand) | 🟡 Usually OK for software, note it |
+| No live marks in software classes | 🟢 Clear knockout — still not legal clearance |
+
+For trademarked *keywords* (vs. names) see `app-store/keyword-optimizer/keyword-criteria.md` → "Trademark Considerations" — the same logic applies to brand terms in your title/subtitle.
+
+## 3. Domain Availability
+
+You want a web home for the app (landing page, support URL, privacy policy host).
+
+### Priority order
+1. **`brandname.com`** — ideal but for short words almost always taken
+2. **`brandname.app`** — the `.app` TLD is purpose-built for apps, HTTPS-enforced, and far more available. Excellent and increasingly expected for indie apps.
+3. **Prefixed `.com`** — `getbrand.com`, `trybrand.com`, `usebrand.com`, `brandapp.com`
+4. **Other TLDs** — `.io`, `.co` as fallbacks
+
+### How to check
+WebSearch / WebFetch a registrar (e.g. query "is `<name>.app` available domain") or a whois lookup. Mark which exact domain is the recommended buy.
+
+A taken `.com` is **not** a dealbreaker if `.app` or a clean prefixed domain is free — but flag it so the user knows the trade-off.
+
+## 4. Social Handle Availability (nice-to-have)
+
+A consistent handle across platforms helps brand recall but is **not a blocker**.
+
+- Check **X/Twitter, Instagram, and (if relevant) TikTok / Mastodon / Bluesky** for `@brandname`, falling back to `@brandnameapp` or `@getbrandname`.
+- A quick way: search each platform, or a multi-platform username checker.
+- Record the best consistent handle available; don't kill an otherwise great name over a taken handle.
+
+## 5. Linguistic & Pronounceability Safety
+
+The name ships worldwide and gets spoken to Siri.
+
+- **No unfortunate meanings** in top ASO markets — at minimum spot-check **Chinese, Japanese, German, Spanish, French** (the highest-revenue App Store locales). A name that's fine in English can be a slur, a laugh, or a competitor's word elsewhere.
+- **Siri-pronounceable** — "Hey Siri, open ___" should work; avoid respellings and silent letters.
+- **Spellable on first hearing** (the radio test) — if users will mistype it, they'll land on a competitor.
+- **No homophone collision** with a big app (sounds like Notion, Bear, Things…).
+
+## Validation Summary Table
+
+Fill this in for each finalist before recommending:
+
+```
+NAME: Brim
+┌────────────────────┬────────────┬──────────────────────────────────────┐
+│ Check              │ Status     │ Notes / Action                         │
+├────────────────────┼────────────┼──────────────────────────────────────┤
+│ App Store name     │ unchecked  │ No live "Brim" tracker found — verify  │
+│                    │            │ in ASC New App, reserve if free        │
+│ Trademark (Cls 9)  │ 🟢 clear    │ No live software mark in USPTO TESS     │
+│ Domain             │ 🟢 .app free │ brim.com taken → buy brim.app           │
+│ Social handle      │ 🟡 partial  │ @brim taken → @brimapp available        │
+│ Linguistic/Siri    │ 🟢 clear    │ Clean EN/ES/DE/JA; Siri-safe            │
+└────────────────────┴────────────┴──────────────────────────────────────┘
+VERDICT: Recommend — reserve "Brim" in App Store Connect, buy brim.app.
+```
+
+## Go / No-Go Rules
+
+- 🔴 **No-Go** if: App Store name is taken with no workable variant, OR an identical trademark exists in software class.
+- 🟠 **Caution** if: confusingly similar trademark, or only awkward domains/handles remain — surface the risk, let the user decide.
+- 🟢 **Go** if: name reservable in ASC, clean trademark knockout, a usable domain (.com or .app), Siri-safe and spellable.
+
+When a name clears, the very next action is always: **reserve it in App Store Connect.**


### PR DESCRIPTION
## Summary

Adds `product/app-namer`, a **validation-first** naming skill that turns an app idea into App-Store-ready name candidates — not generic brainstorming.

## What it does

- Generates candidates across three archetypes (**branded / descriptive / hybrid**), each paired with a subtitle
- Applies App Store **display mechanics**: 30-char name limit, iOS Home-Screen truncation (with a macOS relaxation note), name/subtitle keyword interplay
- Runs each finalist through a **validation gauntlet**: App Store Connect name availability, trademark knockout (USPTO/EUIPO Class 9/42), domain/.app, social handle, linguistic/Siri safety
- Scores on **6 dimensions** and ends with a "reserve in App Store Connect now" action

## Structure

- `SKILL.md` — process, scoring rubric, JSON output, end-to-end example
- `naming-strategies.md` — archetypes, techniques, App Store display mechanics
- `validation-checklist.md` — the knockout gauntlet

## Wiring

- Indexed in `product/SKILL.md` (module + example workflow) and `WORKFLOW.md` (activation table + file locations)
- Cross-links to `app-store/keyword-optimizer` and `product/idea-generator`
- README counts: 139 → 140 total, Product 13 → 14

## Validated by a live run

Ran end-to-end on a real idea (a macOS eye-break / 20-20-20 app). The gauntlet correctly killed taken/trademarked names — **Blink** (Amazon trademark + BlinkMate), **Iris / LookAway / Respite** (existing apps) — and surfaced an ownable survivor. The run also exposed the iOS-centric truncation rule, now fixed with a macOS note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
