### PR TITLE
feat: listings guard in check-counts.sh + close all exposed drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ from the local copy (see "Pinning and rollback" in the README).
 ## [Unreleased]
 
 ### Added
+- `check-counts.sh` now guards **listings**, not just counts: README per-skill tables, category `## Available Skills` indexes, and ROADMAP's category name lists must each name every skill in the tree — the drift class where counts get bumped but names never land is now CI-impossible
 - `growth/store-growth-audit`: **Scoped Runs** — audit a single phase (`P3`, or a range like `P1-P3`): evidence batches subset to the scope, only in-scope scorecard rows update, output is the phase worklist instead of the top-5
 - `growth/store-growth-audit` — the 54-item P0–P9 store-growth playbook as an auditable checklist (SKILL.md + detection-playbook + two phase checklists); every item scored via ASC MCP read / codebase grep / explicit question, routed to the skill that fixes it; backs SwiftShip's `/apple:growth`
 - `app-store/ratings-mechanics` — per-storefront ratings isolation, the never-reset rule, phased + manual release as rating armor
@@ -35,6 +36,7 @@ from the local copy (see "Pinning and rollback" in the README).
 - `scripts/check-counts.sh` now also guards `docs/ROADMAP.md`, `plugin.json`, and `.claude-plugin/marketplace.json` counts
 
 ### Fixed
+- Listing drift the new guard exposed: `design`/`legal`/`testing` category indexes were missing ui-prototyping, privacy-publish, flow-walkthrough; ROADMAP name lists were missing 17 skills (the 11 store-feature generators, run-simulator/run-device, app-namer, and the three above) with stale row counts
 - README detail drift: the Growth/Monetization/App Store per-skill tables and directory-tree comments were missing the five new skills (only the summary-table counts are CI-guarded)
 - Category index drift: `app-store/SKILL.md` and `growth/SKILL.md` "Available Skills" were missing previously added members (iap-finalizer, originality-check, store-signals); `docs/ROADMAP.md` per-category rows for app-store/growth/monetization brought current
 - `check-counts.sh` cross-repo check pointed at `commands/apple/` but SwiftShip's commands live at `commands/` — the count guard could never fire; README docs table now lists CHANGELOG.md

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -181,18 +181,18 @@ Apple docs location: `/Users/ravishankar/Downloads/docs/`
 
 | Category | Count | Skills |
 |----------|-------|--------|
-| generators/ | 52 | logging-setup, analytics-setup, networking-layer, auth-flow, paywall-generator, settings-screen, persistence-setup, onboarding-generator, review-prompt, error-monitoring, ci-cd-setup, localization-setup, push-notifications, deep-linking, test-generator, accessibility-generator, widget-generator, app-icon-generator, feature-flags, live-activity-generator, tipkit-generator, cloudkit-sync, http-cache, pagination, image-loading, share-card, social-export, subscription-lifecycle, referral-system, watermark-engine, streak-tracker, milestone-celebration, whats-new, lapsed-user, usage-insights, variable-rewards, consent-flow, account-deletion, permission-priming, force-update, state-restoration, debug-menu, offline-queue, feedback-form, announcement-banner, quick-win-session, spotlight-indexing, app-clip, screenshot-automation, background-processing, app-extensions, data-export |
-| product/ | 13 | idea-generator, product-agent, competitive-analysis, market-research, prd-generator, architecture-spec, ux-spec, implementation-guide, implementation-spec, test-spec, release-spec, beta-testing, localization-strategy |
+| generators/ | 63 | logging-setup, analytics-setup, networking-layer, auth-flow, paywall-generator, settings-screen, persistence-setup, onboarding-generator, review-prompt, error-monitoring, ci-cd-setup, localization-setup, push-notifications, deep-linking, test-generator, accessibility-generator, widget-generator, app-icon-generator, feature-flags, live-activity-generator, tipkit-generator, cloudkit-sync, http-cache, pagination, image-loading, share-card, social-export, subscription-lifecycle, referral-system, watermark-engine, streak-tracker, milestone-celebration, whats-new, lapsed-user, usage-insights, variable-rewards, consent-flow, account-deletion, permission-priming, force-update, state-restoration, debug-menu, offline-queue, feedback-form, announcement-banner, quick-win-session, spotlight-indexing, app-clip, screenshot-automation, background-processing, app-extensions, data-export, subscription-offers, win-back-offers, promoted-iap, in-app-events, custom-product-pages, product-page-optimization, featuring-nomination, offer-codes-setup, pre-orders, app-store-assets, preview-data-generator |
+| product/ | 14 | idea-generator, product-agent, app-namer, competitive-analysis, market-research, prd-generator, architecture-spec, ux-spec, implementation-guide, implementation-spec, test-spec, release-spec, beta-testing, localization-strategy |
 | macos/ | 8 | app-planner, coding-best-practices, architecture-patterns, swiftdata-architecture, ui-review-tahoe, macos-tahoe-apis, macos-capabilities, appkit-swiftui-bridge |
