### PR TITLE
fix: remove machine-local paths from skills — portable across all install types

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ Use `skills/shared/skill-creator/SKILL.md` as the guide. Key requirements:
 
 ## Apple Docs Reference
 
-Apple documentation files are stored at `/Users/ravishankar/Downloads/docs/`. Skills should reference these for latest API patterns.
+Prefer public `developer.apple.com` links in skill References. A locally captured docs folder (`~/Downloads/docs/`) may be referenced only behind a check-if-exists instruction ("read if present; skip silently if absent") — never hardcode absolute user paths (`/Users/...`) in skills; they break every install that isn't this machine.
 
 See `docs/ROADMAP.md` for planned skills based on available Apple docs.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,8 +99,8 @@ Help improve documentation:
 1. **Fork the repository** on GitHub
 2. **Clone your fork** locally:
    ```bash
-   git clone https://github.com/YOUR_USERNAME/claude-code-ios-skills.git
-   cd claude-code-ios-skills
+   git clone https://github.com/YOUR_USERNAME/claude-code-apple-skills.git
+   cd claude-code-apple-skills
    ```
 3. **Create a branch** for your changes:
    ```bash
@@ -397,7 +397,7 @@ Contributors will be recognized:
 
 ## Resources
 
-- [skill-creator skill](skills/skill-creator/) - Guide for creating skills
+- [skill-creator skill](skills/shared/skill-creator/) - Guide for creating skills
 - [Swift Style Guide](https://google.github.io/swift/)
 - [iOS HIG](https://developer.apple.com/design/human-interface-guidelines/)
 - [Claude Code Docs](https://docs.claude.com/claude-code)

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -30,10 +30,10 @@ cp -r /path/to/claude-code-apple-skills/skills/* .claude/skills/
 Copy only the categories you need:
 
 ```bash
-# Just generators (52 skills)
+# Just generators (63 skills)
 cp -r /path/to/claude-code-apple-skills/skills/generators .claude/skills/
 
-# Just testing/TDD (8 skills)
+# Just testing/TDD (9 skills)
 cp -r /path/to/claude-code-apple-skills/skills/testing .claude/skills/
 
 # Just iOS review skills

--- a/skills/app-store/iap-finalizer/SKILL.md
+++ b/skills/app-store/iap-finalizer/SKILL.md
@@ -19,7 +19,11 @@ Finish a **one-time** in-app purchase on the store side: **price + localization*
 
 ## Prerequisites
 
