### PR TITLE
feat: ASC-automation skills (iap-finalizer, privacy-publish, asc-api helper)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Four repos, four layers — use one or all:
 | **iOS** | 9 | Code review, UI review, navigation, iPad, migration, accessibility, simulator/device runs |
 | **Testing** | 9 | TDD workflows, test infrastructure, snapshot tests, flow walkthrough |
 | **macOS** | 8 | Tahoe APIs, SwiftData, AppKit bridge |
-| **App Store** | 7 | ASO, descriptions, keywords, reviews, search ads, rejections |
+| **App Store** | 8 | ASO, descriptions, keywords, reviews, search ads, rejections, IAP finalize |
 | **SwiftUI** | 5 | AlarmKit, WebKit, text editing, toolbars, Charts 3D |
 | **Growth** | 4 | Analytics, press/media, community, indie business |
 | **Swift** | 3 | Concurrency patterns, Swift 6.2, InlineArray/Span |
@@ -33,7 +33,7 @@ Four repos, four layers — use one or all:
 | **Performance** | 2 | Instruments profiling, SwiftUI debugging |
 | **Security** | 2 | Secure storage, biometrics, privacy manifests |
 | **Core ML** | 1 | Vision, NaturalLanguage, model integration |
-| **Legal** | 1 | Privacy policies, terms of service, EULAs |
+| **Legal** | 2 | Privacy policies, terms of service, EULAs, publish + set ASC URLs |
 | **Monetization** | 1 | Pricing strategy, tiers, free trials |
 | **watchOS** | 1 | Watch apps, complications, health/fitness, widgets |
 | **SwiftData** | 1 | Class inheritance patterns |
@@ -43,7 +43,7 @@ Four repos, four layers — use one or all:
 | **Release Review** | 1 | Pre-release audit checklists |
 | **Shared** | 2 | Meta-skills for creating (`skill-creator`) and auditing (`skill-auditor`) skills |
 
-**Total: 143 skills across 23 categories** (category index files not counted)
+**Total: 145 skills across 23 categories** (category index files not counted)
 
 ## Quick Start
 
@@ -102,7 +102,7 @@ skills/
 ├── visionos/               # visionOS widgets
 ├── testing/                # TDD workflows, test infrastructure, snapshot tests, flow walkthrough (9 skills)
 ├── monetization/           # Pricing strategy, tiers, free trials
-├── app-store/              # ASO, descriptions, screenshots, reviews, search ads, rejections (7 skills)
+├── app-store/              # ASO, descriptions, screenshots, reviews, search ads, rejections, IAP finalize (8 skills)
 ├── watchos/                # Watch apps, complications, health/fitness, widgets
 ├── release-review/         # Security, privacy, UX, distribution audits
 └── shared/                 # Meta-skills: skill-creator, skill-auditor
@@ -201,6 +201,7 @@ Generate production-ready Swift code that adapts to your project:
 | Skill | What It Does |
 |-------|--------------|
 | `privacy-policy` | Privacy policies, Terms of Service, EULAs |
+| `privacy-publish` | Host legal pages + set ASC privacy/support URLs (dry-run) |
 
 ## Core ML Skills
 
@@ -255,6 +256,7 @@ Generate production-ready Swift code that adapts to your project:
 | `review-response-writer` | Professional review responses |
 | `apple-search-ads` | Search Ads campaign setup, keyword bidding, ROAS |
 | `rejection-handler` | Handle rejections, response templates, appeals |
+| `iap-finalizer` | Finalize one-time IAP price + localization in ASC (dry-run) |
 | `marketing-strategy` | Comprehensive promotional strategy |
 
 ## Security Skills

