### PR TITLE
feat: plugin-marketplace distribution — /plugin install apple-skills@indie-apple-stack

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,18 @@
+{
+  "name": "indie-apple-stack",
+  "owner": {
+    "name": "Ravi Shankar"
+  },
+  "metadata": {
+    "description": "The indie Apple developer stack: Apple platform skills now, SwiftShip workflow commands to follow."
+  },
+  "plugins": [
+    {
+      "name": "apple-skills",
+      "source": "./",
+      "description": "147 Apple platform development skills across 23 categories (iOS, macOS, watchOS, visionOS): code generators, product workflow, App Store/ASO, testing and TDD, design, performance, security, and more. Surfaced as 23 category skills that route to the full library.",
+      "strict": false,
+      "skills": ["./skills"]
+    }
+  ]
+}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -15,3 +15,23 @@ jobs:
         run: |
           chmod +x scripts/check-counts.sh
           ./scripts/check-counts.sh
+
+      - name: Every SKILL.md has valid frontmatter
+        run: |
+          chmod +x scripts/check-frontmatter.sh
+          ./scripts/check-frontmatter.sh
+
+  plugin-validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install Claude Code CLI
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: Validate plugin + marketplace
+        run: claude plugin validate . --strict

--- a/README.md
+++ b/README.md
@@ -57,7 +57,22 @@ Four repos, four layers — use one or all:
 
 See **[docs/USAGE.md](docs/USAGE.md)** for complete guide.
 
-### Installation
+### Install as a Plugin (recommended)
+
+In Claude Code:
+
+```
+/plugin marketplace add rshankras/claude-code-apple-skills
+/plugin install apple-skills@indie-apple-stack
+```
+
+This surfaces the library as 23 category skills (`/apple-skills:generators`,
+`/apple-skills:testing`, ...); each category skill routes to its sub-skills on
+demand, so only 23 short descriptions sit in context. Update any time with
+`/plugin marketplace update indie-apple-stack` — no version pinning, you
+always track `main`.
+
+### Manual Install (copy)
 
 ```bash
 # Clone

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -9,6 +9,19 @@ Get up and running with Claude Code Apple Skills in under 5 minutes!
 
 ## Installation (1 minute)
 
+### Option 0: Plugin Install (recommended)
+
+In Claude Code:
+
+```
+/plugin marketplace add rshankras/claude-code-apple-skills
+/plugin install apple-skills@indie-apple-stack
+```
+
+Skills appear as 23 category skills, namespaced by plugin — invoke as
+`/apple-skills:<category>` (e.g. `/apple-skills:generators`). Update with
+`/plugin marketplace update indie-apple-stack`.
+
 ### Option 1: Full Install
 
 ```bash
