### PR TITLE
fix: README per-skill tables for Design + visionOS, guarded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ from the local copy (see "Pinning and rollback" in the README).
 - `scripts/check-counts.sh` now also guards `docs/ROADMAP.md`, `plugin.json`, and `.claude-plugin/marketplace.json` counts
 
 ### Fixed
+- README gains Design (7) and visionOS (2) per-skill tables, both now covered by the listings guard (README_TABLE_CATS += design visionos)
 - Listing drift the new guard exposed: `design`/`legal`/`testing` category indexes were missing ui-prototyping, privacy-publish, flow-walkthrough; ROADMAP name lists were missing 17 skills (the 11 store-feature generators, run-simulator/run-device, app-namer, and the three above) with stale row counts
 - README detail drift: the Growth/Monetization/App Store per-skill tables and directory-tree comments were missing the five new skills (only the summary-table counts are CI-guarded)
 - Category index drift: `app-store/SKILL.md` and `growth/SKILL.md` "Available Skills" were missing previously added members (iap-finalizer, originality-check, store-signals); `docs/ROADMAP.md` per-category rows for app-store/growth/monetization brought current

--- a/README.md
+++ b/README.md
@@ -263,6 +263,25 @@ Generate production-ready Swift code that adapts to your project:
 | `external-purchases` | US web checkout via the External Purchase Link entitlement — 0%-commission era, commission-flip architecture |
 | `bundles-and-licensing` | Own-app bundles, Family Sharing, cross-developer suites, Group/Volume Purchasing (announced) |
 
+## Design Skills
+
+| Skill | What It Covers |
+|-------|----------------|
+| `design/liquid-glass` | Liquid Glass implementation + design rules (SwiftUI/AppKit/UIKit, never glass-on-glass, Regular vs Clear) |
+| `design/animation-patterns` | Springs, PhaseAnimator/KeyframeAnimator, transitions (incl. zoom + interruptibility), symbol effects |
+| `design/ui-prototyping` | Divergent UI directions as named #Preview variants — go wide, remix, tune |
+| `design/design-principles` | The evergreen canon: wayfinding, discoverability, fluid-gesture physics, idea→interface process |
+| `design/ux-writing` | Interface copy: PACE framework, voice/tone, alert anatomy, feature naming |
+| `design/sf-symbols` | Choosing/configuring symbols, custom-symbol authoring, animation vocabulary |
+| `design/typography` | Text styles, Dynamic Type, optical sizes, the SF family + width axis |
+
+## visionOS Skills
+
+| Skill | What It Covers |
+|-------|----------------|
+| `visionos/spatial-design` | Spatial layout ergonomics, eyes-and-hands input, motion comfort, immersion, environment budgets |
+| `visionos/widgets` | Mounting styles, glass/paper textures, proximity-aware layouts, spatial families |
+
 ## SwiftUI Skills
 
 | Skill | What It Covers |

--- a/scripts/check-counts.sh
+++ b/scripts/check-counts.sh
@@ -123,7 +123,7 @@ LISTED=0
 
 # 4a. README per-skill tables — categories that have one must name every skill.
 #     Give a new category a README table? Add it here.
-README_TABLE_CATS="generators growth legal testing monetization swiftui performance app-store security"
+README_TABLE_CATS="generators growth legal testing monetization swiftui performance app-store security design visionos"
 for cat in $README_TABLE_CATS; do
     for f in $(find "skills/$cat" -mindepth 2 -maxdepth 2 -name "SKILL.md" 2>/dev/null); do
         s=$(basename "$(dirname "$f")")


### PR DESCRIPTION
Follow-up to the design/spatial harvests: Design (now 7 skills) and visionOS (now 2) had no README per-skill detail tables — and weren't in the listings guard's category list, making them the last unguarded README drift hole. This adds both tables and extends `README_TABLE_CATS` so `check-counts.sh` enforces them permanently (now 315 listing entries verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)