### PR TITLE
fix: SwiftShip count check pointed at a nonexistent path + CHANGELOG row in README docs table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ from the local copy (see "Pinning and rollback" in the README).
 - `scripts/check-counts.sh` now also guards `docs/ROADMAP.md`, `plugin.json`, and `.claude-plugin/marketplace.json` counts
 
 ### Fixed
+- `check-counts.sh` cross-repo check pointed at `commands/apple/` but SwiftShip's commands live at `commands/` — the count guard could never fire; README docs table now lists CHANGELOG.md
 - Stale recency claims in paywall-generator, test-spec, live-activity-generator, usage-insights, ci-cd-setup
 - `deep-linking/templates/AppShortcuts.swift`: `ContentTypeEntity` declared as `struct` with `case` members — did not parse; now `enum ContentTypeEntity: String, AppEnum`
 - `docs/ROADMAP.md` skill total (149 → 147) and stale maintenance bullets

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ skills/
 |-----|-------------|
 | [docs/USAGE.md](docs/USAGE.md) | How to use for new vs existing apps |
 | [docs/ROADMAP.md](docs/ROADMAP.md) | Skills roadmap and status |
+| [CHANGELOG.md](CHANGELOG.md) | Notable changes and era tags (pinning/rollback points) |
 | [skills/product/WORKFLOW.md](skills/product/WORKFLOW.md) | Full idea to App Store workflow |
 | [CONTRIBUTING.md](CONTRIBUTING.md) | How to contribute |
 

--- a/scripts/check-counts.sh
+++ b/scripts/check-counts.sh
@@ -117,9 +117,11 @@ done
 # --- 4. Cross-repo: SwiftShip command count (skipped if no sibling checkout) --
 echo ""
 echo "== Cross-repo counts =="
+# SwiftShip's commands live at commands/*.md — the /apple: prefix comes from
+# the plugin name, not a subdirectory.
 SWIFTSHIP="${SWIFTSHIP_DIR:-$REPO_DIR/../SwiftShip}"
-if [ -d "$SWIFTSHIP/commands/apple" ]; then
-    CMDS=$(ls "$SWIFTSHIP"/commands/apple/*.md 2>/dev/null | wc -l | tr -d ' ')
+if [ -d "$SWIFTSHIP/commands" ]; then
+    CMDS=$(ls "$SWIFTSHIP"/commands/*.md 2>/dev/null | wc -l | tr -d ' ')
     grep -qF "$CMDS /apple:* commands" README.md \
         || fail "README stack table: SwiftShip row says stale command count (checkout has $CMDS)"
     echo "  SwiftShip: $CMDS commands"


### PR DESCRIPTION
## Changes
- `scripts/check-counts.sh`: cross-repo SwiftShip check looked for `commands/apple/*.md`, but SwiftShip's commands live at `commands/*.md` — the `/apple:` prefix comes from the plugin name, not a subdirectory. The guard silently skipped even with a sibling checkout present.
- README Documentation table: added the `CHANGELOG.md` row (era tags / pinning points).
- CHANGELOG `[Unreleased]` entry added.

## Motivation
The README's "49 /apple:* commands" claim had a drift guard that could never fire. Found while verifying the README after the post-WWDC26 hardening.

## Testing
Cloned SwiftShip fresh and ran `SWIFTSHIP_DIR=… ./scripts/check-counts.sh`: the check now fires, counts 49, and matches the README. All other validators (frontmatter, freshness) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)