### PR TITLE
feat: add originality-check + store-signals skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ skills/
 │   ├── app-extensions/
 │   ├── data-export/
 │   └── ... (63 total)
-├── growth/                 # Analytics, press/media, community, indie business (4 skills)
+├── growth/                 # Analytics, store signals, press/media, community, indie business (5 skills)
 ├── legal/                  # Privacy policies, terms of service, EULAs
 ├── core-ml/                # Vision, NaturalLanguage, model integration
 ├── swiftui/                # AlarmKit, WebKit, text editing, toolbars, Charts 3D
@@ -102,7 +102,7 @@ skills/
 ├── visionos/               # visionOS widgets
 ├── testing/                # TDD workflows, test infrastructure, snapshot tests, flow walkthrough (9 skills)
 ├── monetization/           # Pricing strategy, tiers, free trials
-├── app-store/              # ASO, descriptions, screenshots, reviews, search ads, rejections, IAP finalize (8 skills)
+├── app-store/              # ASO, descriptions, screenshots, reviews, search ads, rejections, originality, IAP finalize (9 skills)
 ├── watchos/                # Watch apps, complications, health/fitness, widgets
 ├── release-review/         # Security, privacy, UX, distribution audits
 └── shared/                 # Meta-skills: skill-creator, skill-auditor
@@ -192,6 +192,7 @@ Generate production-ready Swift code that adapts to your project:
 | Skill | What It Does |
 |-------|--------------|
 | `analytics-interpretation` | Interpret app metrics, AARRR funnels, decision trees |
+| `store-signals` | Turn live reviews/analytics/sales/crashes into a metric-tagged backlog + verify last cycle (read-only ASC) |
 | `press-media` | Press kit, journalist outreach, pitch templates |
 | `community-building` | Social media, building in public, content strategy |
 | `indie-business` | Business entity, taxes, revenue, hiring |
@@ -256,6 +257,7 @@ Generate production-ready Swift code that adapts to your project:
 | `review-response-writer` | Professional review responses |
 | `apple-search-ads` | Search Ads campaign setup, keyword bidding, ROAS |
 | `rejection-handler` | Handle rejections, response templates, appeals |
+| `originality-check` | Guideline-4.3 anti-spam gate: function/content/metadata distinctness before build or submit |
 | `iap-finalizer` | Finalize one-time IAP price + localization in ASC (dry-run) |
 | `marketing-strategy` | Comprehensive promotional strategy |
 

