### PR TITLE
Add generators/preview-data-generator: SwiftUI preview data + variant matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Four repos, four layers — use one or all:
 
 | Layer | Repo | What it is |
 |---|---|---|
-| Knowledge | **claude-code-apple-skills** ← you are here | 140 skills — how to build right |
+| Knowledge | **claude-code-apple-skills** ← you are here | 141 skills — how to build right |
 | Workflow | [SwiftShip](https://github.com/rshankras/SwiftShip) | 33 /apple:* commands — spec-driven idea → App Store |
 | Action | [indie-app-autopilot](https://github.com/rshankras/indie-app-autopilot) | 7 agents — GitHub issue → App Store |
 | Integration | [asc-metadata-mcp](https://github.com/rshankras/asc-metadata-mcp) | 65+ MCP tools — live App Store Connect API |
@@ -19,7 +19,7 @@ Four repos, four layers — use one or all:
 
 | Category | Skills | Purpose |
 |----------|--------|---------|
-| **Generators** | 62 | Production-ready code for common features |
+| **Generators** | 63 | Production-ready code for common features |
 | **Product** | 14 | Idea discovery to App Store workflow |
 | **iOS** | 9 | Code review, UI review, navigation, iPad, migration, accessibility, simulator/device runs |
 | **macOS** | 8 | Tahoe APIs, SwiftData, AppKit bridge |
@@ -43,7 +43,7 @@ Four repos, four layers — use one or all:
 | **Release Review** | 1 | Pre-release audit checklists |
 | **Shared** | 2 | Meta-skills for creating (`skill-creator`) and auditing (`skill-auditor`) skills |
 
-**Total: 140 skills across 23 categories** (category index files not counted)
+**Total: 141 skills across 23 categories** (category index files not counted)
 
 ## Quick Start
 
@@ -77,7 +77,7 @@ skills/
 ├── ios/                    # iOS code review, UI review, planning, navigation, iPad, migration, accessibility, device runs (CLI)
 ├── macos/                  # macOS patterns, Tahoe APIs, SwiftData
 ├── product/                # Idea to App Store workflow (14 skills)
-├── generators/             # Code generators (62 skills)
+├── generators/             # Code generators (63 skills)
 │   ├── logging-setup/
 │   ├── analytics-setup/
 │   ├── networking-layer/
@@ -86,7 +86,7 @@ skills/
 │   ├── background-processing/
 │   ├── app-extensions/
 │   ├── data-export/
-│   └── ... (62 total)
+│   └── ... (63 total)
 ├── growth/                 # Analytics, press/media, community, indie business (4 skills)
 ├── legal/                  # Privacy policies, terms of service, EULAs
 ├── core-ml/                # Vision, NaturalLanguage, model integration
@@ -138,6 +138,7 @@ Generate production-ready Swift code that adapts to your project:
 | `push-notifications` | APNs setup |
 | `deep-linking` | URL schemes, universal links |
 | `test-generator` | Unit/UI tests (Swift Testing + XCTest) |
+| `preview-data-generator` | SwiftUI preview sample data + state/appearance variant matrix |
 | `accessibility-generator` | VoiceOver, Dynamic Type |
 | `widget-generator` | WidgetKit widgets with templates |
 | `feature-flags` | Local/remote feature flags with templates |

--- a/skills/generators/SKILL.md
+++ b/skills/generators/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: generators
-description: Code generator skills that produce production-ready Swift code for common app components. Use when user wants to add logging, analytics, onboarding, review prompts, networking, authentication, paywalls, settings, persistence, error monitoring, CI/CD pipelines, localization, push notifications, deep linking, testing, accessibility, widgets, feature flags, app icons, image caching, pagination, HTTP caching, share cards, social export, subscription lifecycle, referral systems, watermarks, streak tracking, milestone celebrations, what's new screens, lapsed user re-engagement, usage insights, variable rewards, consent flows, account deletion, permission priming, force updates, state restoration, debug menus, offline queues, feedback forms, announcement banners, quick win sessions, Spotlight indexing, App Clips, screenshot automation, background processing, app extensions, or data export.
+description: Code generator skills that produce production-ready Swift code for common app components. Use when user wants to add logging, analytics, onboarding, review prompts, networking, authentication, paywalls, settings, persistence, error monitoring, CI/CD pipelines, localization, push notifications, deep linking, testing, accessibility, widgets, feature flags, app icons, image caching, pagination, HTTP caching, share cards, social export, subscription lifecycle, referral systems, watermarks, streak tracking, milestone celebrations, what's new screens, lapsed user re-engagement, usage insights, variable rewards, consent flows, account deletion, permission priming, force updates, state restoration, debug menus, offline queues, feedback forms, announcement banners, quick win sessions, Spotlight indexing, App Clips, screenshot automation, background processing, app extensions, data export, or SwiftUI preview sample data and variant matrices.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion]
 ---
 
@@ -150,6 +150,14 @@ Test templates for unit, integration, and UI tests.
 - Mock object generation
 - ViewModel and service testing patterns
 - UI testing with page object pattern
+
+### preview-data-generator/
+Sample data and a multi-variant #Preview matrix for SwiftUI views.
+- Canvas sample data with visual edge cases (empty, long strings, missing, list)
+- Data-state previews (loaded/empty/loading/error) for UI prototyping
+- Appearance, Dynamic Type, locale/RTL, and device variant matrix
+- SwiftData in-memory seeded containers; iOS 18 PreviewModifier + @Previewable
+- Reuses test-data-factory fixtures instead of duplicating them
 
 ### accessibility-generator/
 Accessibility infrastructure for inclusive apps.

--- a/skills/generators/preview-data-generator/SKILL.md
+++ b/skills/generators/preview-data-generator/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: preview-data-generator
+description: Generate sample data and a multi-variant #Preview matrix for SwiftUI views — empty/loading/error/loaded states, light/dark, Dynamic Type, locales/RTL, and devices. Use when the user says "add previews", "sample data for previews", "preview my view in different states", "preview data", "prototype this UI", or wants realistic Xcode canvas data without hand-rolling it.
+allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion]
+---
+
+# Preview Data Generator
+
+Generates two tightly-coupled things for a SwiftUI view:
+
+1. **Sample data** tuned for the Xcode canvas — realistic instances *plus* the visual edge cases that break layouts (empty, one item, huge list, long/overflowing strings, missing images, error and loading states).
+2. **A `#Preview` matrix** — the variant blocks you'd otherwise hand-write to prototype and QA a view across light/dark, Dynamic Type, locale/RTL, device sizes, and data states.
+
+This is the design-time counterpart to `testing/test-data-factory` (which makes fixtures for the *test suite*). Where a factory already exists, this skill **reuses** `Model.fixture()` instead of inventing parallel data.
+
+## When This Skill Activates
+
+Use this skill when the user:
+- Wants sample/mock data for Xcode previews ("what do I put in the preview?")
+- Wants to preview a view in multiple states (empty / loading / error / loaded)
+- Is prototyping UI and wants light/dark, Dynamic Type, RTL, or device variants
+- Says "add previews", "preview matrix", "preview this in dark mode + large text"
+- Has a SwiftData `@Model` and needs an in-memory seeded container for previews
+- Is on Xcode 16 / iOS 18 and wants shared, cached preview data via `PreviewModifier`
+
+**Just need fixtures for unit tests?** Use `testing/test-data-factory` instead.
+**Want screenshot regression tests?** Pair this with `testing/snapshot-test-setup` — the same data + variant matrix feeds snapshot tests.
+
+## Reference Files
+
+Load both before generating:
+
+| File | Purpose |
+|------|---------|
+| **preview-data-patterns.md** | Sample-data design, the edge-case catalog, SwiftData in-memory seeding, `PreviewModifier` (iOS 18), `@Previewable`, reusing `test-data-factory` |
+| **preview-matrix.md** | The variant axes, preview `traits:`, `.environment` overrides, deployment-target fallbacks (`#Preview` vs `PreviewProvider`), data-state previews |
+
+## Pre-Generation Checks
+
+Generators are context-aware. Before writing code, detect:
+
+| Check | How | Why it matters |
+|-------|-----|----------------|
+| **Deployment target** | Read project/`.xcodeproj` or `Package.swift` | iOS 17+ → `#Preview` macro; iOS 18+ → `PreviewModifier` + `@Previewable`; below 17 → `PreviewProvider` fallback |
+| **Target view + its models** | Read the view file; Grep its `init`/properties for model types | Determines which types need sample data |
+| **Existing fixtures** | `Grep "static func fixture\|extension .*{ static (let\|var) preview"` | Reuse `Model.fixture()` / existing `.preview` — never duplicate |
+| **SwiftData** | `Grep "@Model"` on the model types | Use the in-memory `.modelContainer(inMemory:)` seed pattern, not plain structs |
+| **View shape** | Does it take a model, a ViewModel, or fetch its own data? | Drives whether to inject data, a mock VM, or a seeded container |
+| **Platform** | iOS / macOS / multiplatform | Device variants and some traits differ |
+
+Ask via AskUserQuestion only what you can't infer — e.g. "Which states matter for this view: empty, loading, error, loaded, or all four?"
+
+## Generation Process
+
+### Step 1: Build the Sample Data
+
+For each model the view needs, generate a `Model.preview` namespace with the realistic case **and the edge cases** (see **preview-data-patterns.md** for the full catalog):
+
+```swift
+extension Article {
+    /// A typical, realistic instance for the canvas.
+    static var preview: Article {
+        Article(id: UUID(), title: "Designing for the Smallest Screen",
+                author: "Mei Chen", body: String(repeating: "Lorem ipsum. ", count: 40),
+                imageURL: URL(string: "https://picsum.photos/seed/1/600/400"),
+                readMinutes: 6, isBookmarked: false)
+    }
+
+    /// Edge cases that expose layout bugs.
+    static var previewLongTitle: Article { .preview.with(title: "An Extraordinarily, Almost Unreasonably Long Headline That Wraps") }
+    static var previewNoImage: Article   { .preview.with(imageURL: nil) }
+    static var previewList: [Article]    { (1...12).map { .preview.with(id: UUID(), title: "Article \($0)") } }
+    static var previewEmpty: [Article]   { [] }
+}
+```
+
+If `Article.fixture()` already exists (from `test-data-factory`), build `.preview` *on top of it* rather than re-specifying every field.
+
+### Step 2: Build the Preview Matrix
+
+Generate the `#Preview` blocks for the axes that matter (see **preview-matrix.md**). Always include **data states** — that's the UI-prototyping payoff:
+
+```swift
+#Preview("Loaded")  { ArticleListView(state: .loaded(Article.previewList)) }
+#Preview("Empty")   { ArticleListView(state: .empty) }
+#Preview("Loading") { ArticleListView(state: .loading) }
+#Preview("Error")   { ArticleListView(state: .error("No connection")) }
+
+#Preview("Dark")        { ArticleListView(state: .loaded(Article.previewList)).preferredColorScheme(.dark) }
+#Preview("XXL Text")    { ArticleListView(state: .loaded(Article.previewList)).dynamicTypeSize(.accessibility3) }
+#Preview("German / RTL", traits: .sizeThatFitsLayout) {
+    ArticleDetailView(article: .previewLongTitle).environment(\.locale, .init(identifier: "de"))
+}
+```
+
+Scale the matrix to the request — don't emit 20 previews for a label. A reasonable default per view: the relevant **data states** + **dark mode** + **one large Dynamic Type** + (if the view has text that localizes) **one long-language/RTL** check.
+
+### Step 3: Wire Up Infrastructure (when needed)
+
+- **SwiftData view** → generate an in-memory `previewContainer` seeded with sample models, attached via `.modelContainer(previewContainer)`.
+- **Xcode 16 / iOS 18** → offer a `PreviewModifier` so the seeded container/data is built **once and cached** across every preview, applied with `#Preview(traits: .modifier(SampleData()))`.
+- **View needs `@State`/`@Bindable`** → use `@Previewable` so state lives directly in the `#Preview` body.
+
+### Step 4: Place the Code
+
+- Sample data → `Article+Preview.swift` (one file per model, in the model's group).
+- Preview blocks → either appended to the view file (Apple's convention) or a sibling `ArticleListView+Previews.swift` for large matrices. Ask if unsure.
+- Wrap preview-only data in `#if DEBUG` so it never ships in release builds.
+
+## Output Format
+
+After generating, always provide:
+
+- **Files created** — full paths (`Article+Preview.swift`, `PreviewSupport.swift`, etc.)
+- **Integration steps** — where the `#Preview` blocks went, how to open the canvas
+- **Deployment-target notes** — which API was used and why (`#Preview` / `PreviewModifier` / `PreviewProvider`)
+- **Testing instructions** — open the canvas, cycle the variants; if pairing with snapshots, how the data feeds `snapshot-test-setup`
+
+## Example Output Summary
+
+```
+✅ Generated previews for ArticleListView (iOS 18 target)
+
+Files created:
+  • Article+Preview.swift        — .preview, .previewLongTitle, .previewNoImage, .previewList, .previewEmpty
+  • PreviewSupport.swift         — SampleData: PreviewModifier (cached in-memory container)
+  • ArticleListView+Previews.swift — 7 #Preview blocks (4 states, dark, XXL text, German)
+
+Integration:
+  • Reused Article.fixture() from test-data-factory for base fields
+  • Open ArticleListView+Previews.swift → canvas shows all 7 variants
+
+API used: #Preview + PreviewModifier (.modifier) — shared container built once, cached.
+```
+
+## When NOT to Use This Skill
+
+- **Fixtures for the test suite** → `testing/test-data-factory`
+- **Snapshot/regression image tests** → `testing/snapshot-test-setup` (feed it this data)
+- **A trivial view with no data** → Xcode's autogenerated `#Preview {}` is enough
+- **Locale-only preview helpers** → `generators/localization-setup` already covers locale preview helpers; reuse them
+
+## Cross-Skill Integration
+
+```
+generators/persistence-setup   → defines @Model types
+        ↓
+testing/test-data-factory      → Model.fixture() for tests
+        ↓
+generators/preview-data-generator (THIS SKILL)
+   • reuses .fixture() for canvas data
+   • builds the #Preview state/appearance matrix
+        ↓
+testing/snapshot-test-setup    → renders the same matrix for regression
+```
+
+## Deliverables
+
+- [ ] Sample data per model: realistic instance + edge cases (empty, long, missing, list)
+- [ ] Existing `.fixture()`/`.preview` reused, not duplicated
+- [ ] `#Preview` matrix covering the view's data states + relevant appearance axes
+- [ ] Correct API for the deployment target (`#Preview` / `PreviewModifier` / `PreviewProvider`)
+- [ ] SwiftData views get a seeded in-memory container
+- [ ] Preview-only code guarded with `#if DEBUG`
+- [ ] Output summary with files, integration, and testing steps
+
+---
+
+**Generate the data and the variants together.** A preview is only as useful as the data in it — and a view is only proven when you've seen it empty, overflowing, in the dark, and at AX5.

--- a/skills/generators/preview-data-generator/preview-data-patterns.md
+++ b/skills/generators/preview-data-generator/preview-data-patterns.md
@@ -1,0 +1,199 @@
+# Preview Sample Data Patterns
+
+Reference for the `preview-data-generator` skill: how to design canvas sample data, the edge cases that matter, SwiftData seeding, and the modern shared-data APIs.
+
+## The Edge-Case Catalog
+
+Test fixtures optimize for *minimal, assertion-friendly* objects. Preview data optimizes for *visual stress* — the cases that expose layout bugs. Generate these for any non-trivial model:
+
+| Case | Why it matters | Example accessor |
+|------|----------------|------------------|
+| **Realistic** | The happy path you design against | `.preview` |
+| **Empty collection** | Empty states are the most-forgotten screen | `.previewEmpty` |
+| **Single item** | Lists that assume "many" break at 1 | `.previewOne` |
+| **Many items** | Spacing, scrolling, performance | `.previewList` (10-20) |
+| **Long strings** | Truncation, wrapping, button overflow | `.previewLongTitle` |
+| **Missing/optional** | `nil` image, no subtitle, no avatar | `.previewNoImage` |
+| **Extremes** | 0, negative, 9,999+, huge numbers | `.previewMaxedOut` |
+| **Loading / Error** | The non-success UI states (see state matrix) | view-level, not model-level |
+
+## Design the `.preview` Namespace
+
+Put canvas data in an `extension` on the model, in a `#if DEBUG` file so it never ships:
+
+```swift
+#if DEBUG
+import Foundation
+
+extension Article {
+    static var preview: Article {
+        Article(
+            id: UUID(),
+            title: "Designing for the Smallest Screen",
+            author: "Mei Chen",
+            body: String(repeating: "Lorem ipsum dolor sit amet. ", count: 30),
+            imageURL: URL(string: "https://picsum.photos/seed/news/600/400"),
+            readMinutes: 6,
+            isBookmarked: false
+        )
+    }
+
+    static var previewLongTitle: Article {
+        preview.with(title: "An Extraordinarily, Almost Unreasonably Long Headline That Will Wrap Onto Several Lines")
+    }
+    static var previewNoImage: Article  { preview.with(imageURL: nil) }
+    static var previewBookmarked: Article { preview.with(isBookmarked: true) }
+
+    static var previewList: [Article] {
+        ["Swift 6 Concurrency", "Liquid Glass in Practice", "Shipping on a Weekend",
+         "The 20-Minute Code Review", "Designing Empty States"]
+            .map { preview.with(id: UUID(), title: $0) }
+    }
+    static var previewEmpty: [Article] { [] }
+}
+#endif
+```
+
+### The `.with(...)` helper
+
+A tiny copy-helper keeps edge cases one line each instead of re-specifying every field:
+
+```swift
+#if DEBUG
+extension Article {
+    func with(
+        id: UUID? = nil, title: String? = nil, author: String? = nil,
+        imageURL: URL?? = nil, isBookmarked: Bool? = nil
+    ) -> Article {
+        Article(
+            id: id ?? self.id,
+            title: title ?? self.title,
+            author: author ?? self.author,
+            body: self.body,
+            imageURL: imageURL ?? self.imageURL,   // double optional → can set to nil explicitly
+            readMinutes: self.readMinutes,
+            isBookmarked: isBookmarked ?? self.isBookmarked
+        )
+    }
+}
+#endif
+```
+
+## Reuse `test-data-factory`, Don't Duplicate
+
+If the project already has a fixture factory (from `testing/test-data-factory`), build previews **on top of it**:
+
+```swift
+#if DEBUG
+extension Article {
+    // Reuse the factory for base fields; previews only override what's visually interesting.
+    static var preview: Article { .fixture(title: "Designing for the Smallest Screen") }
+    static var previewList: [Article] { (1...12).map { .fixture(id: UUID(), title: "Article \($0)") } }
+}
+#endif
+```
+
+**Detection:** `Grep "static func fixture"` in the project. If present, prefer it. If absent, generate the `.preview` data standalone (and optionally suggest adding a factory for tests).
+
+## SwiftData: In-Memory Seeded Container
+
+A `@Model`-backed view needs a *container*, not a struct. Build an in-memory one seeded with sample data — it never touches the real store:
+
+```swift
+#if DEBUG
+import SwiftData
+
+@MainActor
+let previewContainer: ModelContainer = {
+    let container = try! ModelContainer(
+        for: Article.self,
+        configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+    )
+    for article in Article.previewSeed {
+        container.mainContext.insert(article)
+    }
+    return container
+}()
+#endif
+
+// Usage:
+#Preview {
+    ArticleListView()
+        .modelContainer(previewContainer)
+}
+```
+
+## iOS 18 / Xcode 16: `PreviewModifier` (build the data once, cache it)
+
+`PreviewModifier` lets every preview share **one** expensive context (a seeded container, a configured environment) that Xcode builds once and caches — instead of rebuilding per preview:
+
+```swift
+#if DEBUG
+import SwiftUI
+import SwiftData
+
+struct SampleData: PreviewModifier {
+    // Built once, cached, shared across all previews that use this modifier.
+    static func makeSharedContext() async throws -> ModelContainer {
+        let container = try ModelContainer(
+            for: Article.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+        )
+        Article.previewSeed.forEach { container.mainContext.insert($0) }
+        return container
+    }
+
+    func body(content: Content, context: ModelContainer) -> some View {
+        content.modelContainer(context)
+    }
+}
+
+extension PreviewTrait where T == Preview.ViewTraits {
+    static var sampleData: Self { .modifier(SampleData()) }
+}
+#endif
+
+// Usage — clean and shared:
+#Preview(traits: .sampleData) { ArticleListView() }
+#Preview("Dark", traits: .sampleData) { ArticleListView().preferredColorScheme(.dark) }
+```
+
+## Xcode 16: `@Previewable` for `@State` in previews
+
+When a view needs live `@State`/`@Bindable` (toggles, selection, text), `@Previewable` lets it live directly in the `#Preview` body — no wrapper view:
+
+```swift
+#Preview("Interactive") {
+    @Previewable @State var query = ""
+    SearchBar(text: $query)
+}
+```
+
+## Mocking a ViewModel for Previews
+
+If the view owns an `@Observable` ViewModel that fetches data, generate a preview instance pinned to a state instead of letting it hit the network:
+
+```swift
+#if DEBUG
+extension ArticleListViewModel {
+    static var previewLoaded: ArticleListViewModel {
+        let vm = ArticleListViewModel(service: .noop)
+        vm.state = .loaded(Article.previewList)
+        return vm
+    }
+    static var previewEmpty: ArticleListViewModel { let vm = ArticleListViewModel(service: .noop); vm.state = .empty; return vm }
+    static var previewError: ArticleListViewModel { let vm = ArticleListViewModel(service: .noop); vm.state = .error("No connection"); return vm }
+}
+#endif
+```
+
+`.noop` is a do-nothing conformance to the view model's service protocol — reuse the same protocol the app already defines for swappable services (see `generators/networking-layer`).
+
+## Rules
+
+- ✅ Always wrap preview data in `#if DEBUG`
+- ✅ Reuse `.fixture()` if it exists; otherwise keep `.preview` self-contained
+- ✅ Use stable seed strings for image URLs (e.g. `picsum.photos/seed/...`) so previews don't flicker
+- ✅ For SwiftData, always `isStoredInMemoryOnly: true` — never seed the real store
+- ❌ Don't hit the live network in a preview — pin the ViewModel/service to a state
+- ❌ Don't ship preview data — `#if DEBUG` is non-negotiable

--- a/skills/generators/preview-data-generator/preview-matrix.md
+++ b/skills/generators/preview-data-generator/preview-matrix.md
@@ -1,0 +1,153 @@
+# The Preview Variant Matrix
+
+Reference for the `preview-data-generator` skill: the axes a view should be previewed across, the APIs to express them, and how to scale the matrix sensibly.
+
+## The Axes
+
+Each axis catches a different class of bug. Pick the ones the view is actually exposed to — don't emit every axis for every view.
+
+| Axis | Variants | Catches | API |
+|------|----------|---------|-----|
+| **Data state** | loaded · empty · loading · error | The most common prototyping gap | pass state/VM into the view |
+| **Appearance** | light · dark | Hardcoded colors, contrast | `.preferredColorScheme(.dark)` |
+| **Dynamic Type** | default · AX3 · AX5 | Truncation, overlap, fixed heights | `.dynamicTypeSize(.accessibility5)` |
+| **Locale / direction** | long language (de) · RTL (ar/he) · pseudoloc | Layout that assumes English/LTR | `.environment(\.locale,…)` + `.environment(\.layoutDirection, .rightToLeft)` |
+| **Device / size** | SE · Pro Max · iPad | Small-screen crowding, wide layouts | canvas device picker / `.fixedLayout` trait |
+| **Accessibility** | bold text · high contrast · reduce motion | Inaccessible UI | `.environment(\.legibilityWeight,…)`, `.accessibilityReduceMotion` |
+| **Orientation** | portrait · landscape | Constraint breakage | `.landscapeLeft` trait |
+
+## Data-State Previews (the UI-prototype payoff)
+
+This is the axis people most often skip and most need. Drive it through whatever your view reads — an explicit `state` enum, a pinned ViewModel, or a seeded container:
+
+```swift
+#Preview("Loaded")  { ArticleListView(state: .loaded(Article.previewList)) }
+#Preview("Empty")   { ArticleListView(state: .empty) }
+#Preview("Loading") { ArticleListView(state: .loading) }
+#Preview("Error")   { ArticleListView(state: .error("No connection")) }
+```
+
+If the view owns a ViewModel, use the pinned instances from **preview-data-patterns.md**:
+
+```swift
+#Preview("Empty") { ArticleListView(viewModel: .previewEmpty) }
+```
+
+## Appearance & Accessibility
+
+```swift
+#Preview("Dark")        { ArticleDetailView(article: .preview).preferredColorScheme(.dark) }
+#Preview("XXL Text")    { ArticleDetailView(article: .preview).dynamicTypeSize(.accessibility5) }
+#Preview("Bold + Dark") { ArticleDetailView(article: .preview).environment(\.legibilityWeight, .bold).preferredColorScheme(.dark) }
+```
+
+Prefer the dedicated modifiers (`.dynamicTypeSize`, `.preferredColorScheme`) where they exist; fall back to `.environment(\.…)` for keys without one.
+
+## Locale & RTL
+
+```swift
+#Preview("German")  { ArticleDetailView(article: .previewLongTitle).environment(\.locale, .init(identifier: "de")) }
+#Preview("Arabic RTL") {
+    ArticleDetailView(article: .preview)
+        .environment(\.locale, .init(identifier: "ar"))
+        .environment(\.layoutDirection, .rightToLeft)
+}
+```
+
+German/Finnish stress string length; Arabic/Hebrew flip the layout. If the project already has locale preview helpers from `generators/localization-setup`, reuse those instead.
+
+## Layout Traits
+
+Preview traits shape the canvas frame itself:
+
+| Trait | Effect |
+|-------|--------|
+| `.sizeThatFitsLayout` | Canvas hugs the view — ideal for cells, buttons, small components |
+| `.fixedLayout(width:height:)` | Pin an exact size |
+| `.landscapeLeft` / `.landscapeRight` / `.portrait` | Force orientation |
+| `.modifier(SomeModifier())` | Apply a `PreviewModifier` (e.g. shared sample data) |
+
+```swift
+#Preview("Cell", traits: .sizeThatFitsLayout) { ArticleRow(article: .preview) }
+#Preview("Landscape", traits: .landscapeLeft) { ArticleDetailView(article: .preview) }
+```
+
+Combine traits with sample-data modifiers: `#Preview(traits: .sampleData, .sizeThatFitsLayout) { … }`.
+
+## Device Variants
+
+With the `#Preview` macro, the **canvas device picker** is the primary way to switch devices — you don't need one preview per device. Reserve explicit device previews for views that genuinely differ by size class (e.g. an iPad sidebar layout):
+
+```swift
+// Pin a small-screen check when crowding is a real risk:
+#Preview("Compact", traits: .fixedLayout(width: 320, height: 568)) {
+    ArticleListView(state: .loaded(Article.previewList))
+}
+```
+
+(Legacy `.previewDevice("iPhone SE (3rd generation)")` only applies under `PreviewProvider` — see fallback below.)
+
+## Deployment-Target Fallbacks
+
+Generate the right API for the project's minimum target:
+
+| Target | Preview API | Shared data |
+|--------|-------------|-------------|
+| **iOS 18+ / Xcode 16** | `#Preview` + `@Previewable` | `PreviewModifier` (cached) |
+| **iOS 17+** | `#Preview` macro | per-preview `.modelContainer(inMemory:)` |
+| **below iOS 17** | `PreviewProvider` struct | manual sample injection |
+
+`PreviewProvider` fallback (when the macro isn't available):
+
+```swift
+#if DEBUG
+struct ArticleListView_Previews: PreviewProvider {
+    static var previews: some View {
+        Group {
+            ArticleListView(state: .loaded(Article.previewList))
+                .previewDisplayName("Loaded")
+            ArticleListView(state: .empty)
+                .previewDisplayName("Empty")
+            ArticleListView(state: .loaded(Article.previewList))
+                .preferredColorScheme(.dark)
+                .previewDisplayName("Dark")
+        }
+    }
+}
+#endif
+```
+
+## Scaling the Matrix
+
+Match the output to the view and the request — a preview explosion is as unhelpful as no previews.
+
+| View | Sensible default matrix |
+|------|------------------------|
+| **Label / small component** | realistic + long string, `traits: .sizeThatFitsLayout` |
+| **List / collection** | loaded + empty + (loading/error if it has them) + dark |
+| **Detail screen** | loaded + dark + AX5 + one long-language/RTL |
+| **Form with state** | default + filled + invalid, `@Previewable` for live input |
+| **Full prototype pass** | all data states × {light, dark} + AX5 + RTL |
+
+## Good vs. Bad
+
+#### ✅ Good
+
+```swift
+// States first — the prototype payoff — then the appearance checks.
+#Preview("Loaded")   { FeedView(state: .loaded(.previewList)) }
+#Preview("Empty")    { FeedView(state: .empty) }
+#Preview("Error")    { FeedView(state: .error("Offline")) }
+#Preview("Dark+AX5") { FeedView(state: .loaded(.previewList)).preferredColorScheme(.dark).dynamicTypeSize(.accessibility5) }
+```
+
+#### ❌ Bad
+
+```swift
+// One preview, happy path only, network-backed → flaky, proves nothing about empty/dark/large-text.
+#Preview { FeedView() }   // fetches live data, single light-mode state
+```
+
+#### Why it matters
+
+A view isn't done when it compiles — it's done when you've *seen* it empty, overflowing, in the dark, at AX5, and right-to-left. The matrix turns "looks fine on my iPhone in English" into actual coverage, at design time, before a single test or device build.


### PR DESCRIPTION
## Summary

Adds `generators/preview-data-generator` — sample data **and** a multi-variant `#Preview` matrix for SwiftUI views, in one cohesive generator. It's the design-time counterpart to `testing/test-data-factory` (canvas, not the test suite) and **reuses** `.fixture()` where it exists rather than duplicating data.

## What it generates

- **Sample data** with the visual edge cases that break layouts — empty, single, long/overflowing strings, missing images, large lists
- **A `#Preview` matrix** across the axes that matter: **data states (loaded / empty / loading / error)** for UI prototyping, plus light/dark, Dynamic Type, locale/RTL, and device variants

## What makes it more than a generic `#Preview`

- SwiftData **in-memory seeded containers** for `@Model`-backed views
- **iOS 18 / Xcode 16**: `PreviewModifier` (build sample data once, cache across previews) and `@Previewable` (live `@State` in previews)
- Preview `traits:` and `.environment` overrides
- **Deployment-target fallbacks** down to `PreviewProvider`

## Structure

- `SKILL.md` — pre-generation checks, process, output format
- `preview-data-patterns.md` — edge-case catalog, SwiftData seeding, `PreviewModifier`, fixture reuse
- `preview-matrix.md` — variant axes, traits, environment overrides, target fallbacks

## Wiring

- Indexed in `generators/SKILL.md` (frontmatter description + module entry next to `test-generator`)
- README generator table + counts: 140 → 141 total, Generators 62 → 63
- Cross-links: `test-data-factory`, `snapshot-test-setup`, `persistence-setup`, `networking-layer`, `localization-setup` (all verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
