### PR TITLE
feat: reframe app-icon-generator for Liquid Glass / Icon Composer

### DIFF
--- a/skills/generators/app-icon-generator/SKILL.md
+++ b/skills/generators/app-icon-generator/SKILL.md
@@ -1,12 +1,31 @@
 ---
 name: app-icon-generator
-description: Generates app icons programmatically using CoreGraphics following Apple HIG. Use when user wants to create, generate, or design an app icon for macOS or iOS.
+description: Generates an app icon for macOS or iOS — a fast CoreGraphics placeholder and/or flat layered source art to finish in Icon Composer (the Liquid Glass / iOS 26+ standard). Produces appearance variants (light/dark/tinted) and installs into the asset catalog. Use when the user wants to create, generate, iterate, or update an app icon.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion]
 ---
 
 # App Icon Generator
 
-Generate production-quality app icons programmatically using a CoreGraphics Swift script. Produces all required sizes and installs into the Xcode asset catalog.
+Generate an app icon programmatically with a CoreGraphics Swift script, resize it to every required size, and install it into the Xcode asset catalog — with appearance variants (light/dark/tinted).
+
+## Read first — the Liquid Glass era (iOS 26 / macOS 26)
+
+> **Apple icon standards verified as of July 2026** — Icon Composer, Xcode 26, macOS Tahoe 26.4+. This guidance is static (the skill does no per-run web lookup); if that date is well in the past or the OS has moved on, re-verify against the [HIG · App icons](https://developer.apple.com/design/human-interface-guidelines/app-icons) before trusting the specifics below.
+
+Apple's shippable icon format changed. On iOS 26 / macOS 26 the modern app icon is a **layered, light-responsive Liquid Glass icon** authored in **Icon Composer** (free; ships with Xcode 26, needs macOS Tahoe 26.4+). You supply *flat* artwork in up to **four depth groups** (background → foreground); the **system renders the glass** — specular highlights, refraction, translucency, shadows — and masks the rounded-rect shape. One `.icon` file adapts across iPhone, iPad, Mac, and Apple Watch and across **Default / Dark / Mono (tinted)** appearances.
+
+**So this skill does NOT produce the final iOS 26 icon.** Icon Composer is GUI-first; no script can author a true layered `.icon`. Its two honest roles are:
+
+1. **Placeholder** — a fast flat 1024 PNG so early builds, TestFlight, and screenshots feel real before you invest in the real icon.
+2. **Layered source art** — flat background / midground / foreground PNGs (or SVGs), effect-free, ready to drag into Icon Composer, where you assemble depth and export the `.icon`.
+
+**What changed vs. the classic flow:**
+- **Do not bake in lighting.** No pre-painted specular highlights, drop shadows, or gradients-used-as-lighting — the system owns those now, and baking them in double-exposes against the system glass. (The `drawShine`/`drawShadow` blocks below are **legacy-only**, off by default for iOS 26+ targets.)
+- **Do not round the corners.** Icon Composer / the system apply the shape mask — fill a full square canvas.
+- **SVG for shapes, PNG for effects** — vector where you can, raster only where you must.
+- **Provide appearance variants** — light (default), dark, and tinted/mono. A single flat PNG only fills the light slot and won't adapt on iOS 18+.
+
+**Detect the target first:** read the deployment target (`IPHONEOS_DEPLOYMENT_TARGET` / `MACOSX_DEPLOYMENT_TARGET` in the pbxproj, or `.planning/APP.md`). iOS 26+ / macOS 26+ → lead with the Icon Composer handoff and treat the flat PNG as a placeholder. Older targets → the classic flat + appearances path is fine to ship. **If the deployment target is newer than the "verified as of" date above, flag it to the user and re-verify the icon rules against the current HIG before generating** — the skill won't know about anything Apple shipped after that date.
 
 ## When This Skill Activates
 
@@ -74,18 +93,23 @@ Ask via AskUserQuestion:
 
 ## Apple HIG Icon Guidelines
 
-**Read `apple-hig-icons.md` before generating.** Key rules:
+**Read `apple-hig-icons.md` before generating.**
+
+**Timeless rules (all eras):**
 
 1. **No text** in the icon — must be universally recognizable
 2. **Single focal point** — one clear element the eye is drawn to
-3. **Simple shapes** — must be legible at 16x16 (macOS menu bar)
-4. **Fill the canvas** — macOS/iOS apply the rounded rect mask automatically
-5. **Front-facing perspective** — no 3D tilts or dramatic angles
-6. **Use gradients sparingly** — subtle depth, not rainbow
-7. **Ensure contrast** — the focal element must stand out from background
-8. **Platform-appropriate**:
-   - macOS: Can be more detailed (icons display larger)
-   - iOS: Keep simpler (smaller grid, more rounded)
+3. **Simple shapes** — legible at 16×16 (macOS menu bar) and at Home-screen size
+4. **Fill a full square canvas** — never bake in rounded corners; the system / Icon Composer apply the shape mask
+5. **Front-facing** — no 3D tilts or dramatic angles
+6. **Ensure contrast** — the focal element must stand out from the background
+7. **Platform-appropriate detail** — macOS can be more detailed (displays larger); iOS simpler
+
+**Liquid Glass era rules (iOS 26 / macOS 26):**
+
+8. **The system owns lighting.** No baked specular, drop shadows, or gradients-as-lighting — Icon Composer / the system add depth, refraction, and highlights. Keep artwork flat.
+9. **Provide appearance variants** — light (default), dark, and tinted/mono. Make sure the mark reads on all three (tinted renders as a monochrome silhouette on a system-tinted background).
+10. **Layer, don't flatten (final icon)** — organize art into ≤4 depth groups for Icon Composer; SVG for shapes, PNG only for texture.
 
 ## Generation Process
 
@@ -95,7 +119,7 @@ Based on the user's answers (or app context), select:
 - **Background**: Gradient direction, colors, optional radial glow
 - **Primary Element**: The main shape/symbol
 - **Secondary Elements**: Optional ring, glow, accent shapes
-- **Style Modifiers**: Shine, shadow, stroke weight
+- **Style Modifiers**: stroke weight (⚠️ skip Shine/shadow for iOS 26+ targets — the system applies Liquid Glass specular and shadow; baking them in double-exposes)
 
 ### Step 2: Generate Swift Script
 
@@ -132,8 +156,8 @@ let size: CGFloat = 1024
 | `drawGear` | Gear/cog shape | Settings/utility apps |
 | `drawWaveform` | Audio waveform bars | Audio/music apps |
 | `drawDocument` | Page with fold corner | Document/writing apps |
-| `drawShine` | Elliptical specular highlight | Adding polish |
-| `drawShadow` | Drop shadow beneath element | Adding depth |
+| `drawShine` | Elliptical specular highlight | ⚠️ Legacy only — off for iOS 26+ (system paints its own specular) |
+| `drawShadow` | Drop shadow beneath element | ⚠️ Legacy only — off for iOS 26+ (system casts its own shadow) |
 
 ### Step 3: Run Script and Present Variants
 
@@ -203,6 +227,31 @@ For **iOS** (single size, system generates others):
 3. **Copy files** into the asset catalog directory
 4. **Build** to verify: `xcodebuild build -scheme <scheme> -destination 'platform=<platform>' -quiet`
 
+### Step 4.5: Appearance variants & Icon Composer handoff
+
+**Appearance variants (iOS 18+, scriptable).** For the flat path, generate three 1024 PNGs — light (default), dark, and a monochrome/tinted mark — and declare them so the icon adapts to the user's Home screen:
+
+```json
+{
+  "images": [
+    { "filename": "icon_light.png",  "idiom": "universal", "platform": "ios", "size": "1024x1024" },
+    { "filename": "icon_dark.png",   "idiom": "universal", "platform": "ios", "size": "1024x1024",
+      "appearances": [ { "appearance": "luminosity", "value": "dark" } ] },
+    { "filename": "icon_tinted.png", "idiom": "universal", "platform": "ios", "size": "1024x1024",
+      "appearances": [ { "appearance": "luminosity", "value": "tinted" } ] }
+  ],
+  "info": { "author": "xcode", "version": 1 }
+}
+```
+
+**Icon Composer handoff (iOS 26+ / the shippable icon).** The flat PNGs above are a placeholder. For the real Liquid Glass icon:
+
+1. Export the design as **flat layers** — background, midground, foreground — as SVG (shapes) or PNG (texture), with **no** baked highlights, shadows, or corners.
+2. Open **Icon Composer** (Xcode 26 ▸ Open Developer Tool ▸ Icon Composer; needs macOS Tahoe 26.4+). Drag the layers in, organize into ≤4 depth groups, tune specular / refraction / translucency / shadow (don't overdo refraction), and check the Default / Dark / Mono previews.
+3. **Export `.icon`** and add it to the target (it replaces the `AppIcon` set). Icon Composer also exports a flattened 1024 PNG for App Store marketing.
+
+This is a manual GUI step by design — the skill prepares the layers and hands off; it does not author the `.icon`.
+
 ### Step 5: Cleanup
 
 - Keep `scripts/generate-icon.swift` for future regeneration
@@ -263,17 +312,17 @@ For **iOS** (single size, system generates others):
 After completion, report:
 
 ```
-Icon installed successfully!
+Icon installed!
 
-Master: scripts/generate-icon.swift (re-run to regenerate)
-Sizes:  [list of sizes generated]
+Type:     [placeholder flat icon | classic icon + appearances]
+Master:   scripts/generate-icon.swift (re-run to regenerate)
+Sizes:    [list] · appearances: [light/dark/tinted]
 Location: [path to AppIcon.appiconset]
 
-Build and run to see the icon in:
-- Menu bar (macOS)
-- Home screen (iOS)
-- Finder / Spotlight
-- About view
+⚠️ For an iOS 26+ / macOS 26+ target this is a PLACEHOLDER. Finish the real
+   Liquid Glass icon in Icon Composer (see the handoff step) before submitting.
+
+Build and run to see it: Home screen (iOS) · menu bar / Finder / Spotlight (macOS).
 ```
 
 ## Iteration
@@ -287,6 +336,6 @@ If the user wants changes:
 Common adjustment requests:
 - "Make the record dot bigger/smaller" → adjust radius parameter
 - "Different background color" → change gradient hex values
-- "Add more depth" → add radial glow or shine
+- "Add more depth" → add a radial glow (⚠️ not baked shine on iOS 26+ — add depth in Icon Composer instead)
 - "Too busy, simplify" → remove secondary elements
 - "Doesn't look good at small size" → increase stroke widths, simplify shapes


### PR DESCRIPTION
## Reframe app-icon-generator for the Liquid Glass / Icon Composer era

The skill was two generations behind Apple's current icon standard — it produced a single flat CoreGraphics PNG with baked highlights/shadows. This repositions it honestly.

**What changed:**
- New **"Read first — the Liquid Glass era"** section: on iOS 26 / macOS 26 the shippable icon is a layered `.icon` authored in **Icon Composer** (Xcode 26 / macOS Tahoe 26.4+); the system renders specular / refraction / translucency / shadow across Default / Dark / Mono. The skill's honest roles are now **placeholder** + **layered source for Icon Composer**.
- **Killed the anti-pattern:** `drawShine`/`drawShadow` marked legacy-only (off for iOS 26+ — the system paints its own, so baked lighting double-exposes).
- Added **light/dark/tinted appearance variants** + asset-catalog wiring, and an **Icon Composer `.icon` handoff** step.
- Updated the HIG rules (system owns lighting; no baked corners; SVG shapes / PNG effects; ≤4 depth groups).
- Added an **"Apple standards verified as of July 2026"** stamp + a target-newer-than-verified re-verify nudge, so the guidance's staleness is visible next time Apple moves the standard.

Grounded on [Icon Composer](https://developer.apple.com/icon-composer/) and the current [HIG · App icons](https://developer.apple.com/design/human-interface-guidelines/app-icons).

## Pairing

Backs the `/apple:icon` command in the paired **`rshankras/SwiftShip`** PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
