### PR TITLE
feat: display the apple plugin as 'SwiftShip' in the plugin browser

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -23,7 +23,8 @@
         "url": "https://github.com/rshankras/SwiftShip.git"
       },
       "description": "SwiftShip \u2014 49 /apple:* workflow commands + 6 pinned agents: idea validation, roadmap, plan, build, review, TestFlight, App Store submission, and post-launch growth. Install apple-skills alongside it (its commands read that library).",
-      "strict": false
+      "strict": false,
+      "displayName": "SwiftShip"
     }
   ]
 }


### PR DESCRIPTION
The entry name stays `apple` (it IS the `/apple:*` command namespace — typed ergonomics), and gains `displayName: "SwiftShip"` so the `/plugin` browser shows the product brand. Users say "install SwiftShip", type `/apple:build`.

`claude plugin validate .` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)