### PR TITLE
fix: remove strict:false — conflicts with the plugins' own manifests

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,6 @@
       "name": "apple-skills",
       "source": "./",
       "description": "147 Apple platform development skills across 23 categories (iOS, macOS, watchOS, visionOS): code generators, product workflow, App Store/ASO, testing and TDD, design, performance, security, and more. Surfaced as 23 category skills that route to the full library.",
-      "strict": false,
       "skills": [
         "./skills"
       ]
@@ -23,7 +22,6 @@
         "url": "https://github.com/rshankras/SwiftShip.git"
       },
       "description": "SwiftShip \u2014 49 /apple:* workflow commands + 6 pinned agents: idea validation, roadmap, plan, build, review, TestFlight, App Store submission, and post-launch growth. Install apple-skills alongside it (its commands read that library).",
-      "strict": false,
       "displayName": "SwiftShip"
     }
   ]


### PR DESCRIPTION
Docs audit against [plugin-marketplaces → Strict mode](https://code.claude.com/docs/en/plugin-marketplaces): `strict: false` makes the marketplace entry the **entire** plugin definition, and a `plugin.json` that declares components is then a conflict — **the plugin fails to load**.

Both entries carried `strict: false` (copied from the anthropics/skills pattern, whose plugins have no manifests). That was fine until both repos gained `plugin.json` — `apple-skills` in #23 (declares `skills`), SwiftShip in its 2.0 conversion — after which fresh installs and SHA-updates were at risk. Existing installs pinned to older SHAs were unaffected, which is why nothing visibly broke.

Fix: drop `strict` (default `true`: plugin.json is the authority, entry supplements — merged cleanly since both declare the same surface).

## Verification

Fresh installs from a scratch marketplace copy:
- `apple-skills` → exactly **23** category skills (no conflict, no full-library explosion)
- `apple` (fresh HTTPS clone of SwiftShip main) → **49** commands + **6** agents + **3** hooks

`claude plugin validate .` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)