### PR TITLE
docs: sync all skill counts to reality (147) + CI validator to end count drift

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,17 @@
+name: validate
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Documented counts match the tree
+        run: |
+          chmod +x scripts/check-counts.sh
+          ./scripts/check-counts.sh

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Four repos, four layers — use one or all:
 
 | Layer | Repo | What it is |
 |---|---|---|
-| Knowledge | **claude-code-apple-skills** ← you are here | 143 skills — how to build right |
-| Workflow | [SwiftShip](https://github.com/rshankras/SwiftShip) | 33 /apple:* commands — spec-driven idea → App Store |
+| Knowledge | **claude-code-apple-skills** ← you are here | 147 skills — how to build right |
+| Workflow | [SwiftShip](https://github.com/rshankras/SwiftShip) | 49 /apple:* commands — spec-driven idea → App Store |
 | Action | [indie-app-autopilot](https://github.com/rshankras/indie-app-autopilot) | 7 agents — GitHub issue → App Store |
 | Integration | [asc-metadata-mcp](https://github.com/rshankras/asc-metadata-mcp) | 65+ MCP tools — live App Store Connect API |
 
@@ -24,9 +24,9 @@ Four repos, four layers — use one or all:
 | **iOS** | 9 | Code review, UI review, navigation, iPad, migration, accessibility, simulator/device runs |
 | **Testing** | 9 | TDD workflows, test infrastructure, snapshot tests, flow walkthrough |
 | **macOS** | 8 | Tahoe APIs, SwiftData, AppKit bridge |
-| **App Store** | 8 | ASO, descriptions, keywords, reviews, search ads, rejections, IAP finalize |
+| **App Store** | 9 | ASO, descriptions, keywords, reviews, search ads, rejections, originality, IAP finalize |
 | **SwiftUI** | 5 | AlarmKit, WebKit, text editing, toolbars, Charts 3D |
-| **Growth** | 4 | Analytics, press/media, community, indie business |
+| **Growth** | 5 | Analytics, store signals, press/media, community, indie business |
 | **Swift** | 3 | Concurrency patterns, Swift 6.2, InlineArray/Span |
 | **Apple Intelligence** | 3 | Foundation Models, Visual Intelligence, App Intents |
 | **Design** | 3 | Liquid Glass (SwiftUI/AppKit/UIKit/WidgetKit), animation patterns, UI prototyping |
@@ -43,7 +43,7 @@ Four repos, four layers — use one or all:
 | **Release Review** | 1 | Pre-release audit checklists |
 | **Shared** | 2 | Meta-skills for creating (`skill-creator`) and auditing (`skill-auditor`) skills |
 
-**Total: 145 skills across 23 categories** (category index files not counted)
+**Total: 147 skills across 23 categories** (single-skill categories count their category file; other index files aren't counted — enforced by `scripts/check-counts.sh` in CI)
 
 ## Quick Start
 
@@ -105,7 +105,8 @@ skills/
 ├── app-store/              # ASO, descriptions, screenshots, reviews, search ads, rejections, originality, IAP finalize (9 skills)
 ├── watchos/                # Watch apps, complications, health/fitness, widgets
 ├── release-review/         # Security, privacy, UX, distribution audits
-└── shared/                 # Meta-skills: skill-creator, skill-auditor
+├── shared/                 # Meta-skills: skill-creator, skill-auditor
+└── _shared/                # Internal helpers, not skills (asc-api — ASC REST helper used by iap-finalizer & privacy-publish)
 ```
 
 ## Documentation

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -130,25 +130,11 @@ Good: "Add a subscription paywall with monthly and yearly tiers"
 Vague: "Add payments"
 ```
 
-## Skill Categories (148 skills across 23 categories)
+## Skill Categories
 
-| Category | Count | Purpose |
-|----------|-------|---------|
-| `generators/` | 52 | Production-ready code for common features |
-| `product/` | 13 | Idea to App Store workflow, beta testing, localization |
-| `testing/` | 8 | TDD workflows, test infrastructure |
-| `macos/` | 8 | macOS development patterns |
-| `app-store/` | 7 | ASO, descriptions, keywords, search ads, rejections |
-| `ios/` | 7 | iOS code review, UI review, planning, migration |
-| `swiftui/` | 5 | AlarmKit, WebKit, text editing, toolbars, Charts 3D |
-| `growth/` | 5 | Analytics, press/media, community, indie business |
-| `swift/` | 3 | Concurrency, Swift 6.2, memory |
-| `apple-intelligence/` | 3 | Foundation Models, Visual Intelligence, App Intents |
-| `design/` | 2 | Liquid Glass, animations |
-| `legal/` | 2 | Privacy policies, terms of service, EULAs |
-| `performance/` | 2 | Instruments, SwiftUI debugging |
-| `security/` | 2 | Keychain, biometrics, privacy manifests |
-| + 9 more | 9 | Core ML, Monetization, SwiftData, MapKit, Foundation, visionOS, watchOS, Release Review, Shared |
+**147 skills across 23 categories** — see the
+[What's Included table in the README](../README.md#whats-included) for the
+per-category breakdown (kept in sync with the tree by `scripts/check-counts.sh`).
 
 ## Troubleshooting
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -143,33 +143,9 @@ Differences:
 
 ## Skill Categories
 
-| Category | Count | Purpose | When to Use |
-|----------|-------|---------|-------------|
-| `generators/` | 52 | Generate code | Add features to any app |
-| `product/` | 13 | Idea to specs | New app planning, beta testing, localization |
-| `macos/` | 8 | macOS development | Code review, UI review, Tahoe APIs |
-| `testing/` | 8 | TDD & testing | TDD workflows, snapshots, test infrastructure |
-| `app-store/` | 7 | ASO & marketing | Descriptions, keywords, search ads, rejections |
-| `ios/` | 7 | iOS development | Code review, navigation, iPad, migration |
-| `swiftui/` | 5 | SwiftUI features | AlarmKit, WebKit, text editing, toolbars, Charts 3D |
-| `growth/` | 5 | User acquisition | Analytics, press, community, indie business |
-| `swift/` | 3 | Swift language | Concurrency, Swift 6.2, memory (InlineArray/Span) |
-| `apple-intelligence/` | 3 | AI features | Foundation Models, Visual Intelligence, App Intents |
-| `design/` | 2 | Modern UI | Liquid Glass (SwiftUI/AppKit/UIKit/WidgetKit), animations |
-| `legal/` | 2 | Legal documents | Privacy policies, terms of service, EULAs |
-| `performance/` | 2 | Performance | Instruments profiling, SwiftUI debugging |
-| `security/` | 2 | Security | Keychain, biometrics, privacy manifests |
-| `core-ml/` | 1 | On-device ML | Vision, NaturalLanguage, Core ML models |
-| `monetization/` | 1 | Revenue strategy | Pricing models, tiers, free trials |
-| `swiftdata/` | 1 | Data persistence | Class inheritance patterns |
-| `mapkit/` | 1 | Maps & location | GeoToolbox, place descriptors |
-| `foundation/` | 1 | Foundation | AttributedString updates |
-| `visionos/` | 1 | visionOS | Widget development |
-| `watchos/` | 1 | watchOS | Watch apps, complications, health/fitness, widgets |
-| `release-review/` | 1 | Pre-release | Security, privacy, UX audit |
-| `shared/` | 1 | Skill creation | Templates for creating new skills |
-
-**Total: 148 skills across 23 categories**
+**147 skills across 23 categories.** The per-category breakdown lives in one
+place — the [What's Included table in the README](../README.md#whats-included)
+— so it can't drift from the tree (`scripts/check-counts.sh` enforces it in CI).
 
 ---
 

--- a/scripts/check-counts.sh
+++ b/scripts/check-counts.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+
+# Count-sync validator — documented skill counts must match the tree.
+# History: the README has shipped four different totals (143/145/148/…) as
+# skills landed without doc bumps. This makes that structurally impossible.
+#
+# Counting rule (same as the README's "What's Included" table):
+#   - a skill = skills/<category>/<skill>/SKILL.md
+#   - PLUS single-skill categories whose category-level SKILL.md IS the skill
+#     (listed in CATEGORY_LEVEL_SKILLS below — extend it consciously)
+#   - other category-level SKILL.md files are indexes and don't count
+#   - _shared/ holds internal helpers, not skills or a category
+#
+# Usage:  ./scripts/check-counts.sh
+# Exit:   0 = in sync, 1 = drift found
+
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_DIR" || exit 1
+
+VIOLATIONS=0
+fail() {
+    echo "  ✗ $1"
+    VIOLATIONS=$((VIOLATIONS + 1))
+}
+
+# Categories whose category-level SKILL.md is itself the (only) skill.
+# Adding a new one? Add it here AND to the README table.
+CATEGORY_LEVEL_SKILLS="core-ml monetization watchos release-review security"
+
+# --- Compute ground truth ---------------------------------------------------
+SKILL_DIRS=$(find skills -mindepth 3 -maxdepth 3 -name "SKILL.md" | wc -l | tr -d ' ')
+CAT_SKILLS=0
+for c in $CATEGORY_LEVEL_SKILLS; do
+    if [ -f "skills/$c/SKILL.md" ]; then
+        CAT_SKILLS=$((CAT_SKILLS + 1))
+    else
+        fail "skills/$c/SKILL.md missing but listed in CATEGORY_LEVEL_SKILLS"
+    fi
+done
+TOTAL=$((SKILL_DIRS + CAT_SKILLS))
+CATS=$(find skills -mindepth 1 -maxdepth 1 -type d ! -name "_shared" | wc -l | tr -d ' ')
+
+echo "== Ground truth: $TOTAL skills ($SKILL_DIRS skill dirs + $CAT_SKILLS category-level) across $CATS categories =="
+
+# --- 1. Totals everywhere they appear ----------------------------------------
+echo ""
+echo "== Totals in README + docs =="
+grep -qF "| $TOTAL skills" README.md \
+    || fail "README stack table: expected '$TOTAL skills'"
+grep -qF "Total: $TOTAL skills across $CATS categories" README.md \
+    || fail "README: expected 'Total: $TOTAL skills across $CATS categories'"
+for f in docs/USAGE.md docs/QUICK_START.md; do
+    [ -f "$f" ] || continue
+    grep -qF "$TOTAL skills across $CATS categories" "$f" \
+        || fail "$f: expected '$TOTAL skills across $CATS categories'"
+done
+
+# --- 2. Per-category counts in the README table ------------------------------
+echo ""
+echo "== Per-category counts in README 'What's Included' table =="
+# "README label|directory" pairs — every row in the table.
+PAIRS="Generators|generators
+Product|product
+iOS|ios
+Testing|testing
+macOS|macos
+App Store|app-store
+SwiftUI|swiftui
+Growth|growth
+Swift|swift
+Apple Intelligence|apple-intelligence
+Design|design
+Performance|performance
+Security|security
+Core ML|core-ml
+Legal|legal
+Monetization|monetization
+watchOS|watchos
+SwiftData|swiftdata
+MapKit|mapkit
+Foundation|foundation
+visionOS|visionos
+Release Review|release-review
+Shared|shared"
+
+CHECKED=0
+SUM=0
+while IFS='|' read -r label dir; do
+    n=$(find "skills/$dir" -mindepth 2 -maxdepth 2 -name "SKILL.md" 2>/dev/null | wc -l | tr -d ' ')
+    case " $CATEGORY_LEVEL_SKILLS " in
+        *" $dir "*) n=$((n + 1)) ;;
+    esac
+    grep -qF "| **$label** | $n |" README.md \
+        || fail "README table: expected '| **$label** | $n |' (tree has $n for skills/$dir)"
+    CHECKED=$((CHECKED + 1))
+    SUM=$((SUM + n))
+done <<EOF
+$PAIRS
+EOF
+
+[ "$SUM" -eq "$TOTAL" ] || fail "table rows sum to $SUM but total is $TOTAL — a category is missing from this script's PAIRS list"
+echo "  checked $CHECKED categories (rows sum to $SUM)"
+
+# --- 3. Every category dir appears in the table (catches new categories) -----
+for d in $(find skills -mindepth 1 -maxdepth 1 -type d ! -name "_shared" -exec basename {} \;); do
+    printf '%s\n' "$PAIRS" | grep -q "|$d\$" \
+        || fail "skills/$d exists but has no row mapping in this script — add it to PAIRS and the README table"
+done
+
+# --- 4. Cross-repo: SwiftShip command count (skipped if no sibling checkout) --
+echo ""
+echo "== Cross-repo counts =="
+SWIFTSHIP="${SWIFTSHIP_DIR:-$REPO_DIR/../SwiftShip}"
+if [ -d "$SWIFTSHIP/commands/apple" ]; then
+    CMDS=$(ls "$SWIFTSHIP"/commands/apple/*.md 2>/dev/null | wc -l | tr -d ' ')
+    grep -qF "$CMDS /apple:* commands" README.md \
+        || fail "README stack table: SwiftShip row says stale command count (checkout has $CMDS)"
+    echo "  SwiftShip: $CMDS commands"
+else
+    echo "  (no SwiftShip checkout at $SWIFTSHIP — skipping command-count check)"
+fi
+
+# --- Result -------------------------------------------------------------------
+echo ""
+if [ "$VIOLATIONS" -eq 0 ]; then
+    echo "✓ All counts in sync"
+    exit 0
+else
+    echo "✗ $VIOLATIONS count violation(s) — update the docs (or this script, if the rule changed)"
+    exit 1
+fi


### PR DESCRIPTION
## The problem

Four different totals were live at once: **143** (README stack table), **145** (README total line), **148** (docs/USAGE.md and docs/QUICK_START.md) — while the tree actually holds **147** by the README's own counting rule. This is the repo's second count-sync fix (#12 was the first), so this PR also makes it the last.

## Fixes

- **README**: totals → 147 · App Store row 8→9 (originality-check) · Growth row 4→5 (store-signals) · **SwiftShip row 33→49 commands** (16 stale) · `_shared/` documented in the directory structure · counting rule clarified
- **docs/USAGE.md + docs/QUICK_START.md**: their duplicated category tables (much further behind — e.g. generators listed as 52 vs 63) replaced with pointers to the README's single table
- **`scripts/check-counts.sh`** (new): computes ground truth from the tree, checks every total and every README table row, fails on unmapped new categories, and verifies the SwiftShip command count when a sibling checkout exists — same philosophy as SwiftShip's `validate.sh`
- **`.github/workflows/validate.yml`** (new): this repo's first CI — validator on every PR and push

## Verified

```
== Ground truth: 147 skills (142 skill dirs + 5 category-level) across 23 categories ==
  checked 23 categories (rows sum to 147)
  SwiftShip: 49 commands
✓ All counts in sync
```

Any of the four historical drifts would have failed this check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Zx7B9syDSTY5tD3EGeHqf