### PR TITLE
fix: README per-skill tables missing the 5 new skills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ from the local copy (see "Pinning and rollback" in the README).
 - `scripts/check-counts.sh` now also guards `docs/ROADMAP.md`, `plugin.json`, and `.claude-plugin/marketplace.json` counts
 
 ### Fixed
+- README detail drift: the Growth/Monetization/App Store per-skill tables and directory-tree comments were missing the five new skills (only the summary-table counts are CI-guarded)
 - Category index drift: `app-store/SKILL.md` and `growth/SKILL.md` "Available Skills" were missing previously added members (iap-finalizer, originality-check, store-signals); `docs/ROADMAP.md` per-category rows for app-store/growth/monetization brought current
 - `check-counts.sh` cross-repo check pointed at `commands/apple/` but SwiftShip's commands live at `commands/` — the count guard could never fire; README docs table now lists CHANGELOG.md
 - Stale recency claims in paywall-generator, test-spec, live-activity-generator, usage-insights, ci-cd-setup

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ skills/
 │   ├── app-extensions/
 │   ├── data-export/
 │   └── ... (63 total)
-├── growth/                 # Analytics, store signals, press/media, community, indie business (5 skills)
+├── growth/                 # Growth audit, analytics, store signals, press/media, community, indie business (6 skills)
 ├── legal/                  # Privacy policies, terms of service, EULAs
 ├── core-ml/                # Vision, NaturalLanguage, model integration
 ├── swiftui/                # AlarmKit, WebKit, text editing, toolbars, Charts 3D
@@ -129,8 +129,8 @@ skills/
 ├── foundation/             # AttributedString updates
 ├── visionos/               # visionOS widgets
 ├── testing/                # TDD workflows, test infrastructure, snapshot tests, flow walkthrough (9 skills)
-├── monetization/           # Pricing strategy, tiers, free trials
-├── app-store/              # ASO, descriptions, screenshots, reviews, search ads, rejections, originality, IAP finalize (9 skills)
+├── monetization/           # Pricing strategy, tiers, free trials, external purchases, bundles & licensing (3 skills)
+├── app-store/              # ASO, descriptions, screenshots, reviews, search ads, rejections, originality, IAP finalize, ratings, web presence (11 skills)
 ├── watchos/                # Watch apps, complications, health/fitness, widgets
 ├── release-review/         # Security, privacy, UX, distribution audits
 ├── shared/                 # Meta-skills: skill-creator, skill-auditor
@@ -222,6 +222,7 @@ Generate production-ready Swift code that adapts to your project:
 | Skill | What It Does |
 |-------|--------------|
 | `analytics-interpretation` | Interpret app metrics, AARRR funnels, decision trees |
+| `store-growth-audit` | Stage-by-stage audit of an app's growth machinery — 54 levers (P0–P9), each detected via ASC/codebase evidence and routed to its fix (read-only ASC) |
 | `store-signals` | Turn live reviews/analytics/sales/crashes into a metric-tagged backlog + verify last cycle (read-only ASC) |
 | `press-media` | Press kit, journalist outreach, pitch templates |
 | `community-building` | Social media, building in public, content strategy |
@@ -259,6 +260,8 @@ Generate production-ready Swift code that adapts to your project:
 | Skill | What It Does |
 |-------|--------------|
 | `monetization` | Readiness assessment, pricing model selection, tier structure, free trial strategy |
+| `external-purchases` | US web checkout via the External Purchase Link entitlement — 0%-commission era, commission-flip architecture |
+| `bundles-and-licensing` | Own-app bundles, Family Sharing, cross-developer suites, Group/Volume Purchasing (announced) |
 
 ## SwiftUI Skills
 
@@ -289,6 +292,8 @@ Generate production-ready Swift code that adapts to your project:
 | `rejection-handler` | Handle rejections, response templates, appeals |
 | `originality-check` | Guideline-4.3 anti-spam gate: function/content/metadata distinctness before build or submit |
 | `iap-finalizer` | Finalize one-time IAP price + localization in ASC (dry-run) |
+| `ratings-mechanics` | Per-storefront ratings isolation, never-reset rule, phased + manual release as rating armor |
+| `web-presence` | apps.apple.com SEO, landing page + Smart App Banner, deal-site price-drop ecosystem |
 | `marketing-strategy` | Comprehensive promotional strategy |
 
 ## Security Skills


### PR DESCRIPTION
"Is the README up to date?" — the CI-guarded counts were, but the detailed sections weren't: the Growth/Monetization/App Store per-skill tables and the directory-tree comments never picked up the five skills added in #27. This adds those rows (with one-line descriptions matching the tables' style) and updates the three tree comments.

Only the summary-table counts are enforced by `check-counts.sh` — noting for a future hardening pass that the detail tables could get the same guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)