### PR TITLE
feat: add ui-prototyping and flow-walkthrough skills

### DIFF
--- a/skills/design/ui-prototyping/SKILL.md
+++ b/skills/design/ui-prototyping/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: ui-prototyping
+description: Explore multiple *divergent* UI directions for a screen as named Swift #Previews, remix the strongest elements into hybrids, fill them with lived-in sample content and edge-case states, then tune signature animations with a generated tuning panel. Produces real native SwiftUI you carry forward, not throwaway mockups. Use early — after new-app or at the start of any UI-heavy phase, before /apple:plan commits to a single layout. Based on Apple's WWDC method for prototyping with coding agents in Xcode: go wide → remix → make lived-in → tune.
+allowed-tools: [Read, Write, Edit, Bash, Glob, Grep, AskUserQuestion]
+---
+
+# UI Prototyping Skill
+
+Task lists and specs commit you to **one** layout before you've seen the alternatives. The cost is quiet but large: you anchor on the first arbitrary structure an agent guessed, then spend the rest of the phase fighting feature creep around it. This skill front-loads *divergent exploration* — many real, named SwiftUI variations you flip between in Xcode's canvas — so the layout you carry into `/apple:plan` is one you **chose**, not one you defaulted into.
+
+> **Agents are collaborators, not designers. You always have final say.** Go wide, remix, repeat.
+
+## Why this exists (the trap it removes)
+
+A vague prompt — *"make a UI for a book club"* — produces one arbitrary layout, silently guesses at features you never asked for (polling? a photo gallery?), and anchors you on a flawed start. By the time you've bent it to the features you *do* want, it looks clunky and inelegant. Three disciplines remove the trap, and this skill enforces all three:
+
+| Discipline | What it means | What it prevents |
+|---|---|---|
+| **Specificity** | Bake the exact features in; nothing extra | Feature creep, arbitrary navigation elements |
+| **Stylistic intent** | Name the mood — warm coffee-shop palette? paper & typography? clean editorial? | Point-of-view-less, generic layouts |
+| **Multiplicity** | Ask for *many divergent* options at once | Anchoring on the first guess |
+
+Early is your **only** cheap chance to explore wide. Spend it.
+
+## Input
+
+- `.planning/APP.md` — features, audience, platform. The feature list is exactly what you bake into every variation.
+- Optional target screen (arg). If none, prototype the primary screen implied by `<mvp-features>`.
+- **If `APP.md` is missing, that's fine** — elicit the essentials first via `AskUserQuestion` (this is the novice front door): the one screen, its 3–5 must-have features, the mood, and 0–2 reference apps. You do not need to know how to write the "good prompt" — the skill assembles it from your answers.
+
+## The method — go wide → remix → make lived-in → tune
+
+### Stage 1 — Go wide (divergent variations)
+
+1. **Assemble the brief** (via `AskUserQuestion` if it isn't already pinned down in `APP.md`): the screen, the 3–5 must-have features (baked in — *this* is what stops feature creep), the mood cue, reference apps.
+2. **Generate 6–10 genuinely divergent variations** of that ONE screen. Divergence is measured by *organizing metaphor*, not paint: vary tab vs. grid→detail vs. single-scroll vs. dashboard/standings, the navigation shape, typography (New York / serif vs. SF), density, and color/mood. Two variations that differ only in tint = one wasted slot.
+3. **Each variation gets its own `#Preview` with a descriptive, memorable name** — `"Cozy"`, `"Editorial"`, `"Club Hub"`, `"Blueprint Atelier"`. The name is the handle you'll use when you remix. Put each in its own file (or a clearly separated struct) so the named previews render side by side in Xcode's canvas.
+   ```swift
+   #Preview("Cozy") { CozyHomeView(club: .sample) }
+   #Preview("Club Hub") { ClubHubHomeView(club: .sample) }
+   ```
+4. **Only the requested features appear.** If the app needs no polling or gallery, no variation invents one.
+5. **It compiles.** `xcodebuild build` (or the canvas) — you're carrying this forward, not screenshotting a dead mock.
+
+Present the named set; the user flips between them and reacts. **Expect duds** ("…well, it was worth a shot") — range is the goal, not a batting average.
+
+### Stage 2 — Remix + make it lived-in
+
+1. **Remix.** The user names what they liked *by preview name and element* — "the standings board from *Club Hub* + the current-book cover from *Cozy*." Generate new **hybrid** variations from only those elements, each its own new named preview. Go wide → remix → repeat until one direction feels right.
+2. **Lived-in content.** Empty scaffolding lies about how a screen feels. Generate **reusable sample models in their own file** (delegate to `generators/preview-data-generator`) so you can edit them, and make the content *plausible for the audience* — a book club's discussions are about books, not lorem ipsum.
+3. **Edge-case previews.** Think the states through yourself; don't let the agent silently pick the happy path. Cover at minimum:
+   - **Empty / blank-slate** — no meeting scheduled yet, zero items. Is there a call-to-action and an account/management entry, or does it just look broken?
+   - **Unbounded growth** — many members, long message threads, dozens of past items, long titles. Truncate, or an expand control? (The leaderboard that pushes the discussion off-screen is the classic bug.)
+   - **Long input** — does text truncate with `.help()`/detail access, or wrap to multiple lines?
+
+   Delegate the state-matrix generation to the `swiftui-builder` agent (it emits a `#Preview` per state); **you** decide which states matter.
+
+### Stage 3 — Tune key moments (a tuning panel)
+
+Signature interactions — a cover-to-detail transition, a staggered list entrance — are where an app reads as considered or cheap. Don't hand-edit constants scattered across files; have the agent build a **tuning panel**.
+
+1. **Be specific about what you're tuning.** Ease (duration) vs. spring (stiffness / damping / mass)? A single element, or a transition where views enter and leave the hierarchy?
+2. **Break the animation into named phases** — "Phase 1: cover transitions to detail. Phase 2: rows stagger in." Phases give you and the agent a shared vocabulary and let you inspect one phase in isolation.
+3. **Lay the panel out side-by-side on a wide window**, not a modal that obstructs the content — toggle a parameter and see the effect without context-switching. Ask for a resize control that moves the panel beside the UI on a larger canvas.
+4. **Tuning panels generalize** beyond animation: swap app states, colors, fonts, visual offsets. Use `design/animation-patterns` for the curve knowledge; the panel is its runnable counterpart.
+5. **Guard it behind DEBUG / a launch arg** so it never ships — same discipline as walkthrough's `-uiTestSeed`.
+
+## Output: `.planning/PROTOTYPE.md` + real Swift
+
+Record the decisions so the next session — and `/apple:plan` — inherits them:
+
+```markdown
+# UI Prototype — [Screen], Phase [N]
+
+## Variations explored (Stage 1)
+| Preview name | Organizing idea | Verdict |
+|--------------|-----------------|---------|
+| Cozy | single-scroll, warm serif, current-book hero | ✅ base direction |
+| Club Hub | tab bar + standings board | remix: take the standings board |
+| Blueprint Atelier | grid → detail | ✗ too cold |
+
+## Chosen direction & remix (Stage 2)
+- Base: *Cozy*; grafted the standings board from *Club Hub*.
+- Sample data: `PreviewData/BookClubSamples.swift` (editable, reused across previews).
+- Edge cases covered: empty (added CTA + account entry), long member list (rank pinned + expand), long titles (truncate).
+
+## Tuned moments (Stage 3)
+- Cover→detail: spring(stiffness: …, damping: …); rows stagger 0.04s. Panel: `Debug/TransitionTuner.swift` (DEBUG only).
+
+## Carry-forward
+- Winning layout → `/apple:plan` `<flows>` + `<apple-patterns>`; keep the Swift files.
+```
+
+Plus the actual files in the project: the variation views, the sample-data file, and any tuning panel (DEBUG-guarded).
+
+## Honest limits
+
+- **Agents propose; you decide.** Don't delegate "which is best" — that judgment *is* the design work. A pile of variations with no chosen direction is not a result.
+- **Divergent ≠ good.** Some variations will flop; that's the method working, not failing.
+- **Nothing beats real users.** Lived-in sample content is a head start on the feedback stage, not a substitute for people using your app with their own content.
+- **The tuning panel is scaffolding** — DEBUG-only, guarded, and removed or gated before release.
+
+## Cadence & integration
+
+- **Run early, once per signature screen** — after `/apple:new-app`, or at the start of a UI-heavy phase, *before* `/apple:plan` locks a layout. Exploration is cheapest before the "real" screen exists.
+- **Feeds forward:** the winning variation is real SwiftUI — hand its structure to `/apple:plan` (`<flows>` / `<apple-patterns>`) and `/apple:build`; don't rebuild it.
+- **Bookends with `flow-walkthrough` / `/apple:walkthrough`:** prototype the *screen* (diverge, choose, tune), then walkthrough the *flow* (verify transitions and dead-ends) once it's wired up. Explore → build → verify.
+- **Complements `product/ux-spec`:** ux-spec formalizes *one* spec; this skill is how you find the one worth formalizing. Feed the winner in, or skip ux-spec for small apps.
+- **Reuses:** `generators/preview-data-generator` (sample content), the `swiftui-builder` agent (edge-case `#Preview` matrix), `design/animation-patterns` (curve reference).

--- a/skills/testing/flow-walkthrough/SKILL.md
+++ b/skills/testing/flow-walkthrough/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: flow-walkthrough
+description: Verify UI *workflow* correctness that a task list, code review, and static screenshots miss. Drives end-to-end user flows in the Simulator via XCUITest with per-step screenshots, statically audits the navigation graph for dead-ends and missing edit paths, and emits a human discoverability checklist. Use after building any phase/slice that adds or changes UI, or when a user reports "I could only figure out the flow by running it."
+allowed-tools: [Read, Write, Edit, Bash, Glob, Grep]
+---
+
+# Flow Walkthrough Skill
+
+Task lists, compilers, and code review verify that *screens exist and compile*. They are structurally blind to whether the **flow between screens actually works for a human with a goal** — the transitions, the return paths, the dead-ends, the discoverability. This skill closes that gap.
+
+## Why this exists (the three failure classes)
+
+Real UX bugs fail at three different layers, and **no single mechanism catches all three** — so this skill uses three:
+
+| Failure class | Example | Caught by |
+|---|---|---|
+| **Dead-end / missing path** | A saved record can only be *viewed*, never reopened to edit; `Done` calls `popToRoot()` and orphans an in-progress entity | **Layer 1** — static nav-graph audit (no build) |
+| **Reachability regression** | "Run round" no longer reaches the capture screen after a refactor; a `Done` lands on the wrong screen | **Layer 2** — automated flow driving (XCUITest) |
+| **Discoverability** | "How do I even select a contestant?" — the only affordance is a bare row tap | **Layer 3** — human checklist (a UI test taps the row and *passes*) |
+
+> The trap: a UI test happily taps a hidden control and reports PASS. Automation proves a path *works*; only a human judges whether it is *findable*. That residue is why Layer 3 is mandatory, not optional.
+
+## Input: the `<flows>` from PLAN.md
+
+`/apple:plan` emits a `<flows>` block — end-to-end journeys, each a testable script. If `PLAN.md` has no `<flows>`, derive them from the phase's `<mvp-features>`/views and **write them back into PLAN.md first** (a flow that isn't written down can't be checked). A good flow names, for every persisted entity created: the step that **reopens it editable**, and the single **least-discoverable action**.
+
+## The method
+
+### Layer 1 — Static navigation-graph audit (no build required)
+
+Grep the navigation surface and reason over it. Do this first; it's free and catches the highest-severity class.
+
+1. **Build the graph.** Find entry points and edges:
+   - `Grep`: `NavigationStack`, `navigationDestination`, `NavigationLink`, `\.sheet`, `\.fullScreenCover`, `router.push`, `enum Route`, `dismiss()`, `popToRoot`, `@Query`.
+2. **Assert reachability & return paths.** For every screen: how do you get in, and does every `Done`/`Back`/`dismiss` land somewhere intentional? Flag any `popToRoot()` that discards an in-progress or just-saved entity.
+3. **CRUD-completeness.** For every `@Model` with a **Create** path, is there a **Read** *and* an **Update/reopen** path from the persistence surface (a list/history)? A list that only opens a read-only detail is a dead-end for editing — flag it.
+4. **Entry-point sanity.** Does "New X" always create a *fresh* entity with no way back to the previous one except an incomplete list? Flag create-only loops.
+
+Output each finding as `DEAD-END` / `NO-EDIT-PATH` / `ORPHANS-ENTITY` with the file:line and the missing arrow.
+
+### Layer 2 — Automated flow driving (XCUITest + per-step screenshots)
+
+Turn each `<flow>` into a UI test that taps through it and screenshots every step, so the agent can *see* the transitions and assert the destinations.
+
+1. **Ensure a UITest target exists.** If none, add one (xcodegen: a `type: bundle.ui-testing` target; or `xcodebuild`). Keep the generated tests — they become the Phase 5 regression suite.
+2. **Generate one test method per flow** from `<steps>`. After each step, attach a screenshot:
+   ```swift
+   func snap(_ name: String) {
+       let s = XCTAttachment(screenshot: XCUIScreen.main.screenshot())
+       s.name = name; s.lifetime = .keepAlways; add(s)
+   }
+   ```
+   Launch with any needed args (e.g. a `-uiTestSeed` launch argument that seeds SwiftData and, in DEBUG, flips entitlement flags so gated flows are reachable without a real purchase). Assert the **destination** of each step (`XCTAssert(app.staticTexts["Results"].waitForExistence(timeout: 2))`), especially after `Done`/`Back` — that is what catches wrong-destination bugs.
+3. **Run and extract:**
+   ```bash
+   xcodebuild test -project <App>.xcodeproj -scheme <App> \
+     -destination 'platform=iOS Simulator,name=<device>' \
+     -resultBundlePath .planning/walkthrough/<flowId>.xcresult
+   # export per-step screenshots for the agent to read:
+   xcrun xcresulttool export attachments \
+     --path .planning/walkthrough/<flowId>.xcresult \
+     --output-path .planning/walkthrough/<flowId>/   # adapt flag to installed Xcode
+   ```
+   (The `xcresulttool` attachment-export subcommand name shifts across Xcode versions — check `xcrun xcresulttool --help` and adapt.)
+4. **Read the screenshots** in order → a "filmstrip." Confirm each step lands where the flow says it should. A failed assertion or a wrong screen = a flow bug with visual proof.
+
+### Layer 3 — Human discoverability pass (the irreducible residue)
+
+For each flow, emit a short script the human runs and rates — this is the only thing that catches "I couldn't find how to do X":
+
+```
+Flow F1 — Run a contest (as a host)
+  1. Tap "Start a Contest"        → were you sure what to tap? (1–5)
+  2. Add two contestants          → was adding the *second* obvious? (1–5)
+  3. Run each contestant's round  → did you know rows were tappable? (1–5)
+  4. Done on results              → did you land back where you expected? (Y/N)
+  Where did you hesitate? ______
+```
+
+Keep it to the 2–4 flows that matter; ask for a hesitation note, not just scores — the note is where the real bug hides.
+
+## Output: `.planning/WALKTHROUGH.md`
+
+```markdown
+# Flow Walkthrough — Phase [N]
+
+## Layer 1 — Navigation graph (static)
+- 🔴 NO-EDIT-PATH: ContestHistoryView:19 opens read-only ResultsView; a saved Contest can't be reopened to edit. → route to editable setup.
+- 🔴 ORPHANS-ENTITY: ResultsView "Done" calls router.popToRoot() → dumps user home, loses the contest. → dismiss() one level.
+
+## Layer 2 — Driven flows (filmstrips in ./walkthrough/)
+| Flow | Result | Note |
+|------|--------|------|
+| F1 create→run→results→reopen | ❌ DEAD-END at step 6 | reopen lands on read-only results |
+| F2 add second contestant | ✅ reaches capture | |
+
+## Layer 3 — Human discoverability checklist
+[the per-flow scripts above, for the user to fill in]
+
+## Verdict
+[N] dead-ends (fix before phase-complete), [N] reachability failures, discoverability pending human pass.
+```
+
+Store screenshots under `.planning/walkthrough/<flowId>/`. Fix all Layer-1 dead-ends and Layer-2 failures before the phase is marked complete (same gate discipline as visual-qa).
+
+## Honest limits
+- **Tests can't judge feel or findability.** A green Layer-2 run with an unrated Layer-3 checklist is *not* a pass.
+- **Seeding is required for gated/late-state flows.** Provide a DEBUG `-uiTestSeed` path (insert sample models, set entitlement flags) so reopen/edit/results flows are reachable without manually rebuilding state each run. Remove or guard it behind the launch arg so it never affects release.
+- **Discoverability findings are design changes,** not bugs to "fix in code" blindly — surface them, let the human decide.
+
+## Cadence & integration
+- **Run per flow-slice, not per-phase.** Right after you build the create→edit→results loop, walk *that* loop — don't wait for the whole phase. Bugs are cheapest the minute they're introduced.
+- **Complements, doesn't replace, `visual-qa`** (which is static/code-level: colors, touch targets, view states). This skill is about *flow*, that one is about *screens*.
+- **Feeds Phase 5.** The generated XCUITests are kept as the regression suite; hand them to `testing/tdd-feature`/`test-spec` rather than re-writing.
+- **Pairs with a nav-graph review lens.** If `/apple:review` gains a flow/dead-end agent, Layer 1 can run there too; this skill is the runnable, screenshot-producing counterpart.
+```


### PR DESCRIPTION
## Two new skills

Both back new SwiftShip UI commands:

- **`design/ui-prototyping`** — explore *divergent* UI directions for a screen as named SwiftUI `#Preview`s, remix the strongest elements, fill with lived-in content + edge-case states, then tune signature animations with a generated tuning panel. Based on Apple's WWDC prototyping-with-coding-agents method (go wide → remix → make lived-in → tune). Reuses `generators/preview-data-generator`, the `swiftui-builder` agent, and `design/animation-patterns`.
- **`testing/flow-walkthrough`** — verify UI *workflow* correctness that task lists, code review, and static screenshots miss, via three layers: static nav-graph audit, XCUITest-driven flows with per-step screenshots, and a human discoverability checklist.

## Pairing

Ships alongside the paired PR in **`rshankras/SwiftShip`** that adds the `/apple:prototype` and `/apple:walkthrough` commands which invoke these skills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