-| testing/ | 8 | characterization-test-generator, tdd-bug-fix, tdd-feature, test-contract, tdd-refactor-guard, snapshot-test-setup, test-data-factory, integration-test-scaffold |
+| testing/ | 9 | characterization-test-generator, tdd-bug-fix, tdd-feature, test-contract, tdd-refactor-guard, snapshot-test-setup, test-data-factory, integration-test-scaffold, flow-walkthrough |
 | app-store/ | 11 | keyword-optimizer, app-description-writer, screenshot-planner, review-response-writer, marketing-strategy, apple-search-ads, rejection-handler, originality-check, iap-finalizer, ratings-mechanics, web-presence |
-| ios/ | 7 | coding-best-practices, ui-review, app-planner, navigation-patterns, ipad-patterns, migration-patterns, assistive-access |
+| ios/ | 9 | coding-best-practices, ui-review, app-planner, navigation-patterns, ipad-patterns, migration-patterns, assistive-access, run-simulator, run-device |
 | swiftui/ | 5 | alarmkit, webkit, text-editing, toolbars, charts-3d |
 | growth/ | 6 | analytics-interpretation, press-media, community-building, indie-business, store-signals, store-growth-audit |
 | swift/ | 3 | concurrency-patterns, concurrency, memory |
 | apple-intelligence/ | 3 | foundation-models, visual-intelligence, app-intents |
-| design/ | 2 | liquid-glass, animation-patterns |
-| legal/ | 2 | privacy-policy |
+| design/ | 3 | liquid-glass, animation-patterns, ui-prototyping |
+| legal/ | 2 | privacy-policy, privacy-publish |
 | performance/ | 2 | profiling, swiftui-debugging |
 | security/ | 2 | security, privacy-manifests |
 | core-ml/ | 1 | core-ml (with patterns.md, templates.md) |

