### PR TITLE
feat: store-growth-audit skill + 4 new growth/monetization skills + 13 tactic upgrades

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "apple-skills",
       "source": "./",
-      "description": "147 Apple platform development skills across 23 categories (iOS, macOS, watchOS, visionOS): code generators, product workflow, App Store/ASO, testing and TDD, design, performance, security, and more. Surfaced as 23 category skills that route to the full library.",
+      "description": "152 Apple platform development skills across 23 categories (iOS, macOS, watchOS, visionOS): code generators, product workflow, App Store/ASO, testing and TDD, design, performance, security, and more. Surfaced as 23 category skills that route to the full library.",
       "skills": [
         "./skills"
       ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-skills",
-  "description": "147 Apple platform development skills across 23 categories (iOS, macOS, watchOS, visionOS): code generators, product workflow, App Store/ASO, testing and TDD, design, performance, security, and more. Surfaced as 23 category skills that route to the full library.",
+  "description": "152 Apple platform development skills across 23 categories (iOS, macOS, watchOS, visionOS): code generators, product workflow, App Store/ASO, testing and TDD, design, performance, security, and more. Surfaced as 23 category skills that route to the full library.",
   "author": {
     "name": "Ravi Shankar"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ from the local copy (see "Pinning and rollback" in the README).
 ## [Unreleased]
 
 ### Added
+- `growth/store-growth-audit` — the 54-item P0–P9 store-growth playbook as an auditable checklist (SKILL.md + detection-playbook + two phase checklists); every item scored via ASC MCP read / codebase grep / explicit question, routed to the skill that fixes it; backs SwiftShip's `/apple:growth`
+- `app-store/ratings-mechanics` — per-storefront ratings isolation, the never-reset rule, phased + manual release as rating armor
+- `app-store/web-presence` — apps.apple.com Google SEO, landing page + Smart App Banner, the deal-site price-drop ecosystem
+- `monetization/external-purchases` — US External Purchase Link entitlement (0% commission era), commission-flip architecture, day-one funnel analytics
+- `monetization/bundles-and-licensing` — own-app bundles, Family Sharing, cross-developer suites, Group/Volume Purchasing (announced) via School & Business Manager
+- Growth-tactic upgrades across 13 existing skills: developer-name indexing, Apple AI tagging, ASA search-term keyword refresh (keyword-optimizer); discovery-as-research, ASA→organic halo, CPP pairing (apple-search-ads); peer-group benchmarks (analytics-interpretation); pre-shipped alternate icons (product-page-optimization); PPP pricing playbook (pricing-models); regional pre-orders; TestFlight public-link waitlist (beta-testing); announced badge types (in-app-events); Retention Messaging (win-back-offers); distribution levers (marketing-strategy); Creative Assets (screenshot-planner); US external-purchase entitlement nuance (rejection-handler, streak-tracker)
 - `CHANGELOG.md` and the `wwdc25-era-final` era tag — rollback/reference points for unpinned plugin installs
 - `scripts/versions.env` — single source of truth for the current Apple OS generation (bump once per WWDC)
 - `scripts/check-freshness.sh` — CI tripwire: fails when a skill claims recency ("Latest", "New in") against an OS version two or more generations old
@@ -28,6 +34,7 @@ from the local copy (see "Pinning and rollback" in the README).
 - `scripts/check-counts.sh` now also guards `docs/ROADMAP.md`, `plugin.json`, and `.claude-plugin/marketplace.json` counts
 
 ### Fixed
+- Category index drift: `app-store/SKILL.md` and `growth/SKILL.md` "Available Skills" were missing previously added members (iap-finalizer, originality-check, store-signals); `docs/ROADMAP.md` per-category rows for app-store/growth/monetization brought current
 - `check-counts.sh` cross-repo check pointed at `commands/apple/` but SwiftShip's commands live at `commands/` — the count guard could never fire; README docs table now lists CHANGELOG.md
 - Stale recency claims in paywall-generator, test-spec, live-activity-generator, usage-insights, ci-cd-setup
 - `deep-linking/templates/AppShortcuts.swift`: `ContentTypeEntity` declared as `struct` with `case` members — did not parse; now `enum ContentTypeEntity: String, AppEnum`

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Four repos, four layers — use one or all:
 
 | Layer | Repo | What it is |
 |---|---|---|
-| Knowledge | **claude-code-apple-skills** ← you are here | 147 skills — how to build right |
+| Knowledge | **claude-code-apple-skills** ← you are here | 152 skills — how to build right |
 | Workflow | [SwiftShip](https://github.com/rshankras/SwiftShip) | 49 /apple:* commands — spec-driven idea → App Store |
 | Action | [indie-app-autopilot](https://github.com/rshankras/indie-app-autopilot) | 7 agents — GitHub issue → App Store |
 | Integration | [asc-metadata-mcp](https://github.com/rshankras/asc-metadata-mcp) | 65+ MCP tools — live App Store Connect API |
@@ -24,9 +24,9 @@ Four repos, four layers — use one or all:
 | **iOS** | 9 | Code review, UI review, navigation, iPad, migration, accessibility, simulator/device runs |
 | **Testing** | 9 | TDD workflows, test infrastructure, snapshot tests, flow walkthrough |
 | **macOS** | 8 | Tahoe APIs, SwiftData, AppKit bridge |
-| **App Store** | 9 | ASO, descriptions, keywords, reviews, search ads, rejections, originality, IAP finalize |
+| **App Store** | 11 | ASO, descriptions, keywords, reviews, search ads, rejections, originality, IAP finalize, ratings mechanics, web presence |
 | **SwiftUI** | 5 | AlarmKit, WebKit, text editing, toolbars, Charts 3D |
-| **Growth** | 5 | Analytics, store signals, press/media, community, indie business |
+| **Growth** | 6 | Analytics, store signals, growth audit, press/media, community, indie business |
 | **Swift** | 3 | Concurrency patterns, Swift 6.2, InlineArray/Span |
 | **Apple Intelligence** | 3 | Foundation Models, Visual Intelligence, App Intents |
 | **Design** | 3 | Liquid Glass (SwiftUI/AppKit/UIKit/WidgetKit), animation patterns, UI prototyping |
@@ -34,7 +34,7 @@ Four repos, four layers — use one or all:
 | **Security** | 2 | Secure storage, biometrics, privacy manifests |
 | **Core ML** | 1 | Vision, NaturalLanguage, model integration |
 | **Legal** | 2 | Privacy policies, terms of service, EULAs, publish + set ASC URLs |
-| **Monetization** | 1 | Pricing strategy, tiers, free trials |
+| **Monetization** | 3 | Pricing strategy, tiers, free trials, external purchases, bundles & licensing |
 | **watchOS** | 1 | Watch apps, complications, health/fitness, widgets |
 | **SwiftData** | 1 | Class inheritance patterns |
 | **MapKit** | 1 | GeoToolbox, place descriptors |
@@ -43,7 +43,7 @@ Four repos, four layers — use one or all:
 | **Release Review** | 1 | Pre-release audit checklists |
 | **Shared** | 2 | Meta-skills for creating (`skill-creator`) and auditing (`skill-auditor`) skills |
 
-**Total: 147 skills across 23 categories** (single-skill categories count their category file; other index files aren't counted — enforced by `scripts/check-counts.sh` in CI)
+**Total: 152 skills across 23 categories** (single-skill categories count their category file; other index files aren't counted — enforced by `scripts/check-counts.sh` in CI)
 
 ## Quick Start
 

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -147,7 +147,7 @@ Vague: "Add payments"
 
 ## Skill Categories
 
-**147 skills across 23 categories** — see the
+**152 skills across 23 categories** — see the
 [What's Included table in the README](../README.md#whats-included) for the
 per-category breakdown (kept in sync with the tree by `scripts/check-counts.sh`).
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -185,10 +185,10 @@ Apple docs location: `/Users/ravishankar/Downloads/docs/`
 | product/ | 13 | idea-generator, product-agent, competitive-analysis, market-research, prd-generator, architecture-spec, ux-spec, implementation-guide, implementation-spec, test-spec, release-spec, beta-testing, localization-strategy |
 | macos/ | 8 | app-planner, coding-best-practices, architecture-patterns, swiftdata-architecture, ui-review-tahoe, macos-tahoe-apis, macos-capabilities, appkit-swiftui-bridge |
 | testing/ | 8 | characterization-test-generator, tdd-bug-fix, tdd-feature, test-contract, tdd-refactor-guard, snapshot-test-setup, test-data-factory, integration-test-scaffold |
-| app-store/ | 7 | keyword-optimizer, app-description-writer, screenshot-planner, review-response-writer, marketing-strategy, apple-search-ads, rejection-handler |
+| app-store/ | 11 | keyword-optimizer, app-description-writer, screenshot-planner, review-response-writer, marketing-strategy, apple-search-ads, rejection-handler, originality-check, iap-finalizer, ratings-mechanics, web-presence |
 | ios/ | 7 | coding-best-practices, ui-review, app-planner, navigation-patterns, ipad-patterns, migration-patterns, assistive-access |
 | swiftui/ | 5 | alarmkit, webkit, text-editing, toolbars, charts-3d |
-| growth/ | 5 | analytics-interpretation, press-media, community-building, indie-business |
+| growth/ | 6 | analytics-interpretation, press-media, community-building, indie-business, store-signals, store-growth-audit |
 | swift/ | 3 | concurrency-patterns, concurrency, memory |
 | apple-intelligence/ | 3 | foundation-models, visual-intelligence, app-intents |
 | design/ | 2 | liquid-glass, animation-patterns |
@@ -196,7 +196,7 @@ Apple docs location: `/Users/ravishankar/Downloads/docs/`
 | performance/ | 2 | profiling, swiftui-debugging |
 | security/ | 2 | security, privacy-manifests |
 | core-ml/ | 1 | core-ml (with patterns.md, templates.md) |
-| monetization/ | 1 | monetization (with pricing-models.md, app-type-guides.md) |
+| monetization/ | 3 | monetization (with pricing-models.md, app-type-guides.md), external-purchases, bundles-and-licensing |
 | swiftdata/ | 1 | inheritance |
 | mapkit/ | 1 | geotoolbox |
 | foundation/ | 1 | attributed-string |
@@ -204,7 +204,7 @@ Apple docs location: `/Users/ravishankar/Downloads/docs/`
 | watchos/ | 1 | watchos (with 4 reference files) |
 | release-review/ | 1 | release-review |
 | shared/ | 2 | skill-creator, skill-auditor |
-| **Total** | **147 across 23 categories** |
+| **Total** | **152 across 23 categories** |
 
 ---
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -143,7 +143,7 @@ Differences:
 
 ## Skill Categories
 
-**147 skills across 23 categories.** The per-category breakdown lives in one
+**152 skills across 23 categories.** The per-category breakdown lives in one
 place — the [What's Included table in the README](../README.md#whats-included)
 — so it can't drift from the tree (`scripts/check-counts.sh` enforces it in CI).
 

--- a/skills/app-store/SKILL.md
+++ b/skills/app-store/SKILL.md
@@ -79,6 +79,18 @@ Handle App Store rejections and prepare submissions to avoid them.
 - Appeal escalation path (Resolution Center → phone → App Review Board)
 - Top 20 common rejections with fixes (common-rejections.md)
 
+### originality-check/
+Guideline 4.3 anti-spam / originality gate — verify an app (and each portfolio addition) is meaningfully distinct in function, content, and metadata before you invest or submit.
+
+### iap-finalizer/
+Take a one-time In-App Purchase from MISSING_METADATA to READY_TO_SUBMIT via the App Store Connect API — price tier plus localized name/description.
+
+### ratings-mechanics/
+How ratings actually behave — per-storefront isolation (your US stars show nowhere else), the never-reset rule, and phased release + manual release as rating protection.
+
+### web-presence/
+Discovery outside the store app — the apps.apple.com page as a Google citizen, an owned landing page with Smart App Banner, and the deal-site ecosystem that auto-amplifies price drops.
+
 ## Related Generator Skills
 
 These generator skills produce code, metadata, and configuration for App Store features:

--- a/skills/app-store/apple-search-ads/SKILL.md
+++ b/skills/app-store/apple-search-ads/SKILL.md
@@ -97,6 +97,10 @@ Stage 3: Product Page (competitor audiences)
 Stage 4: Search Tab (brand awareness)
 ```
 
+### Discovery Campaigns as Keyword Research
+
+Beyond acquisition, a low-budget broad-match discovery campaign is the cheapest source of Apple's official keyword popularity data and the real queries users type. Even if it never turns a profit, harvest the Search Terms report into your organic metadata — see `keyword-optimizer` advanced tactics (§14) for the quarterly routine.
+
 ## Keyword Strategy
 
 ### Keyword Categories
@@ -123,6 +127,13 @@ Stage 4: Search Tab (brand awareness)
 - Lower volume but very high intent
 - Often cheapest CPT because few advertisers target them
 - Excellent ROAS potential
+
+### The ASA → Organic Halo
+
+Paid conversions on a keyword lift that keyword's **organic** rank — Apple's algorithm reads them as conversion velocity. Two implications:
+
+- Run exact-match campaigns on your target organic terms to accelerate ranking while metadata changes take hold
+- Always defend your brand term once competitors bid on it — brand CPAs are the cheapest in your account, and losing the top slot bleeds organic installs too
 
 ### Keyword Research Process
 
@@ -235,6 +246,10 @@ Apple Search Ads supports linking ad groups to Custom Product Pages (CPPs) for t
 | Feature keywords | Show the specific feature being searched |
 | Audience segments | Different messaging for students vs. professionals |
 | Seasonal campaigns | Holiday or event-themed screenshots/descriptions |
+
+### The Pairing Rule
+
+Every exact-match ad group should point to a CPP whose **first screenshots match that keyword's intent** — 35 CPP slots is enough for every major keyword theme. A user searching "habit tracker" who lands on habit-first screenshots taps through and converts measurably better than one landing on your default page.
 
 ### CPP Setup for Ads
 

--- a/skills/app-store/keyword-optimizer/advanced-tactics.md
+++ b/skills/app-store/keyword-optimizer/advanced-tactics.md
@@ -267,6 +267,40 @@ Apple tracks **impressions → downloads** ratio. Higher conversion = higher ran
 - First screenshot is most important (70% decide from it alone)
 - First 3 words of subtitle are visible in search results
 
+## 12. Developer Name Is Indexed
+
+Your developer/brand name is an **indexed search field**. A descriptive name gives permanent keyword coverage across every app you ship — for free.
+
+```
+Weaker:   Acme LLC              (zero keyword value)
+Stronger: Acme Photo Tools      ("photo" + "tools" index for every app)
+```
+
+### Rules
+- Changing it is heavy (legal entity name change or DBA in App Store Connect) — treat it as a **one-time strategic choice**
+- Don't keyword-stuff it ("Photo Editor Filter Collage Inc") — metadata rejection risk
+
+## 13. Write for Apple's AI Tagging
+
+Apple's AI reads your metadata AND screenshot captions to tag apps for search and Personalized Collections. Ambiguous copy = wrong tags = wrong shelves.
+
+| Clever Caption (Tags Poorly) | Literal Caption (Tags Well) |
+|------------------------------|----------------------------|
+| "Your pocket time machine" | "Restore old photos in one tap" |
+| "Money, mastered" | "Track shared expenses with friends" |
+
+Write copy that is unambiguous about **what the app does** and **who it's for**. Pairs with tactic §2 — the same captions feed both the OCR index and the tagging model.
+
+## 14. Quarterly Keyword Refresh from Apple Ads Search-Term Reports
+
+Keep a small Apple Ads discovery campaign running. The search-term report shows the **literal queries users typed before converting** — ground truth no third-party ASO tool has.
+
+### Quarterly Routine
+1. Export the search-term report from Apple Ads
+2. Filter to terms that converted in paid but aren't in your metadata
+3. Move winners into the keyword field/subtitle at the next release
+4. Re-baseline rankings and repeat next quarter
+
 ## Quick Reference Checklist
 
 ### Zero-Risk Additions
@@ -284,12 +318,15 @@ Apple tracks **impressions → downloads** ratio. Higher conversion = higher ran
 - [ ] No singular AND plural forms
 - [ ] Primary keywords at START of title/subtitle
 - [ ] Most important keywords in first 2 screenshots
+- [ ] Captions written literally for AI tagging (no clever metaphors)
+- [ ] Developer name reviewed as an indexed keyword asset (one-time choice — don't stuff it)
 
 ### Tracking
 - [ ] Note baseline metrics before changes
 - [ ] Check rankings weekly
 - [ ] Update keywords every 4-6 weeks
 - [ ] Swap underperforming keywords (rank >100)
+- [ ] Quarterly: mine Apple Ads search-term report into keyword field/subtitle
 
 ## Sources
 

--- a/skills/app-store/marketing-strategy/decision-matrix.md
+++ b/skills/app-store/marketing-strategy/decision-matrix.md
@@ -117,6 +117,13 @@ Rules engine that maps app attributes to recommended App Store promotional featu
 | 🟠 Medium | Featuring Nomination | "What's New" angle for major update |
 | 🟢 Low | Custom Product Pages | New pages for repositioned app |
 
+### Cross-Stage Distribution Levers
+
+Two tactics worth weaving into Growth and Mature stages that most matrices miss:
+
+- **Checkbox storefronts**: shipping a Catalyst/iPad-on-Mac, visionOS, watchOS, or tvOS variant enters tiny catalogs where charts and featuring are far easier to crack — treat the port as a distribution lever, not just a feature
+- **Secondary category**: costs nothing and gives a second chart presence — pick the less-competitive category where you'd rank higher, not the most descriptive one
+
 ---
 
 ## Dimension 3: App Category → Featuring Angles

--- a/skills/app-store/ratings-mechanics/SKILL.md
+++ b/skills/app-store/ratings-mechanics/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: ratings-mechanics
+description: How App Store ratings actually behave — per-storefront isolation (your US stars show nowhere else), the never-reset rule, phased release + manual release as rating protection, and where prompting/replying fit. Use when planning ratings strategy for new markets, considering a ratings reset, setting release options, or diagnosing "why is my rating missing in country X."
+allowed-tools: [Read, Write, Edit, Glob, Grep]
+---
+
+# Ratings Mechanics
+
+The rating is an asset with mechanics most developers learn the hard way. This skill covers the
+four rules that aren't obvious from the ASC UI. Prompting *code* lives in
+`generators/review-prompt`; reply *writing* lives in `app-store/review-response-writer` — this
+skill is the strategy layer that tells you when each matters.
+
+## When This Skill Activates
+
+- Localizing or expanding into new storefronts ("why does my app show no rating in Japan?")
+- Considering the "reset ratings summary" option on a version release
+- Choosing release options before submitting (phased vs immediate, auto vs manual)
+- Planning a per-market ratings strategy alongside `product/localization-strategy`
+- A bad build or review-bomb is threatening the rating
+
+## Rule 1: Ratings are per-storefront — they do not travel
+
+Your 4.8★ from 2,000 US ratings renders as **no rating at all** on the Japanese storefront until
+Japanese users rate the app there. Every storefront starts from zero.
+
+Consequences:
+
+- ✅ Entering a new market = re-running the early-days ratings playbook *in that market*: prompt
+  eagerly (within guidelines), localize the prompt moment, reply to every early review.
+- ✅ Weight `requestReview` triggers by storefront maturity — a market with 12 ratings needs the
+  prompt more than the home market with 5,000.
+- ❌ Assuming social proof transfers with the binary. A localized listing with zero local ratings
+  converts like an unknown app, because there it *is* one.
+- The written-review pool is also per-storefront: expect empty review sections in fresh markets
+  and seed them via TestFlight communities or launch outreach in that region.
+
+## Rule 2: Never reset the ratings summary
+
+ASC offers a reset when you release a new version. It is almost always a mistake:
+
+- Reset discards the count as well as the average — 4.2★ from 3,000 ratings converts better than
+  a naked 5.0★ from 6, and the count never comes back except one rating at a time.
+- The instinct to reset ("v2 is a big rewrite, old reviews don't apply") is better served by
+  replying to outdated negative reviews (updated ratings **replace** the old score — see
+  `review-response-writer`) and by the What's New copy.
+- ✅ Legitimate near-exception: a catastrophic launch (sub-3★, low count, fixed root cause) on an
+  app with almost no ratings mass. Even then, run the math on count loss first.
+- ❌ Resetting an established app to chase a higher average. You'll rank and convert worse for
+  months.
+
+## Rule 3: Phased release + manual release are rating armor
+
+Two ASC toggles turn a bad build from a rating catastrophe into a contained incident:
+
+- **Manual version release** — approval ≠ release. Release when you're awake and watching
+  crash dashboards, not whenever review finishes.
+- **Phased release** — 7-day staged rollout (1% → 2% → 5% → 10% → 20% → 50% → 100%) to users
+  with automatic updates. A crashing build caught on day 1–2 has burned ~3% of your users;
+  **pause** the rollout, fix, resubmit. Without it, 100% of users get the bad build and the
+  1-star flood arrives before the hotfix does.
+- ✅ Default for every release: phased ON + manual release + monitor day-1 crash rate.
+- ❌ Halting a phased release as a rollback. Pausing stops *new* deliveries only — users who got
+  the build keep it, and manual App Store downloads always get the new version. The armor is
+  damage *limitation*; the fix still has to ship.
+
+## Rule 4: The prompt-and-reply loop is the only rating input you control
+
+- **Prompt** at success moments with `requestReview` — never at launch, never mid-task. Aim the
+  moment, cap the frequency, and localize what "success" means per market. Implementation:
+  `generators/review-prompt`.
+- **Reply** to negative reviews — when a user updates their review after a reply, the new score
+  replaces the old one in the average. Replies are the only mechanism that converts existing
+  1-stars into 4-stars. Templates: `app-store/review-response-writer`.
+- Per-storefront corollary: track "unanswered negative reviews" per market, not globally — a
+  5-review storefront is one bad review away from 60% negative.
+
+## Output Format
+
+When auditing an app's ratings posture, report per storefront:
+
+```
+Storefront | Rating (count) | Unanswered 1–3★ (90d) | Prompt localized? | Phased+manual habit?
+```
+
+flagging: fresh storefronts with no prompting plan, any reset consideration (🔴 stop), and
+releases going out unphased.
+
+## References
+
+- https://developer.apple.com/documentation/storekit/requesting-app-store-reviews
+- https://developer.apple.com/help/app-store-connect/update-your-app/release-a-version-update-in-phases
+- https://developer.apple.com/help/app-store-connect/monitor-app-performance/reset-your-app-s-summary-rating
+- Related skills: `generators/review-prompt`, `app-store/review-response-writer`, `product/localization-strategy`, `growth/store-growth-audit`

--- a/skills/app-store/rejection-handler/common-rejections.md
+++ b/skills/app-store/rejection-handler/common-rejections.md
@@ -172,6 +172,8 @@ content. The "Buy on Web" button and associated links have been
 removed. All digital purchases now go through IAP exclusively.
 ```
 
+**US storefront exception:** Apps on the United States storefront may link out using the StoreKit External Purchase Link entitlement (currently 0% commission on those sales; litigation ongoing in mid-2026 — re-verify before relying on it). The rejection pattern above applies to links WITHOUT the entitlement and to all non-US storefronts. For the strategy trade-offs, see `monetization/external-purchases`.
+
 ## Guideline 3.1.2: Subscriptions
 
 ### 3.1.2 — Subscription Requirements

--- a/skills/app-store/screenshot-planner/SKILL.md
+++ b/skills/app-store/screenshot-planner/SKILL.md
@@ -215,6 +215,12 @@ Notes: [Close the deal]
 0:20-0:30  Final CTA with value prop
 ```
 
+### Creative Assets
+
+> Status: announced (WWDC26) — verify availability in App Store Connect before executing.
+
+Rich video/animated media in the product-page header AND in search results — submittable **without an app update** and testable via Custom Product Pages / PPO. Plan a motion-capable asset library now (source-quality screen captures, layered project files) so you can adopt the moment it reaches your account.
+
 ## Localization
 
 ### Considerations

--- a/skills/app-store/web-presence/SKILL.md
+++ b/skills/app-store/web-presence/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: web-presence
+description: The discovery surfaces outside the App Store app — your apps.apple.com product page ranking on Google, an owned landing page with a Smart App Banner, and the deal-site ecosystem that auto-amplifies price drops. Use when building a landing page, improving Google visibility for an app, planning a price-drop promotion, or auditing off-store discovery.
+allowed-tools: [Read, Write, Edit, Glob, Grep]
+---
+
+# Web Presence
+
+Every app has a public web page at `apps.apple.com` that ranks in Google — most developers never
+work that surface. Pair it with an owned landing page and the deal-site ecosystem and the open
+web becomes a free acquisition channel that compounds with everything on-store.
+
+## When This Skill Activates
+
+- "Make my app findable on Google" / no results for the app's own name
+- Building or reviewing a product landing page
+- Planning a temporary price drop or sale
+- The store-growth audit flags P6.6 (web presence) or P7.5 (deal sites)
+
+## Surface 1: The apps.apple.com page is a Google citizen
+
+Your store listing is crawlable, indexable web content. Its Google snippet is built from your
+**app name, subtitle, and description opening** — one more reason the first description paragraph
+must be benefit-led plain language (see `app-store/app-description-writer`).
+
+- ✅ Search your app's name + category terms on Google periodically; if the store page doesn't
+  rank for your own brand, something is wrong (usually a generic name — see `product/app-namer`).
+- ✅ Ratings, price, and In-App Purchase labels appear in the snippet — per-storefront ratings
+  mechanics apply (`app-store/ratings-mechanics`).
+- ❌ Treating the store URL as un-shareable internal plumbing. It's often your best-ranking page;
+  link to it from everywhere (with `?pt=` provider token for attribution where you need source data).
+
+## Surface 2: An owned landing page + Smart App Banner
+
+One page, one job: convert a web visitor into a store visitor.
+
+- Structure: name + one-line promise → 2–3 screenshots or a short capture → social proof →
+  a prominent **Download on the App Store** badge (Apple's official artwork, linked with your
+  attribution token).
+- **Smart App Banner** — one meta tag; Safari renders a native install/open banner:
+
+  ```html
+  <meta name="apple-itunes-app" content="app-id=YOUR_APP_ID, app-argument=https://yourapp.com/from-web">
+  ```
+
+  ✅ Installed users tapping it deep-link into the app (`app-argument`); everyone else gets a
+  one-tap path to the listing. ❌ Custom "download our app" interstitials — Safari users get the
+  native banner for free, and interstitials tank your Google page experience.
+- The landing page is also where pre-launch waitlists live (TestFlight public link — see
+  `product/beta-testing`) and where press/link-in-bio traffic should land, because you can
+  measure it before it enters the store funnel.
+- App Clips can front the landing page with an instant experience (`generators/app-clip`).
+
+## Surface 3: The deal-site ecosystem
+
+Aggregators and deal communities scrape App Store price drops automatically — you don't submit
+anything, you just drop the price and the ecosystem notices.
+
+The mechanic: temporary price drop → aggregators list it → download spike → **chart climb** →
+charts drive organic downloads that outlive the sale. Velocity is the product; the discounted
+revenue is the cost of the campaign.
+
+- ✅ Drop meaningfully (50%+ or free-for-a-day reads as a deal; 10% doesn't scrape well).
+- ✅ Time drops to compound: with an in-app event, a seasonal moment, or the announced On-Sale
+  badge surface (see `generators/in-app-events`), and have the next release ready so climbers
+  land on a fresh listing.
+- ✅ Prompt for ratings during the spike window — sale users rate too, and the count sticks
+  after prices recover.
+- ❌ Permanent-discount theater (always "90% off") — scrapers and users both learn to ignore it,
+  and review teams notice manipulated anchor pricing.
+- ❌ Dropping the price of a subscription app's *download* — deal sites move paid-upfront apps;
+  subscription apps should use offer codes instead (`generators/offer-codes-setup`).
+
+## Output Format
+
+Audit report:
+
+```
+Google: brand query rank · store-page snippet quality (name/subtitle/desc opener)
+Landing page: live? banner tag? attribution token? waitlist path?
+Deal readiness: pricing model compatible? last drop + result? next planned window?
+```
+
+Each gap routed: copy fixes → `app-store/app-description-writer`; page build → this skill;
+price-drop plan → this skill + `monetization` pricing.
+
+## References
+
+- https://developer.apple.com/documentation/webkit/promoting-apps-with-smart-app-banners
+- https://developer.apple.com/app-store/marketing/guidelines/
+- https://tools.applemediaservices.com/ (official badges & link builder)
+- Related skills: `app-store/app-description-writer`, `generators/app-clip`, `product/beta-testing`, `generators/offer-codes-setup`, `growth/store-growth-audit`

--- a/skills/generators/in-app-events/SKILL.md
+++ b/skills/generators/in-app-events/SKILL.md
@@ -95,6 +95,15 @@ Write a markdown document with all metadata ready for copy/paste into App Store 
 | **New Season** | Seasonal content refreshes | "Winter Season", "Chapter 3" |
 | **Premiere** | First-time content or feature debut | "Introducing Dark Mode", "New Game Mode" |
 
+### Announced Badge Types
+
+> Status: announced (WWDC26) — verify availability in App Store Connect before executing.
+
+| Badge | Use For | Examples |
+|-------|---------|---------|
+| **Now On Sale** | Limited-time price drops on the app or IAPs | "Pro Unlock 50% Off — This Week" |
+| **Try Before You Buy** | Free-trial or demo-access promotions | "7-Day Free Trial Event" |
+
 ## Metadata Best Practices
 
 ### Event Name (30 chars)

--- a/skills/generators/pre-orders/SKILL.md
+++ b/skills/generators/pre-orders/SKILL.md
@@ -32,6 +32,10 @@ Use this skill when the user:
 3. **Featuring eligibility**: Apple can feature pre-order apps
 4. **Marketing anchor**: Give audiences a concrete action ("Pre-order now")
 
+### Not Just for Launches: Regional Pre-Orders
+
+An **existing app** entering new storefronts can run a pre-order (up to 180 days) in just those territories. Accumulated pre-orders convert on day one in the new market — the same velocity spike a launch gets, aimed at the new market's chart entry.
+
 ### Limitations
 - Cannot change app name or primary category after pre-order starts
 - Price increases require 7-day notice to pre-order customers

--- a/skills/generators/product-page-optimization/SKILL.md
+++ b/skills/generators/product-page-optimization/SKILL.md
@@ -25,6 +25,7 @@ Use this skill when the user:
 - Duration: Apple recommends minimum 7 days (typically run 14-28 days)
 - Statistical confidence: Apple shows results when statistically significant
 - Localization: Tests can run in specific localizations
+- Icon treatments: can only use icons that already ship in the app binary's asset catalog as alternate icons — plan icon tests one release ahead
 
 ### Important Limitations
 - Cannot test: app name, subtitle, description, keyword field, or price
@@ -166,6 +167,8 @@ While waiting for PPO results, implement these proven improvements:
 | Style | 3D/detailed | Flat/minimal | Modernized perception |
 | Element | Full logo | Key symbol only | Better small-size recognition |
 | Background | Solid | Gradient | Shelf standout |
+
+**Plan one release ahead:** add candidate icons to the asset catalog as alternate app icons in THIS release so you can PPO-test them in the NEXT one. Shipping them costs nothing — users never see unused alternates.
 
 ### Screenshot Tests
 | Test | Control | Variant | Expected Impact |

--- a/skills/generators/streak-tracker/SKILL.md
+++ b/skills/generators/streak-tracker/SKILL.md
@@ -329,7 +329,7 @@ SwiftData stores persist across app updates but are lost on reinstall. For criti
 
 ### App Store Guidelines
 - **Guideline 4.5.4**: Streak-reminder pushes ("don't lose your 12-day streak!") are marketing notifications — they require explicit opt-in consent in your UI plus an in-app opt-out, not just the system permission prompt.
-- **Guideline 3.1.1**: If streak freezes or repairs are sold, they are digital content and must go through IAP — never an external purchase link.
+- **Guideline 3.1.1**: If streak freezes or repairs are sold, they are digital content and must go through IAP — never an external purchase link. The one sanctioned exception is the US storefront with the StoreKit External Purchase Link entitlement (see `monetization/external-purchases`); everywhere else the rule stands.
 - **Guideline 4.3 (Spam)**: A streak mechanic doesn't differentiate a thin app. If this is one of several similar apps on your account, run `app-store/originality-check` before submitting.
 
 ## References

--- a/skills/generators/win-back-offers/SKILL.md
+++ b/skills/generators/win-back-offers/SKILL.md
@@ -155,6 +155,19 @@ SubscriptionStoreView(groupID: groupID)
 3. Set eligibility criteria (days since churn, previous subscription duration)
 4. Configure offer priority if multiple offers exist
 
+### Retention Messaging (At-Cancel Save Offers)
+
+> Status: announced (WWDC26) — verify availability in App Store Connect before executing.
+
+The App Store can present a save offer at the exact moment a user goes to cancel, configured via App Store Connect or the API. It complements win-back rather than replacing it:
+
+| Mechanism | Fires |
+|-----------|-------|
+| Retention messaging | At cancel — before the user churns |
+| Win-back offer | After lapse — once the subscription has expired |
+
+Configure both once eligible — they cover opposite ends of the churn window.
+
 ## References
 
 - **templates.md** — All production Swift templates

--- a/skills/growth/SKILL.md
+++ b/skills/growth/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: growth
-description: Growth skills for indie Apple developers — user acquisition, analytics interpretation, press/media outreach, community building, and indie business operations. Use when user asks about growing their app, understanding metrics, getting press coverage, or running an indie dev business.
+description: Growth skills for indie Apple developers — user acquisition, analytics interpretation, press/media outreach, community building, and indie business operations. Also covers the stage-by-stage store-growth audit and the post-launch store-signals loop. Use when user asks about growing their app, auditing growth levers, understanding metrics, getting press coverage, or running an indie dev business.
 allowed-tools: [Read, Glob, Grep, AskUserQuestion, WebSearch]
 ---
 
@@ -21,6 +21,12 @@ Use this skill when the user:
 
 ## Available Skills
 
+### store-growth-audit/
+Stage-by-stage audit of an app's App Store growth machinery against a 54-item P0–P9 playbook — every item scored from an ASC read, a codebase check, or an explicit question, then routed to the skill that fixes it. Read-only; works for live apps (audit) and pre-launch apps (growth plan).
+
+### store-signals/
+Close the post-launch loop — turn a live app's App Store signals (reviews, analytics, sales, crashes, listing conversion) into a metric-tagged backlog, and verify whether last cycle's changes moved the metric they promised to move.
+
 ### analytics-interpretation/
 Interpret app metrics and make data-driven decisions. Covers DAU/MAU, retention curves, LTV/ARPU, App Store Connect analytics, funnel analysis (AARRR), cohort analysis, and decision trees for what to fix based on which metric is underperforming.
 
@@ -36,10 +42,10 @@ Business fundamentals for indie app developers. Covers business entity setup (LL
 ## How to Use
 
 1. Identify what growth stage the user is at:
-   - **Pre-launch**: press-media (prepare press kit), community-building (build anticipation)
+   - **Pre-launch**: store-growth-audit (seed the growth plan), press-media (prepare press kit), community-building (build anticipation)
    - **Just launched**: analytics-interpretation (baseline metrics), press-media (launch outreach)
-   - **Growing**: analytics-interpretation (optimize funnel), community-building (scale engagement)
-   - **Established**: indie-business (formalize operations), analytics-interpretation (advanced cohorts)
+   - **Growing**: store-signals (monthly loop), analytics-interpretation (optimize funnel), community-building (scale engagement)
+   - **Established**: store-growth-audit (quarterly re-audit), indie-business (formalize operations), analytics-interpretation (advanced cohorts)
 2. Read the relevant sub-skill's SKILL.md for detailed workflow
 3. Ask clarifying questions about the user's app, audience, and current metrics
 4. Provide actionable guidance tailored to their specific situation

--- a/skills/growth/analytics-interpretation/SKILL.md
+++ b/skills/growth/analytics-interpretation/SKILL.md
@@ -34,6 +34,8 @@ Ask the user via AskUserQuestion:
 4. **What they want to know**
    - "Are my metrics good?" / "What should I fix?" / "Should I keep going?"
 
+Also pull App Store Connect **peer group benchmarks** (App Analytics → Benchmarks): Apple's percentile comparison of your conversion rate, crash rate, and retention against a privacy-preserving peer group of similar apps. This establishes whether a metric is "bad for you" or "bad for the category" — do this before interpreting any trend.
+
 ### Step 2: Identify Key Metrics by App Type
 
 Different monetization models have different north star metrics.

--- a/skills/growth/store-growth-audit/SKILL.md
+++ b/skills/growth/store-growth-audit/SKILL.md
@@ -1,0 +1,196 @@
+---
+name: store-growth-audit
+description: Stage-by-stage audit of an app's App Store growth machinery against a 54-item P0–P9 playbook — every item scored from an App Store Connect MCP call, a codebase check, or an explicit question to the user, then routed to the skill or command that fixes it. Read-only on App Store Connect. Use for a growth audit or scorecard, a pre-launch growth plan, a quarterly re-audit, or "which growth levers am I missing."
+allowed-tools: [Read, Write, Glob, Grep, AskUserQuestion, mcp__asc-metadata__list_apps, mcp__asc-metadata__get_metadata, mcp__asc-metadata__list_locales, mcp__asc-metadata__get_app_pricing, mcp__asc-metadata__list_price_points, mcp__asc-metadata__get_availability, mcp__asc-metadata__list_iap, mcp__asc-metadata__list_subscription_groups, mcp__asc-metadata__list_subscriptions, mcp__asc-metadata__list_app_events, mcp__asc-metadata__list_experiments, mcp__asc-metadata__list_custom_pages, mcp__asc-metadata__get_analytics_report, mcp__asc-metadata__get_sales_report, mcp__asc-metadata__list_reviews]
+---
+
+# Store Growth Audit
+
+Walk an app — new or live — through the full App Store growth playbook, phase by phase, and
+produce a scorecard: what's installed, what's missing, what to do next, and who fixes it.
+
+> The invariant: **every item has a detection rule**. Status comes from an ASC read, a codebase
+> check, or an explicit question — never from vibes. If the user doesn't know, the item is
+> 🟠 *unverified*, not assumed ✅.
+
+## Where it fits (read the seams)
+
+- **Not `store-signals`.** That is the continuous *signal → backlog* loop: are the numbers moving,
+  did last cycle's bets pay off? This is the *structural* audit: is the machinery even installed?
+  Run this quarterly (or pre-launch); run store-signals monthly. Trend questions route there.
+- **Not `analytics-interpretation`.** Metric-quality judgments ("is 3.2% conversion good?") route
+  there; this skill only records the baseline and whether benchmarks were checked.
+- **Fixes never happen here.** Every 🔴/🟠 routes to a named sibling skill and (when driven from
+  SwiftShip) an `/apple:*` command. This skill detects, scores, and routes. Read-only on ASC.
+
+## When This Skill Activates
+
+- "Audit my app's growth / store presence / what levers am I missing"
+- A new app is approaching first submission and needs a growth plan, not just metadata
+- Quarterly re-audit cadence, or after a launch that undershot expectations
+- Before deciding to spend on paid acquisition ("is the free machinery done first?")
+- Portfolio triage: "which of my apps is leaving the most on the table"
+
+## The Model: P0–P9
+
+54 items across ten phases. Each phase is a theme; the item detail lives in the checklist files.
+
+| Phase | Theme | Items | Goal |
+|-------|-------|-------|------|
+| P0 | Day-one money toggles | 4 | Free margin + a measurement baseline before anything else |
+| P1 | On-metadata ASO | 7 | Every indexed field working (title, subtitle, keywords, events, IAPs) |
+| P2 | Conversion assets | 5 | Icon, screenshots, trust signals that convert impressions |
+| P3 | Localization | 5 | Metadata-first market expansion + PPP pricing |
+| P4 | Ratings machinery | 4 | Prompting, replying, and protecting the rating |
+| P5 | Experimentation | 4 | PPO, CPPs, events as a testing habit |
+| P6 | Featuring & free discovery | 6 | Nominations, new-OS adoption, storefronts, web presence |
+| P7 | Paid & external traffic | 8 | Apple Ads ladder, launch spikes, pre-orders, codes |
+| P8 | Earnings | 7 | Paywall experiments, win-backs, web checkout, bundles |
+| P9 | Retention loop & ops | 4 | Retention surfaces + the recurring refresh calendar |
+
+**Compressed priority** (used for action selection, not the maturity ladder): P0 money toggles
+first → P1–P3 (metadata, conversion, localization) → P8.4 web checkout + P8.6 volume purchasing
+(the 2026-era revenue unlocks) → everything else → P7 paid traffic last. Paid spend on top of
+broken free machinery is burned money.
+
+## Reference Files
+
+| File | Purpose |
+|------|---------|
+| `detection-playbook.md` | Gather-once machinery: the MCP batch table, the codebase grep table, the single MANUAL question batch |
+| `audit-checklist-p0-p4.md` | Items P0.1–P4.4 (25): foundations — money toggles through ratings |
+| `audit-checklist-p5-p9.md` | Items P5.1–P9.4 (29): growth loops — experimentation through ops |
+
+## Audit Process
+
+1. **Resolve app + mode.** Get the `appId` (from `.planning/STATE.md` when driven by SwiftShip,
+   else `list_apps` + confirm with the user). App live on the store → *existing* mode; not yet
+   shipped → *pre-launch* mode. A prior scorecard (`GROWTH.md`), if present, becomes the diff baseline.
+2. **Gather evidence — one pass, per `detection-playbook.md`.** Run the full MCP read batch, the
+   full codebase grep pass, and ONE batched AskUserQuestion round for every MANUAL item. Never
+   interleave gathering with scoring; never ask questions one at a time.
+3. **Score all 54 items** against the gathered evidence using each item's `rule:`. Honor
+   `applies-if:` guards (⚪ N/A) and ⏳ ANNOUNCED flags. Every status carries a terse, citable
+   evidence string (`locales: en-US only`, `SBP: enrolled (user, 2026-07)`).
+4. **Compute phase scores + maturity level** (rules below), and — when a prior scorecard exists —
+   per-item deltas: fixed / regressed / new since last audit.
+5. **Select the top 5 actions** (rule below).
+6. **Write or refresh the scorecard** — in a SwiftShip project this is `.planning/GROWTH.md`
+   (schema in SwiftShip's `templates/GROWTH.md`); standalone, write `GROWTH.md` beside the audit.
+   Append an audit-history row; refresh the recurring calendar's next-due dates.
+7. **Print the digest and route.** Maturity level, phase bar, top-5 with routes, deltas,
+   unanswered MANUAL items, next three calendar due-dates, and the suggested next command/skill.
+
+## Item Record Format
+
+Each checklist item is a stanza:
+
+```markdown
+#### P3.1 Metadata-only localization (ja de fr es pt ko zh-Hans) — core
+- detect: MCP `list_locales`
+- rule: ✅ ≥7 target locales localized · 🟠 1–6 non-English locales · 🔴 en-only
+- new-app: plan — seed target locales in the first submission
+- fix: product/localization-strategy → /apple:localize
+```
+
+- **ID** (`P<phase>.<n>`) is stable forever — scorecards diff by ID; never renumber.
+- **Flags** after the name: `core` (phase-gating), `RECURRING` (calendar-driven), `⏳ ANNOUNCED (WWDC26)`.
+- **detect:** `MCP <tool>` · `CODE <grep>` · `MANUAL <question>` · `HYBRID` (combination).
+- **rule:** explicit ✅/🟠/🔴 thresholds; optional `applies-if:` guard → ⚪ N/A when it fails.
+- **new-app:** how pre-launch mode scores it — `plan` / `code` / `defer` (see Modes).
+- **fix:** `sibling-skill → /apple:command` — the skill path works standalone; the command half
+  applies when driven from SwiftShip.
+
+**Status vocabulary:** ✅ done/healthy · 🟠 partial, stale, or unverified · 🔴 missing ·
+⚪ N/A (applies-if failed; excluded from denominators) · ⏳ ANNOUNCED (not yet scoreable; excluded
+from denominators; carries `prep:` and `recheck:` lines instead of a live rule).
+
+## Scoring & Maturity
+
+- **Phase score:** `✅ n / N applicable` — ⚪ and ⏳ items are excluded from N.
+- **Phase grade:**
+  - `Complete` — all applicable items ✅
+  - `Working` — ≥50% ✅ **and no `core` item 🔴**
+  - `Gaps` — any `core` item 🔴, or <50% ✅
+  - `Not started` — no applicable item ✅
+- **`core` items (13):** P0.1, P0.2, P1.1, P2.2, P2.4, P3.1, P4.1, P4.2, P5.1, P6.1, P8.1, P8.4, P9.2.
+- **Growth maturity level (0–9):** the highest P such that every phase ≤ P grades at least
+  `Working`. An app with P0–P3 working but P4 in gaps is Level 3, no matter how good P5–P9 look.
+  The ladder follows numeric phase order; the compressed priority shapes only action selection.
+
+**Top-5 action selection:** from all applicable 🔴 + 🟠 items, order by compressed-priority tier
+(T1: P0 · T2: P1–P3 · T3: P8.4 + P8.6-when-live · T4: P4–P6, rest of P8, P9 · T5: P7), then within
+a tier: `core` first, 🔴 before 🟠, lowest effort first. Two overrides: an **overdue RECURRING**
+calendar item jumps to the top; always include at least one metadata-only quick win (shippable
+without a binary release).
+
+## Modes: Existing vs Pre-Launch
+
+| | Existing app | Pre-launch |
+|---|---|---|
+| Evidence | ASC reads + codebase + MANUAL | `.planning/` docs + codebase + MANUAL |
+| `new-app: plan` items | scored normally | planned-in-docs → 🟠 `planned`; absent → 🔴 |
+| `new-app: code` items | scored normally | scored normally (greps work pre-launch) |
+| `new-app: defer` items | scored normally | ⚪ with an activation trigger noted (e.g. "30 days post-launch") |
+| Output framing | audit + deltas | launch plan (history row tagged `mode: pre-launch`) |
+
+The first post-launch audit diffs cleanly against the pre-launch scorecard — same IDs, same schema.
+
+## Output Format
+
+The scorecard file (schema = SwiftShip `templates/GROWTH.md`):
+header (app, date, mode, maturity) · phase-score table · top-5 actions · ten per-phase tables
+(`ID | Item | Status | Evidence | Next step | Route`) · Watchlist (⏳ announced) · Recurring
+Calendar · Baseline Metrics Snapshot · append-only Audit History.
+
+The printed digest never dumps 54 rows:
+
+```
+Growth audit: <App> — Level 4/9 (existing, re-audit)
+P0 ▓▓▓░ 3/4 · P1 ▓▓▓▓▓░░ 5/7 · P2 ▓▓▓░░ 3/5 · P3 ▓░░░░ 1/5 · P4 ▓▓▓▓ 4/4 …
+Top 5: 1) P0.1 Apply to Small Business Program (route: growth/indie-business) …
+Since last audit: 3 fixed, 1 regressed (P9.3 update freshness)
+Unverified (you were unsure): P0.3 peer benchmarks, P7.2 brand defense
+Calendar: featuring nomination due in 12 days · keyword refresh due 2026-10-01
+Next: /apple:localize (or product/localization-strategy standalone)
+```
+
+## Routing Map
+
+The only place the full route list lives; stanzas carry the short form.
+
+| Audit area | Sibling skill (canonical) | SwiftShip command |
+|---|---|---|
+| SBP, business ops | `growth/indie-business` | — (ASC manual) |
+| Billing grace/retry, subscription lifecycle | `generators/subscription-lifecycle` | `/apple:subscription` |
+| Analytics baseline, benchmarks | `growth/analytics-interpretation` | `/apple:learn-from-store` |
+| Keywords, metadata fields, AI tagging | `app-store/keyword-optimizer` | `/apple:metadata` (or `/apple:aso` if installed) |
+| Apple Ads (discovery, exact, halo, brand) | `app-store/apple-search-ads` | `/apple:aso` if installed |
+| Screenshots, previews, Creative Assets | `app-store/screenshot-planner` | `/apple:screenshots` |
+| Icon + PPO + CPP experiments | `generators/product-page-optimization`, `generators/custom-product-pages` | `/apple:experiment` |
+| In-app events | `generators/in-app-events` | `/apple:event` |
+| Localization + PPP pricing | `product/localization-strategy`, `monetization` (pricing-models) | `/apple:localize` |
+| Ratings: prompting, replies, protection | `app-store/ratings-mechanics`, `generators/review-prompt`, `app-store/review-response-writer` | `/apple:ship` (phased release) |
+| Featuring nominations | `generators/featuring-nomination` | — (ASC manual, calendar-driven) |
+| New-OS adoption | — | `/apple:modernize` |
+| App Intents / Spotlight | `apple-intelligence/app-intents`, `generators/spotlight-indexing` | `/apple:plan` |
+| Web SEO, landing page, deal sites | `app-store/web-presence` | — |
+| Pre-orders, offer codes, waitlist | `generators/pre-orders`, `generators/offer-codes-setup`, `product/beta-testing` | `/apple:testflight` |
+| Paywall + pricing experiments | `generators/paywall-generator`, `monetization` | `/apple:subscription` |
+| Win-backs, retention messaging | `generators/win-back-offers` | `/apple:subscription` |
+| External purchase links / web checkout | `monetization/external-purchases` | — |
+| Bundles, Family Sharing, volume licensing | `monetization/bundles-and-licensing` | — |
+| Retention surfaces | `generators/onboarding-generator`, `generators/push-notifications`, `generators/widget-generator`, `generators/live-activity-generator` | `/apple:plan` |
+
+## Caveats
+
+- **Read-only on ASC.** The audit never mutates anything — not even analytics report setup (that
+  routes to store-signals / `/apple:learn-from-store`). Surface → score → route.
+- **MANUAL honesty.** Ask once, in one batch. "I don't know" scores 🟠 *unverified* — the
+  scorecard tells the user what to go check, it never guesses.
+- **⏳ items are rechecked every audit.** Apple ships announced features on its own schedule; each
+  ⏳ stanza carries a dormant detection rule — when the feature is live, apply it and drop the flag.
+- **Never reset the ratings summary** (P4.4). That item is a guardrail, not a task: resetting
+  discards accumulated social proof and is almost never recoverable. Default ✅; flip to 🔴 only
+  if a reset is planned or happened — then route to `app-store/ratings-mechanics` to stop it.
+- Stable IDs. New items get new numbers; retired items keep their row with status `retired`.

--- a/skills/growth/store-growth-audit/audit-checklist-p0-p4.md
+++ b/skills/growth/store-growth-audit/audit-checklist-p0-p4.md
@@ -1,0 +1,164 @@
+# Audit Checklist P0–P4 — Foundations (25 items)
+
+Stanza format, flags, status vocabulary, and `new-app:` semantics are defined in `SKILL.md`.
+Evidence keys (`EV.*`) are defined in `detection-playbook.md`. IDs are stable — never renumber.
+
+## P0 — Day-one money toggles
+
+#### P0.1 Small Business Program enrollment — core
+- detect: MANUAL Q1
+- rule: ✅ enrolled · 🔴 eligible but not enrolled · 🟠 not sure · applies-if: <$1M proceeds/yr (else ⚪ ineligible)
+- new-app: plan — apply as soon as the account has (or will have) paid transactions; 15% vs 30% commission
+- fix: growth/indie-business → ASC manual (enroll under Agreements)
+
+#### P0.2 Billing Grace Period + Billing Retry enabled — core
+- detect: MANUAL Q2 (+ `EV.subs` to establish applies-if)
+- rule: ✅ both enabled · 🟠 one, or unsure · 🔴 neither · applies-if: has auto-renewable subscriptions
+- new-app: plan — enable at subscription setup; recovers 5–15% of revenue lost to failed cards
+- fix: generators/subscription-lifecycle → /apple:subscription
+
+#### P0.3 Analytics baseline + peer-group benchmarks
+- detect: HYBRID — `EV.analytics` (report configured, baseline recorded) + MANUAL Q3 (benchmarks checked)
+- rule: ✅ baseline snapshot recorded AND benchmarks checked this quarter · 🟠 one of the two · 🔴 neither
+- new-app: defer — activates once the app has 30 days of store data
+- fix: growth/analytics-interpretation → /apple:learn-from-store
+
+#### P0.4 Keyword research done (autocomplete + competitors + Apple Ads discovery probe)
+- detect: HYBRID — keyword research artifacts (`.planning/ASO.md` keyword table or equivalent) + MANUAL Q4
+- rule: ✅ researched list incl. popularity data exists · 🟠 informal/partial research · 🔴 keywords guessed
+- new-app: plan — research before first metadata, not after
+- fix: app-store/keyword-optimizer + app-store/apple-search-ads → /apple:metadata (or /apple:aso if installed)
+
+## P1 — On-metadata ASO
+
+#### P1.1 Title, subtitle, keyword field optimized — core
+- detect: MCP `EV.meta`
+- rule: ✅ all three fields near their 30/30/100 limits, no cross-field duplicate words, keyword field comma-separated without spaces · 🟠 fields present but wasteful (duplicates, spaces, unused chars) · 🔴 subtitle or keyword field empty/default
+- new-app: plan — score the drafted fields in ASO.md by the same rule
+- fix: app-store/keyword-optimizer → /apple:metadata
+
+#### P1.2 Cross-localization indexing exploited
+- detect: MCP `EV.locales` + `EV.meta`
+- rule: ✅ extra indexed locales for the primary storefront carry distinct keywords (e.g. en-GB, es-MX for US) · 🟠 extra locales exist but duplicate the primary keywords · 🔴 primary locale only
+- new-app: plan
+- fix: app-store/keyword-optimizer (advanced-tactics §1) → /apple:localize
+
+#### P1.3 Developer name is a deliberate, descriptive choice
+- detect: MANUAL Q5
+- rule: ✅ descriptive or deliberately branded · 🟠 never considered · 🔴 misleading/squatted (rare)
+- new-app: plan — one-time strategic choice; heavy to change later
+- fix: app-store/keyword-optimizer (advanced-tactics §12)
+
+#### P1.4 Promoted in-app purchases with keyword-bearing display names
+- detect: MCP `EV.iaps` (display names; promoted flag may need MANUAL confirm)
+- rule: ✅ promoted IAPs configured with descriptive 30-char display names · 🟠 IAPs exist, none promoted or names generic ("Pro Upgrade") · 🔴 none configured · applies-if: has IAPs/subscriptions
+- new-app: plan — up to 20 promoted IAPs, each an indexed search result card
+- fix: generators/promoted-iap → /apple:iap
+
+#### P1.5 In-app event metadata used as indexed surface
+- detect: MCP `EV.events`
+- rule: ✅ at least one event in the last 6 months with keyword-conscious name/description · 🟠 events exist but metadata is throwaway · 🔴 never used · applies-if: app has event-worthy moments (judgment — else ⚪)
+- new-app: defer — activates post-launch
+- fix: generators/in-app-events → /apple:event
+
+#### P1.6 Description + promotional text working
+- detect: MCP `EV.meta`
+- rule: ✅ benefit-led first paragraph AND promo text in use (it updates instantly, no review) · 🟠 description fine but promo text empty · 🔴 feature-list-only description
+- new-app: plan
+- fix: app-store/app-description-writer → /apple:metadata
+
+#### P1.7 Metadata written for Apple's AI tagging
+- detect: MCP heuristic on `EV.meta` — is the copy unambiguous about what the app does and who it's for? (judgment; default 🟠 unless clearly literal)
+- rule: ✅ literal, tag-friendly copy incl. screenshot captions · 🟠 clever/metaphorical copy that tags poorly · 🔴 misleading copy
+- new-app: plan
+- fix: app-store/keyword-optimizer (advanced-tactics §13) → /apple:metadata
+
+## P2 — Conversion assets
+
+#### P2.1 Icon is deliberate and has been tested
+- detect: HYBRID — `EV.ppo` (any icon experiment ever) + MANUAL
+- rule: ✅ icon tested via PPO or consciously chosen against competitors · 🟠 default/first-draft icon never revisited · 🔴 placeholder
+- new-app: plan — icon is the single biggest conversion lever in search results
+- fix: generators/product-page-optimization → /apple:icon + /apple:experiment
+
+#### P2.2 Screenshots: first three carry benefit captions — core
+- detect: HYBRID — `EV.meta` where screenshot info is exposed; else MANUAL
+- rule: ✅ first 3 screenshots lead with benefit captions readable at thumbnail size · 🟠 screenshots fine but captions absent/feature-speak · 🔴 raw UI dumps
+- new-app: plan
+- fix: app-store/screenshot-planner → /apple:screenshots
+
+#### P2.3 App preview video (once screenshots are solid)
+- detect: HYBRID — `EV.meta` / MANUAL
+- rule: ✅ preview video live · 🟠 planned/produced but not shipped · 🔴 none and screenshots already solid · applies-if: screenshots done (else ⚪ — sequence matters)
+- new-app: defer
+- fix: app-store/screenshot-planner → /apple:screenshots
+
+#### P2.4 Trust signals: privacy labels, support URL, account deletion — core
+- detect: HYBRID — `EV.meta` (support/privacy URLs live) + `EV.code.accountdeletion` + MANUAL Q6 (labels reviewed)
+- rule: ✅ all three verified current · 🟠 URLs live but labels unreviewed, or account deletion N/A-unclear · 🔴 broken URL or missing deletion where accounts exist
+- new-app: plan
+- fix: legal/privacy-publish + generators/account-deletion → /apple:privacy
+
+#### P2.5 Alternate icons pre-shipped for future PPO icon tests
+- detect: CODE `EV.code.alticons`
+- rule: ✅ candidate alternate icons in the shipped asset catalog · 🔴 none (icon PPO tests blocked one full release)
+- new-app: code — ship candidates in v1.0; unused alternates cost nothing
+- fix: generators/product-page-optimization → /apple:icon
+
+## P3 — Localization
+
+#### P3.1 Metadata-only localization for the big seven — core
+- detect: MCP `EV.locales`
+- rule: ✅ ≥7 of {ja, de, fr, es, pt-BR, ko, zh-Hans} localized (title/subtitle/keywords minimum) · 🟠 1–6 non-English locales · 🔴 English only
+- new-app: plan — metadata-only is Level 0 localization; the app itself can wait
+- fix: product/localization-strategy → /apple:localize
+
+#### P3.2 Per-storefront ratings strategy
+- detect: HYBRID — `EV.territories` (where it's sold) + MANUAL (prompting strategy per market)
+- rule: ✅ aware ratings don't carry across storefronts AND prompting actively in each target market · 🟠 selling wide, prompting only at home · 🔴 assumed the home rating shows everywhere
+- new-app: defer — activates with first non-home-market push
+- fix: app-store/ratings-mechanics → /apple:localize
+
+#### P3.3 PPP pricing for India, Brazil, Turkey, Indonesia
+- detect: MCP `EV.pricing` + `EV.pricepoints`
+- rule: ✅ manual price points set for IN/BR/TR/ID below auto-equalized levels · 🟠 some manual overrides · 🔴 pure auto-equalization · applies-if: paid app or IAP/subs sold in those territories
+- new-app: plan
+- fix: monetization (pricing-models, Pricing Localization) → ASC pricing (dry-run via /apple:ship)
+
+#### P3.4 App itself localized where demand is proven
+- detect: HYBRID — `EV.sales`/`EV.analytics` by territory vs `EV.code.locales`
+- rule: ✅ in-app localization matches the markets producing revenue · 🟠 a market >15% of revenue still un-localized in-app · 🔴 localized nowhere despite proven foreign demand · ⚪ no foreign demand signal yet
+- new-app: defer
+- fix: product/localization-strategy → /apple:localize
+
+#### P3.5 Metadata updates automated via the ASC API
+- detect: CODE `EV.code.automation`
+- rule: ✅ scripted/bulk metadata pushes (fastlane deliver, ASC API scripts, bulk tooling) · 🟠 partially scripted · 🔴 35+ locales maintained by hand
+- new-app: plan
+- fix: /apple:localize + /apple:metadata (bulk update paths) — standalone: `_shared/asc-api`
+
+## P4 — Ratings machinery
+
+#### P4.1 requestReview at success moments — core
+- detect: CODE `EV.code.reviewprompt`
+- rule: ✅ requestReview called at a success moment with condition gating · 🟠 called but at launch/random (guideline-safe but conversion-poor) · 🔴 never prompts
+- new-app: code
+- fix: generators/review-prompt → /apple:build
+
+#### P4.2 Negative reviews answered — core
+- detect: MCP `EV.reviews`
+- rule: ✅ 1–3★ reviews from the last 90 days have developer responses · 🟠 some answered · 🔴 none answered (updated ratings replace old scores — replies are recoverable stars)
+- new-app: defer — activates with first reviews
+- fix: app-store/review-response-writer → route replies via ASC (surfaced by /apple:learn-from-store)
+
+#### P4.3 Phased release + manual version release habit
+- detect: MANUAL Q7
+- rule: ✅ both habits (7-day phased rollout, manual release after approval) · 🟠 one · 🔴 auto-release, full blast (one bad build can nuke the rating before you wake up)
+- new-app: plan — set on the first release
+- fix: app-store/ratings-mechanics → /apple:ship (phased release step)
+
+#### P4.4 Never reset the ratings summary — guardrail
+- detect: MANUAL (only if a reset is being considered; default ✅)
+- rule: ✅ no reset planned/performed · 🔴 reset planned or recently performed
+- new-app: plan — note the rule before v2.0 temptation arrives
+- fix: app-store/ratings-mechanics (read it before touching the toggle)

--- a/skills/growth/store-growth-audit/audit-checklist-p5-p9.md
+++ b/skills/growth/store-growth-audit/audit-checklist-p5-p9.md
@@ -1,0 +1,192 @@
+# Audit Checklist P5–P9 — Growth Loops (29 items)
+
+Stanza format, flags, status vocabulary, and `new-app:` semantics are defined in `SKILL.md`.
+Evidence keys (`EV.*`) are defined in `detection-playbook.md`. IDs are stable — never renumber.
+
+## P5 — Experimentation
+
+#### P5.1 Product Page Optimization running as a habit — core
+- detect: MCP `EV.ppo`
+- rule: ✅ a PPO experiment ran in the last 2 quarters or after the last asset change · 🟠 ran once, long ago · 🔴 never (up to 3 treatments on organic traffic, one variable at a time)
+- new-app: defer — activates ~30 days post-launch (needs traffic)
+- fix: generators/product-page-optimization → /apple:experiment
+
+#### P5.2 Custom Product Pages for distinct audiences
+- detect: MCP `EV.cpp`
+- rule: ✅ CPPs live and mapped to audiences/campaigns (35 slots available) · 🟠 one token CPP · 🔴 none despite distinct audiences · ⚪ genuinely single-audience app
+- new-app: defer
+- fix: generators/custom-product-pages → /apple:experiment
+
+#### P5.3 Creative Assets — ⏳ ANNOUNCED (WWDC26)
+> Status: announced (WWDC26) — verify availability in App Store Connect before executing.
+- prep: keep a motion-capable asset library (from PPO/CPP work) ready — rich video/animated media for the product-page header and search results, submittable without an app update
+- recheck: every audit — is the Creative Assets section live in ASC? When live, apply:
+- dormant rule: ✅ rich media asset live in header/search · 🔴 not adopted within a quarter of availability
+- fix: app-store/screenshot-planner → /apple:screenshots
+
+#### P5.4 In-app events cadence + badge variety
+- detect: MCP `EV.events`
+- rule: ✅ ≥1 event per quarter, badges varied by purpose · 🟠 sporadic events · 🔴 never used · applies-if: app has event-worthy moments (else ⚪)
+- new-app: defer
+- fix: generators/in-app-events → /apple:event
+- note: new badge types (Now On Sale, Try Before You Buy) are ⏳ ANNOUNCED (WWDC26) — recheck each audit
+
+## P6 — Featuring & free discovery
+
+#### P6.1 Featuring nominations as a rolling calendar — core, RECURRING
+- detect: MANUAL Q8 + the scorecard's Recurring Calendar
+- rule: ✅ nomination submitted for the current cycle AND next moment scheduled 6–8 weeks ahead · 🟠 submitted once, no calendar · 🔴 never nominated
+- new-app: plan — first nomination at launch (launches are featuring moments)
+- fix: generators/featuring-nomination → ASC manual (calendar maintained by the audit)
+
+#### P6.2 New-OS APIs adopted at launch
+- detect: HYBRID — `EV.code.newapis` + MANUAL timing (shipped within the new OS's launch window?)
+- rule: ✅ current-cycle APIs adopted in a launch-window release (the most reliable featuring trigger) · 🟠 adopted late · 🔴 still targeting only old APIs
+- new-app: code — build against the current SDK's new surfaces from day one
+- fix: /apple:modernize — standalone: design/ + apple-intelligence/ adoption skills
+
+#### P6.3 Secondary category set
+- detect: MCP `EV.meta` (categories)
+- rule: ✅ secondary category set and deliberately chosen (second chart presence) · 🔴 empty
+- new-app: plan
+- fix: /apple:ship (category step) — standalone: app-store/marketing-strategy (decision-matrix)
+
+#### P6.4 Checkbox storefronts shipped where sensible
+- detect: HYBRID — `EV.code.platforms` + `EV.territories`
+- rule: ✅ viable easy ports shipped (Mac via Catalyst/iPad-on-Mac, visionOS, watchOS, tvOS — tiny catalogs, easy charts and featuring) · 🟠 viable port identified but not shipped · ⚪ no sensible port
+- new-app: plan — check the checkbox platforms at project setup
+- fix: /apple:new-app (platform choice) / /apple:plan — standalone: visionos/, watchos/, ios/ipad-patterns
+
+#### P6.5 App Intents as an out-of-store discovery channel
+- detect: CODE `EV.code.intents` + `EV.code.spotlight`
+- rule: ✅ App Shortcuts + Spotlight indexing shipped (Siri, Spotlight, Shortcuts become discovery surfaces) · 🟠 intents exist but no AppShortcutsProvider/Spotlight · 🔴 none
+- new-app: code
+- fix: apple-intelligence/app-intents + generators/spotlight-indexing → /apple:plan
+
+#### P6.6 Web presence: apps.apple.com SEO + landing page + Smart App Banner
+- detect: MANUAL Q9 (CODE if a web repo is at hand)
+- rule: ✅ landing page live with Smart App Banner, store page ranks for the app's name queries · 🟠 landing page only · 🔴 no web presence
+- new-app: plan — the store's web page ranks on Google from day one; give it help
+- fix: app-store/web-presence
+
+## P7 — Paid & external traffic
+
+#### P7.1 Apple Ads ladder: discovery → exact-match winners (+ CPP pairing)
+- detect: MANUAL Q4 + `EV.cpp` (paired pages)
+- rule: ✅ discovery feeding exact-match campaigns, winners paired with matching CPPs · 🟠 ads running unstructured · 🔴/⚪ no ads (⚪ if deliberately organic-only and P1–P6 healthy)
+- new-app: defer — paid comes after the free machinery works
+- fix: app-store/apple-search-ads → /apple:aso if installed
+
+#### P7.2 Brand term defended
+- detect: MANUAL Q4
+- rule: ✅ brand campaign live (competitors bid on your name; brand CPAs are cheap) · 🟠 unsure · 🔴 brand undefended while competitors bid · applies-if: running ads or brand has search volume
+- new-app: defer
+- fix: app-store/apple-search-ads
+
+#### P7.3 ASA→organic halo tracked
+- detect: MANUAL
+- rule: ✅ organic rank movement watched on paid keywords (paid conversion lifts organic rank) · 🟠 not tracked · ⚪ no ads
+- new-app: defer
+- fix: app-store/apple-search-ads + growth/store-signals → /apple:learn-from-store
+
+#### P7.4 Compressed launch spikes
+- detect: MANUAL Q10 / `.planning/` launch plan
+- rule: ✅ last major release compressed Product Hunt + press embargo + newsletter into 48h (chart velocity beats volume) · 🟠 channels used but spread out · 🔴 launches go out quietly
+- new-app: plan — write the spike plan before launch week
+- fix: growth/press-media + growth/community-building → /apple:release-notes (assets)
+
+#### P7.5 Deal-site ecosystem used for price drops
+- detect: MANUAL Q9
+- rule: ✅ price drops timed knowing aggregators auto-scrape them (spike → chart climb → organic tail) · 🟠 price drops happen unannounced · ⚪ free app, no price to drop
+- new-app: defer
+- fix: app-store/web-presence (deal-site section)
+
+#### P7.6 Pre-orders used (including regionally)
+- detect: MANUAL Q11 + `EV.territories`
+- rule: ✅ pre-orders used at launch or regionally when entering new storefronts (up to 180 days of accumulated taps) · 🟠 known but unused at last opportunity · ⚪ no upcoming launch/expansion
+- new-app: plan — decide pre-order length before first submission
+- fix: generators/pre-orders → /apple:ship
+
+#### P7.7 Offer codes distributed
+- detect: MANUAL Q11 + `EV.iaps`/`EV.subs`
+- rule: ✅ URL-redeemable codes in use for influencers/communities/conferences · 🟠 configured, never distributed · 🔴 unused despite subs/IAP · applies-if: has subs/IAP
+- new-app: defer
+- fix: generators/offer-codes-setup → /apple:subscription
+
+#### P7.8 TestFlight public link as a waitlist
+- detect: MANUAL Q11
+- rule: ✅ public link doubled as pre-launch waitlist (up to 10k testers → day-one installers) · 🟠 TestFlight private-only pre-launch · ⚪ already long-launched with no major relaunch coming
+- new-app: plan
+- fix: product/beta-testing → /apple:testflight
+
+## P8 — Earnings
+
+#### P8.1 Paywall + pricing experiments — core
+- detect: HYBRID — `EV.code.paywall` + MANUAL Q12
+- rule: ✅ paywall variable (trial length, intro offer, layout) tested in the last 2 quarters · 🟠 paywall shipped, never experimented · 🔴 no deliberate paywall · applies-if: monetized
+- new-app: plan (paywall) / defer (experiments)
+- fix: generators/paywall-generator + monetization → /apple:subscription
+
+#### P8.2 Win-back offers configured
+- detect: MCP `EV.subs` (offers) — MANUAL fallback
+- rule: ✅ win-back offers live (the App Store surfaces them to lapsed subscribers by itself) · 🔴 not configured · applies-if: subscriptions ≥ minimum eligibility
+- new-app: defer
+- fix: generators/win-back-offers → /apple:subscription
+
+#### P8.3 Retention Messaging (save offer at cancel) — ⏳ ANNOUNCED (WWDC26)
+> Status: announced (WWDC26) — verify availability in App Store Connect before executing.
+- prep: draft the save-offer copy and eligibility rules now; decide the discount you can afford at the cancel moment
+- recheck: every audit — Retention Messaging live in ASC/API? When live, apply:
+- dormant rule: ✅ save offer configured at cancel moment · 🔴 not configured within a quarter of availability · applies-if: subscriptions
+- fix: generators/win-back-offers (Retention Messaging section) → /apple:subscription
+
+#### P8.4 US web checkout / External Purchase Links — core
+- detect: HYBRID — CODE `EV.code.extpurchase` + MANUAL Q13
+- rule: ✅ shipped with commission-flip architecture + analytics from day one (currently 0% commission; litigation ongoing — re-verify) · 🟠 planned/considered · 🔴 not considered · applies-if: US storefront + digital goods revenue
+- new-app: plan — architect the flip switch before you need it
+- fix: monetization/external-purchases
+
+#### P8.5 Cross-developer bundles & suites
+- detect: MANUAL Q14
+- rule: ✅ partnered bundle live or in motion with complementary indie apps · 🟠 explored · ⚪ no sensible partner category
+- new-app: defer
+- fix: monetization/bundles-and-licensing
+
+#### P8.6 Group Purchases + Volume Purchasing — ⏳ ANNOUNCED (WWDC26)
+> Status: announced (WWDC26) — verify availability in App Store Connect before executing.
+- prep: identify whether schools/clinics/businesses buy your app; if yes, prepare multi-seat pricing now
+- recheck: every audit — Group Purchases / Apple School & Business Manager licensing live? When live, apply:
+- dormant rule: ✅ institutional licensing configured · 🔴 institutional demand exists but unconfigured · applies-if: B2B/edu buyer segment
+- fix: monetization/bundles-and-licensing
+
+#### P8.7 Own-app bundles + Family Sharing
+- detect: MCP `EV.iaps` + `EV.subs` (familySharable) + MANUAL (bundles)
+- rule: ✅ Family Sharing enabled where it fits AND multi-app developers bundle their own apps · 🟠 either unexamined · ⚪ single free app · applies-if: paid/subs
+- new-app: plan
+- fix: monetization/bundles-and-licensing → /apple:subscription
+
+## P9 — Retention loop & ops
+
+#### P9.1 Retention surfaces shipped
+- detect: CODE — `EV.code.onboarding`, `EV.code.notifications`, `EV.code.widgets`, `EV.code.liveactivity`
+- rule: ✅ onboarding + notifications + at least one ambient surface (widget/Live Activity) · 🟠 some · 🔴 none (retention feeds both ranking and LTV)
+- new-app: code
+- fix: generators/onboarding-generator, push-notifications, widget-generator, live-activity-generator → /apple:plan
+
+#### P9.2 Quarterly keyword refresh from ASA search-term reports — core, RECURRING
+- detect: MANUAL Q15 + the scorecard's Recurring Calendar
+- rule: ✅ refresh done within the last quarter with search-term data · 🟠 refreshed without paid-data input · 🔴 keywords untouched for two-plus quarters
+- new-app: defer — first refresh one quarter after launch
+- fix: app-store/keyword-optimizer (advanced-tactics §14) → /apple:metadata
+
+#### P9.3 Update freshness
+- detect: MCP `EV.meta` (current version's release recency)
+- rule: ✅ shipped within ~8–12 weeks (each release re-triggers indexing + freshness signals) · 🟠 3–6 months · 🔴 6+ months stale
+- new-app: ⚪ pre-launch
+- fix: /apple:next-version — standalone: growth/store-signals for what to ship
+
+#### P9.4 The re-run loop is closed — RECURRING
+- detect: the scorecard itself — Recurring Calendar rows have `last done` within cadence
+- rule: ✅ PPO re-run after last asset change, featuring calendar rolling, benchmarks rechecked · 🟠 calendar exists, rows overdue · 🔴 no calendar
+- new-app: plan — seed the calendar at launch
+- fix: this skill (re-audit) + generators/product-page-optimization + growth/analytics-interpretation

--- a/skills/growth/store-growth-audit/detection-playbook.md
+++ b/skills/growth/store-growth-audit/detection-playbook.md
@@ -1,0 +1,87 @@
+# Detection Playbook — gather once, evaluate 54
+
+The audit's evidence-gathering machinery. Run **all three passes up front**, store the evidence
+under the keys below, then evaluate every checklist item against the stored evidence. Never
+interleave gathering with scoring; never ask MANUAL questions one at a time.
+
+## Pass 1 — MCP evidence batch (read-only, ~14 calls)
+
+One call per row; each populates an evidence key consumed by the listed items.
+
+| Call | Evidence key | Feeds items |
+|------|--------------|-------------|
+| `list_apps` | `EV.app` (appId, state, live?) | mode detection |
+| `get_metadata` | `EV.meta` (name, subtitle, keywords, description, promo text, categories, URLs, version, what's-new) | P1.1 P1.2 P1.6 P1.7 P2.2 P2.3 P2.4 P6.3 P9.3 |
+| `list_locales` | `EV.locales` (localized locales + per-locale fields) | P1.2 P3.1 P3.4 |
+| `get_app_pricing` | `EV.pricing` (base price + per-storefront overrides) | P3.3 |
+| `list_price_points` | `EV.pricepoints` (available tiers per storefront) | P3.3 |
+| `get_availability` | `EV.territories` (territories, platforms) | P3.2 P6.4 P7.6 |
+| `list_iap` | `EV.iaps` (IAPs, display names, familySharable) | P1.4 P7.7 P8.7 |
+| `list_subscription_groups` + `list_subscriptions` | `EV.subs` (groups, tiers, offers, familySharable) | P0.2 P8.1 P8.2 P8.7 |
+| `list_app_events` | `EV.events` (events, badges, dates, metadata) | P1.5 P5.4 |
+| `list_experiments` | `EV.ppo` (PPO experiments + states + dates) | P2.1 P5.1 P9.4 |
+| `list_custom_pages` | `EV.cpp` (custom product pages) | P5.2 P7.1 |
+| `get_analytics_report` | `EV.analytics` (impressions, page views, CVR, retention, sources) | P0.3 P3.4 baseline snapshot |
+| `get_sales_report` | `EV.sales` (units/proceeds, by territory) | P3.4 baseline snapshot |
+| `list_reviews` | `EV.reviews` (recent reviews, stars, developer-response present?) | P4.2 |
+
+Pre-launch mode: skip the batch (no live app); `EV.meta`-class evidence comes from
+`.planning/ASO.md`, `APP.md`, `ROADMAP.md` instead. Analytics not configured yet → note
+"baseline lands next cycle — route to store-signals to set up" (never call setup from the audit).
+
+## Pass 2 — codebase grep batch
+
+One pass over the app repo (skip if no codebase is at hand — affected items fall back to MANUAL).
+
+| Pattern (Grep/Glob) | Evidence key | Feeds items |
+|---------------------|--------------|-------------|
+| `requestReview\|SKStoreReviewController\|AppStore.requestReview` | `EV.code.reviewprompt` | P4.1 |
+| `setAlternateIconName\|CFBundleAlternateIcons` + alternate entries in `*.xcassets` | `EV.code.alticons` | P2.5 |
+| `import AppIntents\|AppShortcutsProvider\|INIntent` | `EV.code.intents` | P6.5 |
+| `CSSearchableItem\|CoreSpotlight` | `EV.code.spotlight` | P6.5 |
+| `import WidgetKit` / `import ActivityKit` | `EV.code.widgets` / `EV.code.liveactivity` | P9.1 |
+| `UNUserNotificationCenter\|requestAuthorization` | `EV.code.notifications` | P9.1 |
+| onboarding flow markers (`Onboarding`, first-run flags) | `EV.code.onboarding` | P9.1 |
+| `com.apple.developer.storekit.external-purchase` in `*.entitlements` | `EV.code.extpurchase` | P8.4 |
+| `*.storekit` config, `SubscriptionStoreView\|StoreKit` paywall views | `EV.code.paywall` | P8.1 |
+| deletion flow (`deleteAccount`, account-deletion UI) | `EV.code.accountdeletion` | P2.4 |
+| `*.lproj` dirs / locales inside `*.xcstrings` | `EV.code.locales` | P3.4 |
+| platform targets in `project.pbxproj` (`SDKROOT`, `SUPPORTED_PLATFORMS`, Catalyst flag) | `EV.code.platforms` | P6.4 |
+| fastlane/ASC-API scripts (`fastlane/`, `deliver`, `app_store_connect_api_key`, metadata upload scripts) | `EV.code.automation` | P3.5 |
+| new-OS API adoption (imports gated by current-year `#available`) | `EV.code.newapis` | P6.2 |
+
+## Pass 3 — the MANUAL question batch
+
+One `AskUserQuestion` round covering every MANUAL/HYBRID item the first two passes can't settle.
+Ask only what's still unknown; phrase options so each maps directly to a status. "Not sure" is
+always an option and always scores 🟠 *unverified*.
+
+| # | Question | Maps to |
+|---|----------|---------|
+| 1 | Enrolled in the App Store Small Business Program? (enrolled / not enrolled / ineligible >$1M / not sure) | P0.1 |
+| 2 | Billing Grace Period AND Billing Retry enabled in ASC? (both / one / neither / no subs) | P0.2 |
+| 3 | Checked ASC peer-group benchmarks for this app? (yes, recently / long ago / never) | P0.3 |
+| 4 | Apple Ads: any discovery campaign run for keyword research? Exact-match campaigns? Brand term defended? | P0.4 P7.1 P7.2 |
+| 5 | Is the developer/brand name a deliberate, descriptive choice? | P1.3 |
+| 6 | Privacy nutrition labels reviewed against current data collection? | P2.4 |
+| 7 | Do you release phased + manual (not auto-release on approval)? | P4.3 |
+| 8 | Any featuring nomination submitted in the last 6 months? A calendar for them? | P6.1 |
+| 9 | Landing page live? Smart App Banner on it? Ever listed on deal sites during a price drop? | P6.6 P7.5 |
+| 10 | Launch-spike playbook used at last major release (Product Hunt + press + newsletter inside 48h)? | P7.4 |
+| 11 | Pre-orders ever used (incl. regionally for new storefronts)? Offer codes distributed? TestFlight public link used as a waitlist? | P7.6 P7.7 P7.8 |
+| 12 | Paywall/pricing experiments run in the last two quarters? | P8.1 |
+| 13 | US web-checkout / External Purchase Link entitlement: shipped, planned, or not considered? | P8.4 |
+| 14 | Any cross-developer bundle conversations? Institutional (school/business) buyers in your audience? | P8.5 P8.6 |
+| 15 | ASA search-term report folded into keywords in the last quarter? | P9.2 |
+
+Trim the batch: drop questions already answered by evidence (e.g. `EV.code.extpurchase` present →
+ask only about the commission-flip architecture, not whether it shipped). In portfolio mode ask
+only the account-level questions (1, 3, 4-brand, 8) once for all apps.
+
+## Freshness caveats
+
+- Analytics/sales reports arrive on Apple's schedule; a missing report is "no data yet", not 🔴.
+- `EV.reviews` developer-response coverage is the signal for P4.2 — count unanswered 1–3★ reviews
+  from the last 90 days, don't judge tone here (that's `review-response-writer`'s job).
+- Evidence strings must be terse and dated where MANUAL: `SBP: enrolled (user, 2026-07)`,
+  `locales: en-US, de, ja`, `PPO: last experiment 2026-03 (stale)`.

--- a/skills/monetization/SKILL.md
+++ b/skills/monetization/SKILL.md
@@ -8,6 +8,8 @@ allowed-tools: [Read, Write, Edit, Glob, Grep, WebSearch, AskUserQuestion]
 
 End-to-end monetization guidance for Apple platform apps — from "should I charge?" to "here's your pricing page structure."
 
+Sub-skills in this category: `external-purchases/` (US web checkout via the External Purchase Link entitlement, commission-flip architecture) and `bundles-and-licensing/` (own-app bundles, Family Sharing, cross-developer suites, institutional volume licensing). Route there when the question is beyond the single-app price tag.
+
 ## When This Skill Activates
 
 Use this skill when the user:

--- a/skills/monetization/bundles-and-licensing/SKILL.md
+++ b/skills/monetization/bundles-and-licensing/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: bundles-and-licensing
+description: Revenue beyond the single-app price tag — own-app bundles, Family Sharing as a conversion lever, cross-developer bundles & suites, and institutional licensing via Group Purchases / Apple School & Business Manager. Use when a developer has multiple apps, a subscription worth sharing, complementary indie partners, or school/clinic/business buyers.
+allowed-tools: [Read, Write, Edit, Glob, Grep]
+---
+
+# Bundles & Licensing
+
+Four ways one piece of software earns more than one price tag. Ordered from
+available-today to announced.
+
+## When This Skill Activates
+
+- A portfolio developer asks how apps can sell each other ("bundle my apps?")
+- Deciding whether to enable Family Sharing on a subscription or purchase
+- Exploring partnerships with complementary indie apps
+- Schools, clinics, or businesses keep asking "how do we buy 30 seats?"
+- The store-growth audit flags P8.5, P8.6, or P8.7
+
+## 1. Own-app bundles (available now)
+
+App bundles group up to 10 of your own paid apps — or apps sharing a subscription — at a bundle
+price, with **Complete My Bundle** crediting what a user already paid.
+
+- ✅ Portfolio play: your catalog cross-sells itself on every member app's product page — a
+  discovery surface, not just a discount (pairs with the checkbox-storefront and portfolio
+  tactics in `app-store/marketing-strategy`).
+- ✅ Price the bundle at "second app ~half off, third+ nearly free" — the goal is basket size
+  and page presence, not margin per unit.
+- ❌ Bundling apps with no shared audience; the bundle card confuses both product pages.
+- Mechanics: paid apps only (or one subscription spanning the bundle); free apps can't bundle.
+
+## 2. Family Sharing (available now — chronically under-enabled)
+
+A checkbox per IAP/subscription in ASC, plus StoreKit handling for shared entitlements.
+
+- ✅ Enable for subscriptions whose *job* is shareable (utilities, education, health, home) —
+  "the whole family for one price" beats a 6× cheaper feel at maybe 1.5× usage cost, and it's a
+  paywall differentiator against non-sharing competitors.
+- ✅ Handle `Transaction.currentEntitlements` for family members who never purchased; test the
+  revoked-from-family path.
+- ❌ Enabling it on a per-seat B2B-ish product where sharing cannibalizes real seats — that's
+  what volume licensing (below) is for.
+- One-way door: you can turn Family Sharing **on** for existing subscribers, but turning it off
+  only affects new purchases.
+
+## 3. Cross-developer bundles & suites
+
+Combined subscriptions spanning apps from *different* developers — the "indie suite" model
+(several complementary tools, one subscription).
+
+- The unlock: each partner's install base becomes the others' warm audience — distribution
+  cheaper than any paid channel.
+- ✅ Partner selection: same buyer, adjacent jobs, no feature overlap (writing tool + reference
+  manager + focus timer, not three writing tools). Draft revenue-share on *attribution of the
+  acquiring app*, not equal splits.
+- ✅ Verify current ASC mechanics before promising a ship date — cross-developer suites are a
+  recent capability and terms/tooling are still settling; the fallback is coordinated own-app
+  pricing + mutual offer codes (`generators/offer-codes-setup`).
+- ❌ Partnering with an app whose rating or privacy posture you wouldn't put your name on — a
+  suite shares reputational blast radius (run `app-store/originality-check` thinking on partners).
+
+## 4. Group Purchases & Volume Purchasing — institutional sales
+
+> Status: announced (WWDC26) — verify availability in App Store Connect before executing.
+
+Multi-seat subscription purchases and licensing through **Apple School Manager / Apple Business
+Manager** — the institutional unlock if your buyers are schools, clinics, or businesses.
+
+- prep now: identify whether an institutional segment already exists in your reviews/support mail
+  ("can we get this for our class/team?"); design a seats model (who assigns, who owns data) and
+  per-seat pricing before the tooling lands.
+- Custom Apps via Apple Business Manager exist today for bespoke B2B distribution; Group
+  Purchases extends the mainstream store to multi-seat — different tools, same buyer.
+- ✅ Education/health apps: this often outearns consumer conversion optimization by an order of
+  magnitude — one district buys more seats than a year of paywall A/B tests adds.
+- ❌ Building seat management UI before validating a single institutional buyer exists.
+
+## Decision sketch
+
+| You have | Reach for |
+|---|---|
+| 2+ paid apps, shared audience | Own-app bundle |
+| A shareable-job subscription | Family Sharing on |
+| A complementary indie peer with real traffic | Cross-developer suite (or mutual offer codes today) |
+| Institutions asking to buy seats | Group/Volume Purchasing prep now, ship when live |
+
+## Output Format
+
+```
+Portfolio: bundle-eligible apps? bundle live? Complete-My-Bundle pricing sane?
+Family Sharing: enabled where the job is shareable? entitlement handling tested?
+Partnerships: candidate named? terms sketched?
+Institutional: demand evidence? seats model drafted? feature availability rechecked?
+```
+
+Each gap routed to the numbered section above; StoreKit implementation to
+`generators/subscription-lifecycle`, offer distribution to `generators/offer-codes-setup`.
+
+## References
+
+- https://developer.apple.com/help/app-store-connect/create-an-app-bundle/
+- https://developer.apple.com/documentation/storekit/supporting-family-sharing-in-your-app
+- https://support.apple.com/guide/apple-business-manager/welcome/web
+- Related skills: `monetization` (pricing/tiers), `generators/subscription-lifecycle`, `generators/offer-codes-setup`, `growth/store-growth-audit`

--- a/skills/monetization/external-purchases/SKILL.md
+++ b/skills/monetization/external-purchases/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: external-purchases
+description: US web checkout via the StoreKit External Purchase Link entitlement — currently 0% Apple commission (litigation ongoing), how to ship it safely, and how to architect for a commission flip so a future ruling is a config change, not a rewrite. Use when adding external purchase links, weighing web checkout vs IAP, or planning US-storefront pricing strategy.
+allowed-tools: [Read, Write, Edit, Glob, Grep]
+---
+
+# External Purchases (US Web Checkout)
+
+On the **US storefront**, apps may link out to a web checkout for digital goods using the
+StoreKit External Purchase Link entitlement — and as of mid-2026, court orders have Apple's
+commission on those purchases at **0%**, with the fee case still moving through district court.
+This is the largest indie revenue unlock of the era, and it is *reversible by a ruling* — so the
+engineering rule is: **ship it now, architect it so a commission can be flipped on later.**
+
+> Verify current state before relying on this: the entitlement terms, the commission rate, and
+> the litigation status have each changed more than once. Treat every number here as
+> "true as of 2026-07, re-check."
+
+## When This Skill Activates
+
+- "Add a web checkout / Stripe / external purchase link" for digital goods
+- Deciding IAP vs web checkout for a US-heavy revenue base
+- The store-growth audit flags P8.4
+- Reviewing an app whose external links might be non-compliant (wrong storefront, no entitlement)
+
+## The rules of the road
+
+- **US storefront only.** Elsewhere, Guideline 3.1.1 still applies in force (separate regimes
+  exist in the EU/JP/KR — different entitlements, different terms; don't extrapolate from the US).
+- **Entitlement required**: `com.apple.developer.storekit.external-purchase-link` in the app's
+  entitlements + the matching `Info.plist` declarations. A bare `Link("Buy", …)` to your site
+  without the entitlement is still a rejection (see `app-store/rejection-handler` §3.1.1).
+- Present the link per the entitlement's UI terms (StoreKit's `ExternalPurchaseLink` /
+  disclosure sheet where required). Don't dark-pattern the IAP option away if you keep both.
+- Purchases made on the web are **your** customer relationship: your payment processor, your
+  refunds, your taxes (Apple's commission was also Apple's merchant-of-record work — that work
+  is now yours).
+
+## Architecture: the commission flip
+
+Design so that a future "Apple takes N% of external purchases initiated in-app" ruling changes a
+config value, not your codebase:
+
+- ✅ Route every in-app-initiated web checkout through **one** link-out service that stamps the
+  session (`source=app`, timestamp, storefront) — web-organic checkouts stay unstamped. If a
+  commission returns, it applies to a knowable, logged subset.
+- ✅ Keep a single `CommissionPolicy` (remote-configurable): `rate`, `applies_to`,
+  `effective_date`. Report/accrue against it from day one — at 0% it's just a counter.
+- ✅ Log day-one analytics: link taps → checkout starts → completions, vs the IAP funnel. The
+  conversion drop through a web checkout (Apple's sheet, Safari hop, payment form) is real;
+  whether 0% beats IAP's frictionless 85–70% is an *empirical* per-app question.
+- ❌ Scattering `openURL("https://…/buy")` calls through features — un-auditable, un-flippable.
+- ❌ Ripping out StoreKit. Keep IAP as a fallback path (non-US storefronts still need it, and
+  some US users convert better in-sheet).
+
+## Decision sketch
+
+| Situation | Lean |
+|---|---|
+| Subscriptions, US-heavy, ARPU high enough to absorb processor fees + your own support | Web checkout for new subs; keep IAP for the rest of world |
+| Impulse-priced consumables/unlocks | IAP — checkout friction eats more than 15–30% commission |
+| Existing subscriber base on IAP | Don't force-migrate; offer web at renewal decision points |
+| B2B/prosumer, invoicing needs | Web checkout regardless of commission math |
+
+## Output Format
+
+```
+Status: entitlement present? · storefront scope correct (US-only gating)? ·
+link-out service centralized? · CommissionPolicy flippable? · funnel analytics live?
+Verdict + the one next step.
+```
+
+## References
+
+- https://developer.apple.com/documentation/storekit/externalpurchaselink
+- https://developer.apple.com/support/storekit-external-entitlement-us/
+- https://developer.apple.com/app-store/review/guidelines/#in-app-purchase
+- Related skills: `app-store/rejection-handler` (the non-entitled rejection pattern), `generators/subscription-lifecycle`, `monetization` (pricing), `growth/store-growth-audit`

--- a/skills/monetization/pricing-models.md
+++ b/skills/monetization/pricing-models.md
@@ -228,6 +228,14 @@ Apple provides 87 price tiers with automatic localization. Key considerations:
 - Consider offering **lower tiers in emerging markets** via App Store pricing tools
 - Apple's "Pricing and Availability" now supports per-country pricing
 
+### PPP Pricing Playbook
+
+Apple's automatic price equalization converts currency — it ignores purchasing-power differences. Set **manual per-storefront prices** for India, Brazil, Turkey, and Indonesia (commonly a 2-5x paid-conversion lift in those markets):
+
+- Pick from the storefront's price-point list near **local psychological thresholds** (₹99/₹199, R$9,90, ₺49,99, Rp29.000) — not the auto-converted value
+- Revisit annually — currency swings quietly break threshold pricing
+- Keep US/EU prices anchored; PPP cuts are for PPP markets only
+
 ## When to Change Your Price
 
 **Raise prices when:**

--- a/skills/product/beta-testing/SKILL.md
+++ b/skills/product/beta-testing/SKILL.md
@@ -59,6 +59,10 @@ Before recruiting testers, understand Apple's two-tier beta system.
 - Stress-testing with diverse devices, OS versions, and usage patterns
 - Gathering signal on whether the value proposition resonates
 
+#### The Public-Link Waitlist Play
+
+Publish your TestFlight **public link** on your landing page and socials as a pre-launch waitlist — up to 10,000 external testers with zero email-collection infrastructure. Testers convert to day-one installers and early reviewers at launch, feeding the first-48-hours velocity that new apps get ranked on.
+
 #### Group Management
 
 Create tester cohorts for targeted feedback:


### PR DESCRIPTION
## What

Turns the 54-item P0–P9 App Store growth master sequence into library skills, and closes the gaps a two-repo coverage analysis found (11 items covered nowhere, ~25 only partially).

### 5 new skills (147 → 152)

| Skill | Covers |
|---|---|
| `growth/store-growth-audit` | The centerpiece: all 54 items as an auditable checklist — each with a **detection rule** (ASC MCP read / codebase grep / explicit question), ✅🟠🔴⚪⏳ thresholds, and a fix-route to the sibling skill. Existing-app audit + re-audit deltas, or pre-launch growth plan. Backs the upcoming SwiftShip `/apple:growth` command. |
| `app-store/ratings-mechanics` | Per-storefront ratings isolation, the never-reset rule, phased + manual release as rating armor |
| `app-store/web-presence` | apps.apple.com Google SEO, landing page + Smart App Banner, deal-site price-drop ecosystem |
| `monetization/external-purchases` | US External Purchase Link entitlement (0%-commission era), commission-flip architecture, day-one analytics |
| `monetization/bundles-and-licensing` | Own-app bundles, Family Sharing, cross-developer suites, Group/Volume Purchasing (announced) |

### 13 existing skills upgraded
Developer-name indexing, Apple AI tagging, ASA search-term keyword refresh (keyword-optimizer); discovery-as-research + ASA→organic halo + CPP pairing (apple-search-ads); peer-group benchmarks (analytics-interpretation); pre-shipped alternate icons (PPO); PPP pricing (pricing-models); regional pre-orders; TestFlight public-link waitlist (beta-testing); announced badge types (in-app-events); Retention Messaging (win-back-offers); distribution levers (marketing-strategy); Creative Assets (screenshot-planner); US external-purchase nuance replacing the outdated "never external links" framing (rejection-handler, streak-tracker).

### Guardrails
- Announced-but-unshipped features (Creative Assets, Retention Messaging, Group/Volume Purchasing) carry `> Status: announced (WWDC26) — verify availability in App Store Connect before executing.` plus dormant detection rules — the freshness tripwire stays honest.
- Closes pre-existing index drift: `app-store/SKILL.md` + `growth/SKILL.md` Available Skills were missing iap-finalizer / originality-check / store-signals; ROADMAP category rows for app-store/growth/monetization brought current. (Other ROADMAP rows — e.g. generators/ 52 vs actual 63 — remain stale; left out of scope.)

### Verification
`check-counts.sh`, `check-frontmatter.sh`, `check-freshness.sh` all pass locally.

### Follow-up
A companion SwiftShip PR adds `/apple:growth` (command + `templates/GROWTH.md`) referencing `growth/store-growth-audit` — it needs this PR merged to main first (SwiftShip CI resolves skill refs against this repo's main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)