--- a/skills/_shared/asc-api/README.md
+++ b/skills/_shared/asc-api/README.md
@@ -1,0 +1,39 @@
+# `_shared/asc-api/` — App Store Connect REST helper
+
+Shared foundation for the ASC-automation skills (`app-store/iap-finalizer`, `legal/privacy-publish`, and the TestFlight enabler). It exists because a SwiftShip *skill* is a markdown playbook that orchestrates existing tools — it can't add new endpoints. The `asc-metadata` MCP covers a lot, but **not** IAP price/localization or app privacy/support URLs. `asc.py` fills those gaps by calling the ASC REST API directly with your own key.
+
+> **Not the MCP's key.** The `asc-metadata` MCP holds its credential *inside the server*; a skill can't reach it. `asc.py` uses a **separate `.p8`** you generate and store under `~/.appstoreconnect/`.
+
+## One-time setup (§0)
+
+1. **Generate a key** — App Store Connect ▸ **Users and Access ▸ Integrations ▸ App Store Connect API ▸ Team Keys** ▸ generate with role **App Manager** (Admin only if it must also manage users).
+2. **Download** `AuthKey_<KEY_ID>.p8` (downloadable **once**) →
+   ```
+   ~/.appstoreconnect/private_keys/AuthKey_<KEY_ID>.p8
+   ```
+3. **Record IDs** — put `KEY_ID` and `ISSUER_ID` in `~/.appstoreconnect/config` (or export as env):
+   ```
+   ASC_KEY_ID=XXXXXXXXXX
+   ASC_ISSUER_ID=aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee
+   ```
+4. **Dependency:** `pip install cryptography`
+
+**Never commit the `.p8`** (or the config). Keep them under `~/.appstoreconnect/` only.
+
+## Usage — safe by default
+
+`asc.py` **prints the request and does not send** unless you add `--apply`. This is the shared `dry-run → show diff → confirm → --apply` convention every skill follows (mirrors the MCP's `dryRun`, and honors "gate outward/ASC writes per-step").
+
+```bash
+python3 asc.py GET   /v1/apps
+python3 asc.py GET   "/v1/inAppPurchases/<id>/pricePoints?filter[territory]=USA"
+python3 asc.py POST  /v1/inAppPurchasePriceSchedules @body.json          # dry-run
+python3 asc.py POST  /v1/inAppPurchasePriceSchedules @body.json --apply  # sends
+python3 asc.py PATCH /v1/appInfoLocalizations/<id> '{"data":{...}}' --apply
+```
+
+Prove it works before trusting it: run any `GET … --apply` (e.g. `/v1/apps`) once — a 200 with your apps confirms the key + JWT are good.
+
+## Caveat for skill authors
+
+**Verify every endpoint/field against the current [App Store Connect API reference](https://developer.apple.com/documentation/appstoreconnectapi) before an `--apply`.** The API evolves; the flows in the dependent skills were captured 2026-07. The helper is deliberately dumb (auth + transport only) — the skills own the request bodies.

--- a/skills/_shared/asc-api/asc.py
+++ b/skills/_shared/asc-api/asc.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""asc.py - minimal App Store Connect REST helper (ES256 JWT auth).
+
+SAFE BY DEFAULT: prints the request and does NOT send unless you pass --apply.
+Every SwiftShip skill that uses this runs dry-run -> show diff -> confirm -> --apply.
+
+One-time setup (see README.md):
+  1. App Store Connect > Users and Access > Integrations > App Store Connect API
+     > Team Keys > generate a key with role "App Manager".
+  2. Download AuthKey_<KEY_ID>.p8 (one download only) to
+     ~/.appstoreconnect/private_keys/AuthKey_<KEY_ID>.p8
+  3. export ASC_KEY_ID=... ASC_ISSUER_ID=...   (or put them in ~/.appstoreconnect/config)
+
+Usage:
+  asc.py GET   /v1/apps
+  asc.py GET   "/v1/inAppPurchases/<id>/pricePoints?filter[territory]=USA"
+  asc.py POST  /v1/inAppPurchasePriceSchedules @body.json          # dry-run: prints only
+  asc.py POST  /v1/inAppPurchasePriceSchedules @body.json --apply  # actually sends
+  asc.py PATCH /v1/appInfoLocalizations/<id> '{"data":{...}}' --apply
+
+Dependency: cryptography  ->  pip install cryptography
+"""
+import sys, os, json, time, base64, urllib.request, urllib.error
+
+BASE = "https://api.appstoreconnect.apple.com"
+CONFIG = os.path.expanduser("~/.appstoreconnect/config")
+
+
+def _b64url(b):
+    return base64.urlsafe_b64encode(b).rstrip(b"=")
+
+
+def _load_config():
+    key_id = os.environ.get("ASC_KEY_ID")
+    issuer = os.environ.get("ASC_ISSUER_ID")
+    if (not key_id or not issuer) and os.path.exists(CONFIG):
+        for line in open(CONFIG):
+            line = line.strip()
+            if line.startswith("#") or "=" not in line:
+                continue
+            k, v = (x.strip() for x in line.split("=", 1))
+            if k == "ASC_KEY_ID" and not key_id:
+                key_id = v
+            if k == "ASC_ISSUER_ID" and not issuer:
+                issuer = v
+    if not key_id or not issuer:
+        sys.exit("Missing ASC_KEY_ID / ASC_ISSUER_ID (env or ~/.appstoreconnect/config).")
+    return key_id, issuer
+
+
+def _make_token(key_id, issuer):
+    try:
+        from cryptography.hazmat.primitives.serialization import load_pem_private_key
+        from cryptography.hazmat.primitives.asymmetric import ec, utils
+        from cryptography.hazmat.primitives import hashes
+    except ImportError:
+        sys.exit("Missing dependency: pip install cryptography")
+    p8 = os.path.expanduser(f"~/.appstoreconnect/private_keys/AuthKey_{key_id}.p8")
+    if not os.path.exists(p8):
+        sys.exit(f"Private key not found: {p8}")
+    key = load_pem_private_key(open(p8, "rb").read(), password=None)
+    now = int(time.time())
+    header = {"alg": "ES256", "kid": key_id, "typ": "JWT"}
+    payload = {"iss": issuer, "iat": now, "exp": now + 1200, "aud": "appstoreconnect-v1"}
+    signing_input = (
+        _b64url(json.dumps(header, separators=(",", ":")).encode())
+        + b"."
+        + _b64url(json.dumps(payload, separators=(",", ":")).encode())
+    )
+    der = key.sign(signing_input, ec.ECDSA(hashes.SHA256()))
+    r, s = utils.decode_dss_signature(der)
+    raw = r.to_bytes(32, "big") + s.to_bytes(32, "big")
+    return (signing_input + b"." + _b64url(raw)).decode()
+
+
+def main():
+    args = sys.argv[1:]
+    apply = "--apply" in args
+    args = [a for a in args if a != "--apply"]
+    if len(args) < 2:
+        sys.exit(__doc__)
+    method, path = args[0].upper(), args[1]
+    body = None
+    if len(args) >= 3:
+        raw = args[2]
+        body = open(os.path.expanduser(raw[1:])).read() if raw.startswith("@") else raw
+    url = BASE + path if path.startswith("/") else path
+    print(f"# {method} {url}")
+    if body:
+        print(body)
+    if not apply:
+        print("# DRY-RUN (default) - not sent. Re-run with --apply to send.")
+        return
+    key_id, issuer = _load_config()
+    token = _make_token(key_id, issuer)
+    req = urllib.request.Request(url, data=body.encode() if body else None, method=method)
+    req.add_header("Authorization", f"Bearer {token}")
+    req.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(req) as resp:
+            print(resp.read().decode())
+    except urllib.error.HTTPError as e:
+        print(f"HTTP {e.code}", file=sys.stderr)
+        print(e.read().decode(), file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/app-store/iap-finalizer/SKILL.md
+++ b/skills/app-store/iap-finalizer/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: iap-finalizer
+description: Take a one-time in-app purchase from MISSING_METADATA to READY_TO_SUBMIT in App Store Connect — set its price schedule and localized display name/description (and optional review screenshot) via the ASC REST API. Use at Phase 6 (Pre-Release), after the IAP is built in-app (Phase 4) and its ASC record exists. NOT for subscriptions, and NOT the same as promoted-iap (which displays IAPs in-app).
+allowed-tools: [Read, Bash, mcp__asc-metadata__list_iap, mcp__asc-metadata__get_iap, AskUserQuestion]
+---
+
+# IAP Finalizer
+
+Finish a **one-time** in-app purchase on the store side: **price + localization**, the two fields the `asc-metadata` MCP can't set (it exposes only reference name / review note / family-sharing). Moves an IAP from `MISSING_METADATA` → `READY_TO_SUBMIT` so it can ship with the build.
+
+> **This finalizes; it does not define.** The product id, tier, and price *decision* come from Phase 4 (Monetization / StoreKit). The ASC IAP record must already exist (created via the MCP `create_iap` or the ASC UI). This skill sets the metadata on that existing record.
+
+## Where it fits (read the seams)
+
+- **Not Phase 4.** Phase 4 builds the IAP *into the app* (StoreKit 2, paywall) and *decides* the price. This is Phase 6 store-metadata finalization.
+- **Price = one source of truth.** Do **not** re-ask the price. **Read it** from the monetization decision in `.planning/` (e.g. `MONETIZATION.md` / `PLAN.md`); only *confirm* it. Re-eliciting risks drift from the paywall/StoreKit price.
+- **Not `promoted-iap`.** That generator displays promoted IAPs in-app; this sets ASC price/localization. Different jobs.
+- **One-time IAPs only.** Subscriptions are a separate ASC flow (groups/offers) — out of scope here.
+
+## Prerequisites
+
+- `_shared/asc-api/` set up (see its README — key + `~/.appstoreconnect/`).  `ASC=python3 ~/.claude/swiftship-skills/_shared/asc-api/asc.py`
+- The IAP already exists in ASC. Get its id with the MCP: `list_iap` → pick the product.
+- Price decided in Phase 4. Read it from `.planning/` and confirm — don't invent it.
+
+## Flow — dry-run → confirm → apply
+
+1. **Confirm state.** MCP `get_iap` → current state + `productId`. Read the target price + Display Name (≤30) + Description (≤45) from `.planning/`; confirm with the user via `AskUserQuestion` if anything is missing.
+2. **Find the price point.**
+   ```
+   $ASC GET "/v1/inAppPurchases/<IAP_ID>/pricePoints?filter[territory]=USA"
+   ```
+   Pick the `inAppPurchasePricePoint` id whose `customerPrice` matches the target tier (e.g. 6.99).
+3. **Set the price** (one-time IAPs use *price schedules*):
+   ```
+   $ASC POST /v1/inAppPurchasePriceSchedules @price.json          # dry-run: review the body
+   $ASC POST /v1/inAppPurchasePriceSchedules @price.json --apply  # after you confirm
+   ```
+   Body: `data` relationships `inAppPurchase`→{IAP_ID}, `baseTerritory`→USA, `manualPrices`→[new `inAppPurchasePrices`]; `included` a new `inAppPurchasePrices` referencing the price point with `startDate: null` (="now").
+4. **Set the localization:**
+   ```
+   $ASC POST /v1/inAppPurchaseLocalizations '{"data":{"type":"inAppPurchaseLocalizations","attributes":{"locale":"en-US","name":"<=30","description":"<=45"},"relationships":{"inAppPurchase":{"data":{"type":"inAppPurchases","id":"<IAP_ID>"}}}}}' --apply
+   ```
+   PATCH the existing localization id instead if one already exists.
+5. **Review screenshot (optional):** `POST /v1/inAppPurchaseAppStoreReviewScreenshots` — the 3-step ASC upload (reserve → upload bytes → commit).
+6. **Verify:** MCP `get_iap` → state no longer `MISSING_METADATA`.
+
+## Done
+
+- IAP priced + localized in ASC; state advanced; ready to submit with the build.
+
+## Caveats
+
+- **Verify each endpoint/field against the current [ASC API reference](https://developer.apple.com/documentation/appstoreconnectapi) before `--apply`** (captured 2026-07).
+- Every write is **dry-run first** — show the body, confirm, then `--apply`. Never `--apply` a price the user hasn't seen.
+- One-time IAPs only. Subscriptions → the MCP `create_subscription*` tools + a separate flow.

--- a/skills/legal/privacy-publish/SKILL.md
+++ b/skills/legal/privacy-publish/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: privacy-publish
+description: Turn drafted legal docs (privacy policy, terms) into hosted pages and set the App Store Connect Privacy Policy / Support / Marketing URLs via the ASC REST API. Use at Phase 6 / submission, after legal drafts exist. The App Privacy "nutrition label" stays manual (Apple exposes no API) — this prints the exact answers to click.
+allowed-tools: [Read, Bash, AskUserQuestion, mcp__claude-in-chrome__navigate, mcp__claude-in-chrome__computer, mcp__claude-in-chrome__read_page]
+---
+
+# Privacy Publish
+
+Close the "hosted legal pages + ASC URLs" gap: render `.planning/legal/{privacy,terms}.md` → host them → PATCH the Privacy/Support URLs onto the App Store version. The one thing with no API — the **App Privacy nutrition label** — is handed off as a precise checklist.
+
+> Depends on the user's web infra, so **ask once, remember**. Hosting choice is theirs; the ASC URL-setting is the automatable part.
+
+## Prerequisites
+
+- Legal drafts exist: `.planning/legal/privacy.md`, `.planning/legal/terms.md` (from `legal/privacy-policy`).
+- `_shared/asc-api/` set up (README).  `ASC=python3 ~/.claude/swiftship-skills/_shared/asc-api/asc.py`
+- The app has a current editable App Store version + an en-US `appInfoLocalization` and `appStoreVersionLocalization` (get their ids first).
+
+## Flow — dry-run → confirm → apply
+
+1. **Render.** Markdown → minimal self-contained HTML (or keep `.md` if the host renders it).
+2. **Publish** (pick per the user's infra — `AskUserQuestion` once, then remember in `.planning/`):
+   - **git static site** — commit + push to the pages repo/branch.
+   - **WordPress** — `POST /wp-json/wp/v2/pages` with an application password.
+   - **Netlify / S3 / other** — the host's CLI.
+   - **Browser fallback** — drive the CMS with `claude-in-chrome` (detect → preview → confirm → act → fall back, per `TOOL-HANDOFF.md`).
+   - **Confirm both URLs resolve (HTTP 200)** before touching ASC.
+3. **Set the ASC URLs** (REST — dry-run, confirm, then `--apply`):
+   - **Privacy Policy URL** → `appInfoLocalizations` (`privacyPolicyUrl`):
+     ```
+     $ASC PATCH /v1/appInfoLocalizations/<id> '{"data":{"type":"appInfoLocalizations","id":"<id>","attributes":{"privacyPolicyUrl":"https://…/privacy"}}}' --apply
+     ```
+   - **Support / Marketing URL** → `appStoreVersionLocalizations` (`supportUrl`, `marketingUrl`) — PATCH the current version's en-US localization id.
+4. **Nutrition label (manual — no API).** Emit a checklist matching `Sources/PrivacyInfo.xcprivacy` (e.g. *Data Not Collected*, no tracking) for the user to click in ASC ▸ App Privacy. Do not claim this step is automated.
+
+## Done
+
+- Legal pages live + resolving; Privacy/Support URLs set via API; nutrition-label checklist handed off.
+
+## Caveats
+
+- **Verify each endpoint/field against the current [ASC API reference](https://developer.apple.com/documentation/appstoreconnectapi) before `--apply`** (captured 2026-07).
+- Confirm URLs return 200 *before* setting them in ASC — a dead Privacy URL is a common rejection (Guideline 5.1.1).
+- The nutrition label and some age-rating specifics have **no public API** — those remain ASC-UI/manual by design.


### PR DESCRIPTION
## ASC-automation skills (Phase-6 gaps)

Adds the two skills from the ASC proposal + their shared foundation. Fills what the `asc-metadata` MCP can't reach: **IAP price/localization** and **app privacy/support URLs**.

- **`_shared/asc-api/`** — `asc.py`, an ES256-JWT + REST helper. **`--dry-run` by default** (prints the request; add `--apply` to send). Uses *your own* `.p8` (§0 in the README), not the MCP's internal key.
- **`app-store/iap-finalizer`** — one-time IAP `MISSING_METADATA → READY_TO_SUBMIT`: price schedule + en-US localization. **Reads the price from the Phase-4 monetization decision**; distinct from `promoted-iap`.
- **`legal/privacy-publish`** — render → host → PATCH `appInfoLocalizations.privacyPolicyUrl` + `appStoreVersionLocalizations.supportUrl`. Nutrition label stays manual (no API).

Endpoints verified against the current [ASC API reference](https://developer.apple.com/documentation/appstoreconnectapi) (2026-07). Every write is **dry-run → confirm → `--apply`**.

⚠️ **`asc.py` is syntax-checked, not live-tested** (needs a real `.p8` + hits Apple). Prove it with one `GET /v1/apps --apply` before trusting.

Pairs with the `/apple:iap` + `/apple:privacy` commands in the **`rshankras/SwiftShip`** PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
