### PR TITLE
feat: list SwiftShip in the marketplace — apple@indie-apple-stack

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Ravi Shankar"
   },
   "metadata": {
-    "description": "The indie Apple developer stack: Apple platform skills now, SwiftShip workflow commands to follow."
+    "description": "The indie Apple developer stack: the apple-skills knowledge library and the SwiftShip /apple:* workflow."
   },
   "plugins": [
     {
@@ -12,7 +12,18 @@
       "source": "./",
       "description": "147 Apple platform development skills across 23 categories (iOS, macOS, watchOS, visionOS): code generators, product workflow, App Store/ASO, testing and TDD, design, performance, security, and more. Surfaced as 23 category skills that route to the full library.",
       "strict": false,
-      "skills": ["./skills"]
+      "skills": [
+        "./skills"
+      ]
+    },
+    {
+      "name": "apple",
+      "source": {
+        "source": "github",
+        "repo": "rshankras/SwiftShip"
+      },
+      "description": "SwiftShip \u2014 49 /apple:* workflow commands + 6 pinned agents: idea validation, roadmap, plan, build, review, TestFlight, App Store submission, and post-launch growth. Install apple-skills alongside it (its commands read that library).",
+      "strict": false
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -72,6 +72,13 @@ demand, so only 23 short descriptions sit in context. Update any time with
 `/plugin marketplace update indie-apple-stack` — no version pinning, you
 always track `main`.
 
+Want the full workflow too? The same marketplace carries
+[SwiftShip](https://github.com/rshankras/SwiftShip)'s 49 `/apple:*` commands:
+
+```
+/plugin install apple@indie-apple-stack
+```
+
 ### Manual Install (copy)
 
 ```bash


### PR DESCRIPTION
## What

The `indie-apple-stack` marketplace now catalogs both halves of the stack:

| Plugin | Source | Provides |
|---|---|---|
| `apple-skills` | this repo | 147 skills as 23 category skills |
| `apple` | `rshankras/SwiftShip` (external github source) | 49 `/apple:*` workflow commands + 6 pinned agents |

Full-stack install becomes:

```
/plugin marketplace add rshankras/claude-code-apple-skills
/plugin install apple-skills@indie-apple-stack
/plugin install apple@indie-apple-stack
```

Also: `metadata.description` updated (the "to follow" promise is now delivered), README plugin section gains the full-stack line.

## Order

**Merge after SwiftShip#44** — the entry resolves against SwiftShip `main`, which needs the plugin packaging (merged: rshankras/SwiftShip#44 is green and awaiting merge).

## Verification

- `claude plugin validate .` — passes
- `check-counts.sh` + `check-frontmatter.sh` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)