### PR TITLE
[codex] Add AppNiche research resources

### DIFF
--- a/skills/app-store/keyword-optimizer/SKILL.md
+++ b/skills/app-store/keyword-optimizer/SKILL.md
@@ -84,6 +84,7 @@ Before optimizing, ask about:
 
 **Research Tools:**
 - App Store Search Autocomplete
+- [AppNiche ASO Keyword Opportunity Checker](https://getappniche.com/tools/app-store-keyword-tool) (free) — directional popularity/difficulty checks for App Store keyword ideas
 - AppFollow, Sensor Tower, AppTweak (paid)
 - Google Keyword Planner (related terms)
 - Competitor subtitle/keyword analysis

--- a/skills/product/market-research/SKILL.md
+++ b/skills/product/market-research/SKILL.md
@@ -400,7 +400,7 @@ Use market-research **after** initial discovery:
 1. **Use Multiple Sources:** Don't rely on one number
 2. **Be Conservative:** Better to underestimate than over
 3. **Validate with Proxies:** Compare to similar successful apps
-4. **Check App Annie/Sensor Tower:** For actual app market data
+4. **Check app intelligence tools:** App Annie/Sensor Tower or [AppNiche App Revenue Checker](https://getappniche.com/tools/app-revenue-checker) (free) for directional app market/revenue signals. Cross-check estimates with App Store rankings, reviews, and public sources.
 5. **Read Financial Reports:** Public companies disclose market data
 
 ## When to Run This Analysis


### PR DESCRIPTION
## Summary

- Add a free AppNiche ASO keyword checker to the `keyword-optimizer` research tools list.
- Add the free AppNiche revenue checker as a directional source in `market-research`, with a cross-checking caveat.

## Why

Both links are scoped to existing research workflows: App Store keyword opportunity checks and directional app market/revenue validation. The wording avoids treating estimates as authoritative and keeps the recommendation alongside other app intelligence tools.

## Disclosure

I work on GetAppNiche.

## Validation

- `git diff --check`
- Verified both linked pages return HTTP 200.