-- `_shared/asc-api/` set up (see its README — key + `~/.appstoreconnect/`).  `ASC=python3 ~/.claude/swiftship-skills/_shared/asc-api/asc.py`
+- `_shared/asc-api/` set up (see its README — key + `~/.appstoreconnect/`).
+- Set `ASC="python3 <path to asc.py>"`. `asc.py` lives at `_shared/asc-api/asc.py` under the same `skills/` root as this skill — resolve it **relative to this SKILL.md file's location** (`../../_shared/asc-api/asc.py` from this skill's directory), never relative to the project cwd (skills run with cwd = the user's project). Known install locations:
+  - SwiftShip symlink install: `~/.claude/swiftship-skills/_shared/asc-api/asc.py`
+  - Copied install: `.claude/skills/_shared/asc-api/asc.py` (project) or `~/.claude/skills/_shared/asc-api/asc.py` (global)
+  - Plugin install: resolve from this file's location — the `_shared/` tree ships with the plugin.
 - The IAP already exists in ASC. Get its id with the MCP: `list_iap` → pick the product.
 - Price decided in Phase 4. Read it from `.planning/` and confirm — don't invent it.
 

--- a/skills/apple-intelligence/SKILL.md
+++ b/skills/apple-intelligence/SKILL.md
@@ -71,6 +71,7 @@ App Intents for Siri, Shortcuts, Spotlight, and Apple Intelligence.
 
 ## Reference Documentation
 
-- `/Users/ravishankar/Downloads/docs/FoundationModels-Using-on-device-LLM-in-your-app.md`
-- `/Users/ravishankar/Downloads/docs/Implementing-Visual-Intelligence-in-iOS.md`
-- `/Users/ravishankar/Downloads/docs/AppIntents-Updates.md`
+- [Foundation Models](https://developer.apple.com/documentation/foundationmodels)
+- [Visual Intelligence](https://developer.apple.com/documentation/visualintelligence)
+- [App Intents](https://developer.apple.com/documentation/appintents)
+- Local captured docs (optional): if `~/Downloads/docs/` contains `FoundationModels-Using-on-device-LLM-in-your-app.md`, `Implementing-Visual-Intelligence-in-iOS.md`, or `AppIntents-Updates.md`, read them for extra detail; skip silently if absent.

--- a/skills/apple-intelligence/app-intents/SKILL.md
+++ b/skills/apple-intelligence/app-intents/SKILL.md
@@ -249,4 +249,4 @@ Before shipping App Intents integration:
 - [App Shortcuts](https://developer.apple.com/documentation/AppIntents/app-shortcuts)
 - [IndexedEntity](https://developer.apple.com/documentation/AppIntents/IndexedEntity)
 - [Spotlight integration](https://developer.apple.com/documentation/CoreSpotlight)
-- `/Users/ravishankar/Downloads/docs/AppIntents-Updates.md`
+- Local captured doc (optional): `~/Downloads/docs/AppIntents-Updates.md` — read if present; skip silently if absent.

--- a/skills/apple-intelligence/app-intents/advanced-features.md
+++ b/skills/apple-intelligence/app-intents/advanced-features.md
@@ -713,4 +713,4 @@ struct MusicShortcuts: AppShortcutsProvider {
 - [AppIntentsPackage](https://developer.apple.com/documentation/AppIntents/AppIntentsPackage)
 - [Visual Intelligence integration](https://developer.apple.com/documentation/VisualIntelligence)
 - [NSUserActivity](https://developer.apple.com/documentation/foundation/nsuseractivity)
-- `/Users/ravishankar/Downloads/docs/AppIntents-Updates.md`
+- Local captured doc (optional): `~/Downloads/docs/AppIntents-Updates.md` — read if present; skip silently if absent.

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -60,5 +60,6 @@ SwiftUI animation patterns for iOS 13–18+.
 
 ## Reference Documentation
 
-- `/Users/ravishankar/Downloads/docs/SwiftUI-Implementing-Liquid-Glass-Design.md`
-- `/Users/ravishankar/Downloads/docs/AppKit-Implementing-Liquid-Glass-Design.md`
+- [Applying Liquid Glass to custom views (SwiftUI)](https://developer.apple.com/documentation/swiftui/applying-liquid-glass-to-custom-views)
+- [NSGlassEffectView (AppKit)](https://developer.apple.com/documentation/appkit/nsglasseffectview)
+- Local captured docs (optional): if `~/Downloads/docs/SwiftUI-Implementing-Liquid-Glass-Design.md` or `~/Downloads/docs/AppKit-Implementing-Liquid-Glass-Design.md` exists, read it for extra detail; skip silently if absent.

--- a/skills/legal/privacy-publish/SKILL.md
+++ b/skills/legal/privacy-publish/SKILL.md
@@ -13,7 +13,11 @@ Close the "hosted legal pages + ASC URLs" gap: render `.planning/legal/{privacy,
 ## Prerequisites
 
 - Legal drafts exist: `.planning/legal/privacy.md`, `.planning/legal/terms.md` (from `legal/privacy-policy`).
-- `_shared/asc-api/` set up (README).  `ASC=python3 ~/.claude/swiftship-skills/_shared/asc-api/asc.py`
+- `_shared/asc-api/` set up (README).
+- Set `ASC="python3 <path to asc.py>"`. `asc.py` lives at `_shared/asc-api/asc.py` under the same `skills/` root as this skill — resolve it **relative to this SKILL.md file's location** (`../../_shared/asc-api/asc.py` from this skill's directory), never relative to the project cwd (skills run with cwd = the user's project). Known install locations:
+  - SwiftShip symlink install: `~/.claude/swiftship-skills/_shared/asc-api/asc.py`
+  - Copied install: `.claude/skills/_shared/asc-api/asc.py` (project) or `~/.claude/skills/_shared/asc-api/asc.py` (global)
+  - Plugin install: resolve from this file's location — the `_shared/` tree ships with the plugin.
 - The app has a current editable App Store version + an en-US `appInfoLocalization` and `appStoreVersionLocalization` (get their ids first).
 
 ## Flow — dry-run → confirm → apply

--- a/skills/shared/skill-auditor/SKILL.md
+++ b/skills/shared/skill-auditor/SKILL.md
@@ -253,6 +253,6 @@ The 9 C-01 offenders all use `## When to Use` (non-canonical) rather than `## Wh
 
 ## References
 
-- `/Users/ravishankar/Work/MyApps/claude-code-apple-skills/CLAUDE.md` — normative source for frontmatter schema, naming, emoji convention
+- `../../../CLAUDE.md` (repo root, resolved relative to this SKILL.md — not the project cwd) — normative source for frontmatter schema, naming, emoji convention. If absent (skills-only copies), use https://github.com/rshankras/claude-code-apple-skills/blob/main/CLAUDE.md
 - `skills/shared/skill-creator/SKILL.md` — companion meta-skill for creating new skills (this auditor only audits; it does not create)
 - `skills/ios/SKILL.md` — canonical aggregator example

--- a/skills/swift/concurrency-patterns/SKILL.md
+++ b/skills/swift/concurrency-patterns/SKILL.md
@@ -98,4 +98,4 @@ Based on the problem, read from this directory:
 
 - [Swift Concurrency](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/concurrency/)
 - [Migrating to Swift 6](https://www.swift.org/migration/documentation/migrationguide/)
-- Apple doc: `/Users/ravishankar/Downloads/docs/Swift-Concurrency-Updates.md`
+- Local captured doc (optional): `~/Downloads/docs/Swift-Concurrency-Updates.md` — read if present; skip silently if absent.

--- a/skills/swift/concurrency/SKILL.md
+++ b/skills/swift/concurrency/SKILL.md
@@ -447,7 +447,7 @@ nonisolated struct JSONParser {
 - Xcode build settings: Swift Compiler > Concurrency
 - SwiftSettings API for Swift packages
 - Official migration tooling: [swift.org/migration](https://www.swift.org/migration)
-- Apple doc reference: `/Users/ravishankar/Downloads/docs/Swift-Concurrency-Updates.md`
+- Local captured doc (optional): `~/Downloads/docs/Swift-Concurrency-Updates.md` — read if present; skip silently if absent.
 
 ---
 
@@ -622,7 +622,7 @@ When reviewing code that uses or should use Swift 6.2 concurrency features:
 - **Actors and isolation deep dive**: `swift/concurrency-patterns/actors-and-isolation.md`
 - **Structured concurrency patterns**: `swift/concurrency-patterns/structured-concurrency.md`
 - **Swift 6 migration guide**: `swift/concurrency-patterns/migration-guide.md`
-- **Apple documentation**: `/Users/ravishankar/Downloads/docs/Swift-Concurrency-Updates.md`
+- **Local captured doc (optional)**: `~/Downloads/docs/Swift-Concurrency-Updates.md` — read if present; skip silently if absent.
 
 ## References
 

--- a/skills/swiftdata/inheritance/SKILL.md
+++ b/skills/swiftdata/inheritance/SKILL.md
@@ -345,4 +345,4 @@ When reviewing code that uses SwiftData class inheritance, verify each item:
 
 - [Preserving your app's model data across launches](https://developer.apple.com/documentation/swiftdata/preserving-your-apps-model-data-across-launches)
 - [SwiftData documentation](https://developer.apple.com/documentation/swiftdata)
-- Apple doc: `/Users/ravishankar/Downloads/docs/SwiftData-Class-Inheritance.md`
+- Local captured doc (optional): `~/Downloads/docs/SwiftData-Class-Inheritance.md` — read if present; skip silently if absent.


### PR DESCRIPTION
## Why

First of two PRs preparing the repo for Claude Code **plugin-marketplace distribution** (`/plugin marketplace add rshankras/claude-code-apple-skills`). Plugin installs version by git SHA — whatever is on `main` is the release — so no skill may depend on this machine's filesystem layout. These paths already broke `cp -r` installs for anyone else.

## What

- **`iap-finalizer` + `privacy-publish`**: the hardcoded `ASC=python3 ~/.claude/swiftship-skills/_shared/asc-api/asc.py` is now a dual-context instruction — resolve `asc.py` **relative to the SKILL.md file's own location** (skills run with cwd = the user's project), with the SwiftShip-symlink, copied (`.claude/skills`, `~/.claude/skills`), and plugin install locations listed. The literal `~/.claude/swiftship-skills/...` path is retained, so SwiftShip's `validate.sh` reference contract still resolves.
- **7 files** referencing `/Users/ravishankar/Downloads/docs/*.md` (design, apple-intelligence ×3, swiftdata/inheritance, swift/concurrency ×2, swift/concurrency-patterns): public `developer.apple.com` links are now primary (all verified HTTP 200); the local captured-docs folder is optional behind "read if present; skip silently if absent".
- **`skill-auditor`**: normative CLAUDE.md referenced as `../../../CLAUDE.md` relative to the skill, GitHub URL fallback for skills-only copies.
- **`CLAUDE.md`**: Apple Docs Reference section now codifies the convention — public links first; local docs only behind check-if-exists; never absolute user paths.
- **`CONTRIBUTING.md`**: stale `claude-code-ios-skills` clone URL and `skills/skill-creator/` path fixed.
- **`docs/QUICK_START.md`**: stale per-category counts (generators 52→63, testing 8→9).

## Verification

- `./scripts/check-counts.sh` — 147 skills / 23 categories, all in sync
- `grep -rn "/Users/ravishankar" skills/` — empty
- SwiftShip `scripts/validate.sh` — all 197 skill references still resolve

PR 2 follows with `.claude-plugin/marketplace.json`, six category index skills, install docs, and CI plugin validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)