--- a/skills/app-store/originality-check/SKILL.md
+++ b/skills/app-store/originality-check/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: originality-check
+description: Guideline-4.3 anti-spam / originality gate — score whether an app (and each portfolio addition) is meaningfully distinct in function, content, and metadata before you invest or submit. Use at validation/new-app time and again before submission. Protects the whole developer account from 4.3 (spam/duplicate) rejections. NOT rejection-handler (that works an existing rejection) and NOT competitive-analysis (that positions in the market).
+allowed-tools: [Read, Write, WebSearch, Glob, Grep, AskUserQuestion, mcp__asc-metadata__list_apps, mcp__asc-metadata__get_metadata]
+---
+
+# Originality Check
+
+Decide, with evidence, whether an app is *distinct enough to exist* — before you build it or submit it.
+
+> At portfolio scale, shipping many similar small apps is exactly what triggers **Guideline 4.3
+> (spam / duplicate)**. One 4.3 is a warning; repeated 4.3s put the **whole account** at risk. This
+> is the go/no-go distinctness gate that keeps that from happening.
+
+## Where it fits (read the seams)
+
+- **Not `rejection-handler`.** That works a rejection you *already have*. This is upstream — it
+  prevents the 4.3 by catching sameness before you ship.
+- **Not `competitive-analysis` / `market-research`.** Those size demand and position you in the
+  market. This judges *distinctness* (function + content + metadata) vs your own portfolio and vs
+  near-identical competitors — a spam risk, not a demand question.
+- **Two moments to run it:** at `validate` / `new-app` (don't build a dup) and before `submit`
+  (don't trip 4.3). Also periodically across the portfolio (internal cannibalization / template-sameness).
+
+## Prerequisites
+
+- The app idea or a shipped app to evaluate (name, one-line function, target metadata).
+- Optional: `.planning/VALIDATION.md` (competitor + market data). If missing/stale, gather fresh
+  via WebSearch or the `product/competitive-analysis` skill.
+- Optional ASC access to read the developer's existing portfolio (`list_apps` / `get_metadata`).
+
+## Flow
+
+1. **Internal check (your own portfolio).** `list_apps` → for each shipped app read its positioning
+   (`get_metadata`). Does the candidate overlap one you already ship in **function**, **code
+   template**, or **metadata**? Two apps that differ only in theme/reskin = 4.3 risk.
+2. **External check (the market).** Read `VALIDATION.md` if present; otherwise `WebSearch` for close
+   look-alikes. Judge: is the core function a thin reskin of an existing app, or a genuine wedge?
+3. **Distinctness scorecard.** Score each dimension *meaningful difference vs cosmetic*, and flag any
+   that is only skin-deep:
+
+   | Dimension | Distinct if… |
+   |---|---|
+   | **Function** | it does something materially different, not a template swap |
+   | **Content / data** | unique data or content, not a generic wrapper |
+   | **Metadata** | name / keywords / screenshots not near-identical to siblings or competitors |
+   | **UX / value** | a real reason a user picks *this* one |
+
+4. **Verdict + remedy.**
+   - **Distinct** → proceed.
+   - **Borderline** → give concrete ways to differentiate (merge sibling apps into one configurable
+     app, add the unique wedge, or drop it); if approved, name the specific wedge that MUST be built
+     to clear 4.3.
+   - **Duplicate** → recommend not shipping; if several thin apps already exist, recommend
+     consolidating into one strong app (better for ranking *and* review).
+5. **Record.** Write the verdict + reasoning to `.planning/` (VALIDATION or STATE). For a
+   borderline-approved app, record the wedge as a build requirement so `plan`/`build` deliver it.
+
+## Done
+
+- A written verdict (distinct / borderline+wedge / duplicate) with per-dimension reasoning, and —
+  if borderline — the specific differentiation that must ship before submission.
+
+## Caveats
+
+- **Cosmetic theming ≠ differentiation.** Apple judges function + metadata similarity, not your
+  intent. Score honestly.
+- **Protect the account.** When in doubt between "borderline ship" and "consolidate," prefer one
+  strong app over several thin ones.
+- Guideline numbers/text drift — confirm current 4.3 wording at the
+  [App Review Guidelines](https://developer.apple.com/app-store/review/guidelines/) (captured 2026-07).

--- a/skills/growth/store-signals/SKILL.md
+++ b/skills/growth/store-signals/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: store-signals
+description: Close the post-launch loop — turn a live app's App Store signals (reviews, analytics, sales, crashes, listing conversion) into a metric-tagged backlog for the next version, AND verify whether last cycle's changes moved the metric they promised to move. Read-only on App Store Connect; every change is surfaced and routed to another command, never auto-applied. Use before planning the next version, on a monthly cadence, or ~1-2 weeks after shipping to check if a change worked.
+allowed-tools: [Read, Write, Glob, Grep, AskUserQuestion, mcp__asc-metadata__list_apps, mcp__asc-metadata__list_reviews, mcp__asc-metadata__get_review, mcp__asc-metadata__get_analytics_report, mcp__asc-metadata__setup_analytics_reports, mcp__asc-metadata__get_sales_report, mcp__asc-metadata__get_diagnostics, mcp__asc-metadata__get_perf_metrics, mcp__asc-metadata__list_beta_feedback_crashes, mcp__asc-metadata__get_metadata]
+---
+
+# Store Signals
+
+Pull what the *shipped* app is actually telling you and convert it into the next backlog — then
+verify whether last cycle's bets paid off.
+
+> This is the missing arc that turns build → ship into a **loop**:
+> `ship → MEASURE → DIAGNOSE → next PLAN → build → ship → measure again…`
+> The ledger (`SIGNALS.md`) is what makes it a loop and not a monthly report.
+
+## Where it fits (read the seams)
+
+- **Not `analytics-interpretation`.** That *interprets* a metric you hand it (is 14% D7 good?). This
+  is the end-to-end operate loop: gather every signal → cluster → diagnose → **write a metric-tagged
+  backlog** → **close last cycle's hypotheses**. It *uses* analytics-interpretation's benchmarks.
+- **Read-only on ASC.** Never responds to reviews, never mutates metadata/pricing. It surfaces, gates
+  on explicit OK, and routes the change to the right command (`next-version`, `bugfix`, `metadata`).
+- **Feeds planning.** Output is a dated backlog appended to `ROADMAP.md` + rows in `SIGNALS.md`,
+  consumed by `/apple:next-version` / `/apple:release`.
+
+## Prerequisites
+
+- A live (or TestFlight) app; resolve its `appId` from `.planning/STATE.md`, else `list_apps` + confirm.
+- `.planning/` context: `STATE.md`, `APP.md`, `POSITIONING.md` (job-to-be-done + guardrails).
+- `.planning/SIGNALS.md` if present — the OPEN hypotheses from prior runs (each with a target metric,
+  recorded baseline, and "check-after" date). See **signals-ledger.md** for the ledger + backlog formats.
+
+## Flow
+
+1. **Load prior hypotheses.** Read `SIGNALS.md` → the OPEN rows to verify in step 5.
+2. **Pull the signals (read-only), this period vs trailing:**
+   - **Reviews / ratings** — `list_reviews` (recent, lowest-star first; flag unanswered), `get_review` for detail.
+   - **Analytics** — `get_analytics_report`: retention, funnel/conversion, acquisition, impression→download.
+     No report configured yet → `setup_analytics_reports` and note "retention/funnel lands next cycle."
+   - **Sales** — `get_sales_report`: proceeds/units vs trailing 7/30-day.
+   - **Stability / perf** — `get_diagnostics` (crash/hang signatures) + `get_perf_metrics` (launch, memory, energy).
+   - **Beta** — `list_beta_feedback_crashes` if in TestFlight.
+   - **Listing** — `get_metadata` to spot ASO conversion problems against current copy.
+3. **Normalize & cluster.** Dedupe reviews into recurring themes (requests / complaints / praise) with
+   frequency; attach magnitude (users / revenue / retention implicated). Weight by **frequency ×
+   revenue impact**, not by how loud one reviewer is.
+4. **Diagnose, filter, prioritize.** Map each cluster to the core metric it moves (rating · D7 · Pro
+   conversion · crash-free rate · ASO conversion · proceeds); score **impact × confidence ÷ effort**.
+   **Strategy filter:** cross-check `POSITIONING.md` — on-strategy → backlog; off-strategy → list under
+   **"Declined (why)"** (never silently drop, never silently build). Carry the app's guardrails forward.
+   Small-N (new app): say so, lean on qualitative reviews, flag low confidence.
+5. **Close the prior loop.** For each OPEN hypothesis whose change shipped and whose "check-after" date
+   passed: compare the target metric now vs its baseline → **WIN / REGRESSION / NEUTRAL**. WIN → resolve;
+   REGRESSION → open a revert/rethink task; NEUTRAL → keep watching or retire.
+6. **Write the backlog.** Append a dated, metric-tagged section to `ROADMAP.md` and update `SIGNALS.md`
+   (one row per hypothesis; formats in **signals-ledger.md**). Then output a ranked digest (top 3-5
+   "what's hurting most, why, the proposed move"), the loop-closure results, and a suggested next
+   command (`/apple:next-version`, `/apple:bugfix` for a hot crash, `/apple:metadata` for an ASO fix).
+
+## Portfolio mode
+
+With no single app (or `--portfolio`): run steps 2-4 across every app in `list_apps`, then rank which
+app to invest in next — biggest fixable revenue/retention/rating gap first (pairs with
+`portfolio-health-monitor`). Output one line per app + the single highest-ROI move overall.
+
+## Done
+
+- A ranked cited digest, the WIN/REGRESSION/NEUTRAL loop-closure for last cycle, and a metric-tagged
+  backlog written to `ROADMAP.md` + `SIGNALS.md`, with a routed next command.
+
+## Caveats
+
+- **Read-only on ASC** — never auto-apply pricing, metadata, or review responses; surface → gate → route.
+- **Evidence over vibes** — every backlog item cites its signal + magnitude; the loudest reviewer is
+  not the roadmap.
+- **Always verify last cycle (step 5) before planning the next** — that closure is the whole point.
+- Apple delivers analytics on its own schedule; a freshly configured report is empty until next cycle.

--- a/skills/growth/store-signals/signals-ledger.md
+++ b/skills/growth/store-signals/signals-ledger.md
@@ -1,0 +1,59 @@
+# Signals Ledger & Backlog Formats
+
+Reference formats for `store-signals`. `SIGNALS.md` is the durable **ledger** (one row per
+hypothesis, survives across cycles); the **backlog** section is appended to `ROADMAP.md` each run.
+
+## `.planning/SIGNALS.md` — the hypothesis ledger
+
+Step 1 reads it, step 5 resolves the OPEN rows, step 6 appends new ones. Each row is one testable bet.
+
+```markdown
+# Signals Ledger
+
+| id | signal (evidence) | hypothesis | target metric | baseline | status | shipped-in | check-after |
+|----|-------------------|------------|---------------|----------|--------|------------|-------------|
+| S1 | 6/40 reviews ask "team mode" | team mode gives repeat reason to return | D7 retention | 14% | open | — | — |
+| S2 | crash sig `-[Settings]` 4.1% sessions | fix settings crash | crash-free rate | 95.9% | shipped | v1.3 | 2026-07-15 |
+| S3 | TTR 3.2% (poor) | bolder icon lifts tap-through | impression→download | 3.2% | win | v1.3 | 2026-07-01 |
+```
+
+- **status:** `open` (identified, not yet built) · `shipped` (change is live, awaiting check-after) ·
+  `win` / `regression` / `neutral` (verified in a later cycle) · `retired` (dropped).
+- **baseline:** the metric value recorded *at the time the hypothesis was written* — never overwrite it;
+  step 5 compares "now" against this frozen number.
+- **check-after:** absolute date (~+14d post-ship) when the metric is expected to have moved.
+
+## Backlog section appended to `ROADMAP.md`
+
+Every item carries the fields below so `next-version` can plan against evidence, not intuition.
+
+```markdown
+## Backlog from store signals — <YYYY-MM-DD>
+
+### <item title>
+- **signal:** 6 reviews request "team/bracket mode"
+- **evidence:** 6 of last 40 reviews; 4.6★ but 3 name it explicitly
+- **type:** feature | bug | ASO | pricing | retention
+- **hypothesis:** team mode lifts rating + D7 by giving a repeat-event reason to return
+- **target metric + baseline:** D7 retention (now 14%); rating (now 4.6)
+- **effort:** S | M | L
+- **score:** impact × confidence ÷ effort
+- **check-after:** +14d post-ship
+
+### Declined (off-strategy / guardrail)
+- <request> — declined because <reason vs POSITIONING.md / guardrail>
+```
+
+## Loop-closure block (step 5 output)
+
+```markdown
+## Loop closure — <YYYY-MM-DD>
+| id | shipped-in | metric | baseline → now | verdict | action |
+|----|------------|--------|----------------|---------|--------|
+| S2 | v1.3 | crash-free rate | 95.9% → 99.4% | WIN | mark resolved |
+| S3 | v1.3 | impression→download | 3.2% → 3.1% | NEUTRAL | keep watching |
+```
+
+Verdict rule of thumb (see `analytics-interpretation` for per-metric benchmarks): < 3pp move on a
+retention/conversion metric ≈ NEUTRAL (noise); a clear move in the wrong direction = REGRESSION →
+open a revert/rethink task.


### PR DESCRIPTION
## What

Adds two skills backing SwiftShip's new post-launch / guardrail commands:

- **`app-store/originality-check`** — the Guideline-4.3 anti-spam / portfolio-distinctness gate. Internal (own-portfolio overlap via `list_apps`) + external (market look-alikes) checks, a 4-dimension scorecard (function / content / metadata / UX-value), and a verdict + remedy (distinct / borderline+wedge / duplicate→consolidate). Backs `/apple:differentiate`.
- **`growth/store-signals`** (+ `signals-ledger.md`) — the post-launch loop: pull reviews / analytics / sales / crashes / ASO → cluster by frequency × revenue → diagnose + strategy-filter → close last cycle's `SIGNALS.md` hypotheses (WIN/REGRESSION/NEUTRAL) → write a metric-tagged backlog. Read-only on App Store Connect. Backs `/apple:learn-from-store`.

## Registration

- README: `originality-check` added to the **App Store Skills** table (app-store dir count 8 → 9); `store-signals` added to the **Growth Skills** table (growth dir count 4 → 5).

Both follow the lean SKILL.md house format (frontmatter `name` / `description` / `allowed-tools` array → intro blockquote → Where it fits → Prerequisites → Flow → Done → Caveats), modeled on `app-store/iap-finalizer`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