@@ -56,6 +69,8 @@ Check that skills are installed:
 ls .claude/skills/
 # Should show: generators  ios  macos  testing  monetization  product  ...
 ```
+
+Plugin installs: run `/plugin` and confirm `apple-skills` lists 23 skills.
 
 ## First Use (2 minutes)
 
@@ -140,6 +155,7 @@ per-category breakdown (kept in sync with the tree by `scripts/check-counts.sh`)
 
 ### Skill Not Activating
 
+0. Plugin installs: names are namespaced — try `/apple-skills:<category>` (e.g. `/apple-skills:testing`)
 1. Check skill is in `.claude/skills/` directory
 2. Verify YAML front matter is valid: `head -5 .claude/skills/testing/SKILL.md`
 3. Use explicit trigger phrases from the skill's "When This Skill Activates" section

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -151,6 +151,9 @@ place — the [What's Included table in the README](../README.md#whats-included)
 
 ## FAQ
 
+### How do I install these skills?
+Plugin (recommended): in Claude Code run `/plugin marketplace add rshankras/claude-code-apple-skills`, then `/plugin install apple-skills@indie-apple-stack` — the library appears as 23 category skills (`/apple-skills:<category>`), updated via `/plugin marketplace update indie-apple-stack`. Or copy `skills/` into `.claude/skills/` per the README.
+
 ### Can I skip phases for a new app?
 Yes, but not recommended. Specs build on each other. Skipping means less structured implementation.
 

--- a/scripts/check-frontmatter.sh
+++ b/scripts/check-frontmatter.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Every SKILL.md must open with --- and declare name: and description: in its
+# frontmatter. Plugin installs surface skills by frontmatter name — a missing
+# name falls back to an unstable install-directory string, so this is a
+# distribution contract, not a style check. Kept separate from check-counts.sh
+# (counts) on purpose.
+cd "$(dirname "$0")/.." || exit 1
+
+fails=0
+while IFS= read -r f; do
+    if ! head -1 "$f" | grep -q '^---$'; then
+        echo "  ✗ $f: does not open with frontmatter (---)"
+        fails=$((fails+1))
+        continue
+    fi
+    fm=$(awk 'NR>1 && /^---$/{exit} NR>1{print}' "$f")
+    printf '%s\n' "$fm" | grep -q '^name:'        || { echo "  ✗ $f: missing name:"; fails=$((fails+1)); }
+    printf '%s\n' "$fm" | grep -q '^description:' || { echo "  ✗ $f: missing description:"; fails=$((fails+1)); }
+done < <(find skills -name SKILL.md)
+
+if [ "$fails" -eq 0 ]; then
+    echo "✓ All SKILL.md frontmatter valid (name + description present)"
+    exit 0
+fi
+echo "✗ $fails frontmatter problem(s)"
+exit 1

--- a/skills/foundation/SKILL.md
+++ b/skills/foundation/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: foundation
+description: Foundation framework skills — AttributedString patterns for rich text formatting, alignment, selection, and SwiftUI integration. Use when working with styled text or AttributedString APIs.
+allowed-tools: [Read, Glob, Grep]
+---
+
+# Foundation Skills
+
+Foundation framework patterns for Apple platforms.
+
+## When This Skill Activates
+
+Use this skill when the user:
+- Works with **AttributedString** (formatting, attributes, runs)
+- Needs **rich text** alignment, selection, or styling logic
+- Integrates attributed text with **SwiftUI**
+
+## Available Skills
+
+Paths are relative to THIS file's directory — skills run with cwd set to the
+user's project, so resolve each path from this SKILL.md's own location.
+
+| Skill | Read | Covers |
+|-------|------|--------|
+| attributed-string | `attributed-string/SKILL.md` | AttributedString formatting, alignment, selection, SwiftUI integration |
+
+## How to Route
+
+1. Read `attributed-string/SKILL.md` (relative to this file) plus any reference files it lists.
+2. Apply the guidance to the user's code. For TextEditor-based rich text editing UI, see also `../swiftui/text-editing/SKILL.md`.

--- a/skills/mapkit/SKILL.md
+++ b/skills/mapkit/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: mapkit
+description: MapKit and GeoToolbox skills — PlaceDescriptor patterns, geocoding, and cross-service place identifiers with MapKit integration. Use when working with maps, place data, or geocoding.
+allowed-tools: [Read, Glob, Grep]
+---
+
+# MapKit Skills
+
+Location and place-data patterns built on MapKit and GeoToolbox.
+
+## When This Skill Activates
+
+Use this skill when the user:
+- Works with **PlaceDescriptor** or GeoToolbox
+- Needs **geocoding** or reverse geocoding
+- Handles **place identifiers across services** (Apple Maps + third-party)
+
+## Available Skills
+
+Paths are relative to THIS file's directory — skills run with cwd set to the
+user's project, so resolve each path from this SKILL.md's own location.
+
+| Skill | Read | Covers |
+|-------|------|--------|
+| geotoolbox | `geotoolbox/SKILL.md` | GeoToolbox PlaceDescriptor, geocoding, multi-service place identifiers |
+
+## How to Route
+
+1. Read `geotoolbox/SKILL.md` (relative to this file) plus any reference files it lists.
+2. Apply the guidance to the user's code.

--- a/skills/performance/SKILL.md
+++ b/skills/performance/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: performance
+description: Performance profiling and SwiftUI debugging skills — Instruments guidance, hangs, memory issues, slow launches, energy drain, unnecessary re-renders, and view identity problems. Use when an app is slow, janky, or resource-hungry.
+allowed-tools: [Read, Glob, Grep, Bash]
+---
+
+# Performance Skills
+
+Diagnose and fix performance problems, from system-level profiling to SwiftUI render behavior.
+
+## When This Skill Activates
+
+Use this skill when the user:
+- Reports the app is **slow, janky, or hanging**
+- Wants to profile with **Instruments** (Time Profiler, Allocations, Hangs)
+- Is investigating **memory issues, slow launches, or energy drain**
+- Sees SwiftUI views **re-rendering too often** or slow `body` evaluations
+- Asks about **view identity** problems or `_printChanges()`
+
+## Available Skills
+
+Paths are relative to THIS file's directory — skills run with cwd set to the
+user's project, so resolve each path from this SKILL.md's own location.
+
+| Skill | Read | Covers |
+|-------|------|--------|
+| profiling | `profiling/SKILL.md` | Instruments workflows; hangs, memory, slow launch, energy diagnosis |
+| swiftui-debugging | `swiftui-debugging/SKILL.md` | Unnecessary re-renders, view identity, slow body evaluations |
+
+## How to Route
+
+1. Match the request to a row above — system-level symptoms → profiling; SwiftUI render symptoms → swiftui-debugging.
+2. Read that SKILL.md (relative to this file) plus any reference files it lists.
+3. Apply the guidance to the user's code.

--- a/skills/swiftdata/SKILL.md
+++ b/skills/swiftdata/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: swiftdata
+description: SwiftData skills — class inheritance patterns for hierarchical models, type-based querying, polymorphic relationships, and inheritance-vs-enum decisions. Use when designing SwiftData model hierarchies.
+allowed-tools: [Read, Glob, Grep]
+---
+
+# SwiftData Skills
+
+SwiftData modeling patterns beyond the basics.
+
+## When This Skill Activates
+
+Use this skill when the user:
+- Designs **hierarchical SwiftData models** (class inheritance)
+- Needs **type-based or polymorphic queries**
+- Weighs **inheritance vs enum** for model variants
+
+## Available Skills
+
+Paths are relative to THIS file's directory — skills run with cwd set to the
+user's project, so resolve each path from this SKILL.md's own location.
+
+| Skill | Read | Covers |
+|-------|------|--------|
+| inheritance | `inheritance/SKILL.md` | Class inheritance, polymorphic relationships, type-based querying, inheritance-vs-enum |
+
+## How to Route
+
+1. Read `inheritance/SKILL.md` (relative to this file) plus any reference files it lists.
+2. Apply the guidance to the user's code. For broader macOS SwiftData architecture, see also `../macos/swiftdata-architecture/SKILL.md`.

--- a/skills/swiftui/SKILL.md
+++ b/skills/swiftui/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: swiftui
+description: SwiftUI framework skills for AlarmKit alarms and timers, 3D charts, rich text editing with AttributedString, customizable toolbars, and WebKit/WebView embedding. Use when implementing these SwiftUI features.
+allowed-tools: [Read, Glob, Grep]
+---
+
+# SwiftUI Skills
+
+Focused SwiftUI framework skills — each sub-skill covers one API area in depth.
+
+## When This Skill Activates
+
+Use this skill when the user:
+- Wants alarms or timers with **AlarmKit** (custom UI, Live Activities, snooze)
+- Is creating **3D data visualizations** with Swift Charts (Chart3D, SurfacePlot)
+- Needs **styled text or rich text editing** (Text, AttributedString, TextEditor)
+- Is implementing or customizing **toolbars** (customizable toolbars, search integration)
+- Wants to **embed web content** (WebView, WebPage, JavaScript interop)
+
+## Available Skills
+
+Paths are relative to THIS file's directory — skills run with cwd set to the
+user's project, so resolve each path from this SKILL.md's own location.
+
+| Skill | Read | Covers |
+|-------|------|--------|
+| alarmkit | `alarmkit/SKILL.md` | Alarms and timers with custom UI, Live Activities, snooze (iOS 18+) |
+| charts-3d | `charts-3d/SKILL.md` | Chart3D, SurfacePlot, interactive pose control, surface styling |
+| text-editing | `text-editing/SKILL.md` | Text, AttributedString, TextEditor with formatting controls |
+| toolbars | `toolbars/SKILL.md` | Customizable toolbars, search integration, transition effects, platform behavior |
+| webkit | `webkit/SKILL.md` | WebView and WebPage embedding, navigation, JavaScript interop |
+
+## How to Route
+
+1. Match the request to a row above.
+2. Read that SKILL.md (relative to this file) plus any reference files it lists.
+3. Apply the guidance to the user's code.

--- a/skills/visionos/SKILL.md
+++ b/skills/visionos/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: visionos
+description: visionOS skills — widget patterns including mounting styles, glass/paper textures, proximity-aware layouts, and spatial widget families. Use when building or adapting widgets for visionOS.
+allowed-tools: [Read, Glob, Grep]
+---
+
+# visionOS Skills
+
+Spatial-computing patterns for visionOS.
+
+## When This Skill Activates
+
+Use this skill when the user:
+- Builds or adapts **widgets for visionOS**
+- Asks about **mounting styles**, glass/paper **textures**, or spatial widget families
+- Needs **proximity-aware layouts**
+
+## Available Skills
+
+Paths are relative to THIS file's directory — skills run with cwd set to the
+user's project, so resolve each path from this SKILL.md's own location.
+
+| Skill | Read | Covers |
+|-------|------|--------|
+| widgets | `widgets/SKILL.md` | Mounting styles, glass/paper textures, proximity-aware layouts, spatial families |
+
+## How to Route
+
+1. Read `widgets/SKILL.md` (relative to this file) plus any reference files it lists.
+2. Apply the guidance to the user's code.


### PR DESCRIPTION
## Why

Second of two PRs moving the repo to the 2026-standard distribution for Claude Code extensions: **plugin marketplaces**, as used by `anthropics/skills` and `obra/superpowers`. Install becomes two commands — no clone, no copy:

```
/plugin marketplace add rshankras/claude-code-apple-skills
/plugin install apple-skills@indie-apple-stack
```

Packaging is **additive**: the `cp -r` and SwiftShip-symlink flows are unchanged.

## Design

- **One plugin, 23 category skills.** The plugin entry uses `source: "./"` + explicit `skills: ["./skills"]`, so only immediate `<category>/SKILL.md` children register — the 23 category indexes, which route to all 147 sub-skills via relative Read. Measured always-on cost: **~2.1k tokens/session** (vs ~10× that if all 142 sub-skills were exposed individually).
- **Marketplace `indie-apple-stack`** hosts the whole stack: a `swiftship` entry (external github source) joins after SwiftShip's own plugin conversion.
- **No `version` field** — git-SHA versioning; `/plugin marketplace update` tracks `main`, matching how cp-r users already behave. (Pinning would silently strand plugin users on the first unbumped merge.)
- **6 new category index skills** (foundation, mapkit, performance, swiftdata, swiftui, visionos) — the categories that lacked one. Depth-2 files are uncounted by `check-counts.sh`, so totals stay **147/23**.

## CI

- `scripts/check-frontmatter.sh`: every SKILL.md must declare `name:` + `description:` (plugin skill names come from frontmatter; a missing name falls back to an unstable install-dir string). Added to the `validate` job.
- New `plugin-validate` job: `claude plugin validate . --strict` (hard-fail — a malformed marketplace.json on `main` breaks every plugin user at next update).

## Verification

- `./scripts/check-counts.sh` — 147 skills / 23 categories, in sync
- `./scripts/check-frontmatter.sh` — all pass (includes the 6 new files)
- `claude plugin validate . --strict` — passes
- **End-to-end**: added the local checkout as a marketplace, installed the plugin — `claude plugin details` shows exactly **23 skills** (no `_shared`, no sub-skill leak), ~2,098 tok always-on. Test install removed afterwards.

Best reviewed after #18 (portable paths) merges — with git-SHA versioning, whatever is on `main` is the release, so the machine-local path fixes should land first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)