--- a/scripts/check-counts.sh
+++ b/scripts/check-counts.sh
@@ -114,7 +114,50 @@ for d in $(find skills -mindepth 1 -maxdepth 1 -type d ! -name "_shared" -exec b
         || fail "skills/$d exists but has no row mapping in this script — add it to PAIRS and the README table"
 done
 
-# --- 4. Cross-repo: SwiftShip command count (skipped if no sibling checkout) --
+# --- 4. Listings match the tree (README tables, category indexes, ROADMAP) ----
+# Counts alone let name lists rot (a skill lands, the table row count is bumped,
+# but the skill is never *named*). Three surfaces claim per-skill name coverage:
+echo ""
+echo "== Listings match the tree =="
+LISTED=0
+
+# 4a. README per-skill tables — categories that have one must name every skill.
+#     Give a new category a README table? Add it here.
+README_TABLE_CATS="generators growth legal testing monetization swiftui performance app-store security"
+for cat in $README_TABLE_CATS; do
+    for f in $(find "skills/$cat" -mindepth 2 -maxdepth 2 -name "SKILL.md" 2>/dev/null); do
+        s=$(basename "$(dirname "$f")")
+        grep -q "$s" README.md \
+            || fail "README: skills/$cat/$s is not named in its per-skill table"
+        LISTED=$((LISTED + 1))
+    done
+done
+
+# 4b. Category indexes — a SKILL.md with an '## Available Skills' section must
+#     name every member skill.
+for idx in skills/*/SKILL.md; do
+    grep -q "## Available Skills" "$idx" || continue
+    catdir=$(dirname "$idx")
+    for f in $(find "$catdir" -mindepth 2 -maxdepth 2 -name "SKILL.md"); do
+        s=$(basename "$(dirname "$f")")
+        grep -q "$s" "$idx" \
+            || fail "$idx: 'Available Skills' does not name $s"
+        LISTED=$((LISTED + 1))
+    done
+done
+
+# 4c. ROADMAP's 'Skills by Category' name lists claim full coverage — every
+#     skill dir must be named somewhere in docs/ROADMAP.md.
+for f in $(find skills -mindepth 3 -maxdepth 3 -name "SKILL.md" ! -path "skills/_shared/*"); do
+    s=$(basename "$(dirname "$f")")
+    c=$(basename "$(dirname "$(dirname "$f")")")
+    grep -q "$s" docs/ROADMAP.md \
+        || fail "docs/ROADMAP.md: $c/$s is not named in any category row"
+    LISTED=$((LISTED + 1))
+done
+echo "  checked $LISTED listing entries"
+
+# --- 5. Cross-repo: SwiftShip command count (skipped if no sibling checkout) --
 echo ""
 echo "== Cross-repo counts =="
 # SwiftShip's commands live at commands/*.md — the /apple: prefix comes from

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -41,6 +41,9 @@ SwiftUI animation patterns for iOS 13–18+.
 - SF Symbol effects
 - Animation completions, transactions, timing curves
 
+### ui-prototyping/
+Explore divergent UI directions for a screen as named, runnable Swift `#Preview` variants — compare, remix, and tune before committing to one design.
+
 ## Key Principles
 
 ### 1. Platform Consistency

--- a/skills/legal/SKILL.md
+++ b/skills/legal/SKILL.md
@@ -24,6 +24,9 @@ Use this skill when the user:
 ### privacy-policy/
 Generate privacy policies, terms of service, and EULAs tailored to your app's data collection practices, third-party SDKs, and target regions. Includes Apple Privacy Nutrition Label mapping and hosting guidance.
 
+### privacy-publish/
+Publish the generated legal pages to hosted URLs and set the App Store Connect Privacy Policy / Support URLs via the ASC API (dry-run first).
+
 ## How to Use
 
 1. User requests legal documents or compliance guidance

--- a/skills/testing/SKILL.md
+++ b/skills/testing/SKILL.md
@@ -50,6 +50,9 @@ Test fixture factories for your models. Makes writing tests faster by eliminatin
 **integration-test-scaffold/**
 Cross-module test harness with mock servers, in-memory stores, and test configuration. For testing networking + persistence + business logic together.
 
+**flow-walkthrough/**
+Drive each user flow in the Simulator (XCUITest + per-step screenshots), audit the navigation graph for dead-ends, and run a human discoverability check.
+
 ## How to Use
 
 1. Identify whether user is working on **new code** or **existing code**


### PR DESCRIPTION
Follow-up to #30's observation: only summary-table **counts** were CI-guarded, so per-skill **name lists** could rot silently. This makes that class of drift impossible.

## The guard (new §4 in `check-counts.sh`)

Three surfaces claim per-skill name coverage; each must now name every skill in the tree:

1. **README per-skill tables** — for the 9 categories that have one (`README_TABLE_CATS`, extend when a new category gets a table)
2. **Category `## Available Skills` indexes** — any category SKILL.md with that section
3. **ROADMAP "Skills by Category" name lists** — every skill dir must appear somewhere in `docs/ROADMAP.md`

Negative-tested: a fake `skills/growth/fake-drift-test/` trips all three checks (plus the count checks) and the tree passes clean after removal. 293 listing entries verified.

## Drift it exposed (fixed here)

- `design`/`legal`/`testing` category indexes were missing **ui-prototyping**, **privacy-publish**, **flow-walkthrough**
- ROADMAP name lists were missing **17 skills** — the 11 store-feature generators (subscription-offers → preview-data-generator), run-simulator/run-device, app-namer, plus the three above — with stale row counts (generators 52→63, product 13→14, testing 8→9, ios 7→9, design 2→3, legal names)

All four CI gates pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)