### PR TITLE
fix: clone SwiftShip plugin over HTTPS — github source type uses SSH

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -19,8 +19,8 @@
     {
       "name": "apple",
       "source": {
-        "source": "github",
-        "repo": "rshankras/SwiftShip"
+        "source": "url",
+        "url": "https://github.com/rshankras/SwiftShip.git"
       },
       "description": "SwiftShip \u2014 49 /apple:* workflow commands + 6 pinned agents: idea validation, roadmap, plan, build, review, TestFlight, App Store submission, and post-launch growth. Install apple-skills alongside it (its commands read that library).",
       "strict": false


### PR DESCRIPTION
First real-world install of `apple@indie-apple-stack` failed: the `{"source": "github", "repo": ...}` form clones via `git@github.com:`, which needs an SSH key — `Permission denied (publickey)` for everyone without one. Anonymous HTTPS works fine for a public repo, so the entry now uses `{"source": "url", "url": "https://github.com/rshankras/SwiftShip.git"}`.

`claude plugin validate .` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)