### PR TITLE
chore: route review replies to /apple:ratings + cross-count 50 → 51

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ from the local copy (see "Pinning and rollback" in the README).
 - App Store Guidelines risk sections in the five engagement-mechanic generators (variable-rewards, streak-tracker, milestone-celebration, watermark-engine, quick-win-session), cross-linked to `app-store/originality-check`
 
 ### Changed
+- Audit routes updated for SwiftShip's new /apple:ratings: P4.2 fix-route and the routing map now point review replies at the gated command; README stack-table row bumped to 51 /apple:* commands
 - store-growth-audit watchlist graduations, verified against WWDC26 transcripts: P5.3 Creative Assets (Asset Library live, renders on iOS 27), P8.3 Retention Messaging (ASC tier open to all; real-time API access-gated), P8.6 Group/Volume Purchasing (live for StoreKit 2 subs, on by default) — all three moved from ⏳ announced to live detection rules; P1.7 extended with App Store Tags curation, P5.2 with keyword→CPP routing
 - skill-auditor known-current constants bumped to the iOS 27 / WWDC26 era; M-02 now defers to `scripts/versions.env` as the normative source
 - `scripts/check-counts.sh` now also guards `docs/ROADMAP.md`, `plugin.json`, and `.claude-plugin/marketplace.json` counts
@@ -60,6 +61,7 @@ from the local copy (see "Pinning and rollback" in the README).
 - ASC-automation skills: `iap-finalizer`, `privacy-publish`, `_shared/asc-api` (#13)
 
 ### Changed
+- Audit routes updated for SwiftShip's new /apple:ratings: P4.2 fix-route and the routing map now point review replies at the gated command; README stack-table row bumped to 51 /apple:* commands
 - All documented counts synced to reality (147) with `scripts/check-counts.sh` making drift impossible (#17)
 - App Annie reference replaced with vendor-neutral app intelligence tools (#25)
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Four repos, four layers — use one or all:
 | Layer | Repo | What it is |
 |---|---|---|
 | Knowledge | **claude-code-apple-skills** ← you are here | 160 skills — how to build right |
-| Workflow | [SwiftShip](https://github.com/rshankras/SwiftShip) | 50 /apple:* commands — spec-driven idea → App Store |
+| Workflow | [SwiftShip](https://github.com/rshankras/SwiftShip) | 51 /apple:* commands — spec-driven idea → App Store |
 | Action | [indie-app-autopilot](https://github.com/rshankras/indie-app-autopilot) | 7 agents — GitHub issue → App Store |
 | Integration | [asc-metadata-mcp](https://github.com/rshankras/asc-metadata-mcp) | 65+ MCP tools — live App Store Connect API |
 

--- a/skills/growth/store-growth-audit/SKILL.md
+++ b/skills/growth/store-growth-audit/SKILL.md
@@ -190,7 +190,7 @@ The only place the full route list lives; stanzas carry the short form.
 | Icon + PPO + CPP experiments | `generators/product-page-optimization`, `generators/custom-product-pages` | `/apple:experiment` |
 | In-app events | `generators/in-app-events` | `/apple:event` |
 | Localization + PPP pricing | `product/localization-strategy`, `monetization` (pricing-models) | `/apple:localize` |
-| Ratings: prompting, replies, protection | `app-store/ratings-mechanics`, `generators/review-prompt`, `app-store/review-response-writer` | `/apple:ship` (phased release) |
+| Ratings: prompting, replies, protection | `app-store/ratings-mechanics`, `generators/review-prompt`, `app-store/review-response-writer` | `/apple:ratings` (health + replies); `/apple:ship` (phased release) |
 | Featuring nominations | `generators/featuring-nomination` | — (ASC manual, calendar-driven) |
 | New-OS adoption | — | `/apple:modernize` |
 | App Intents / Spotlight | `apple-intelligence/app-intents`, `generators/spotlight-indexing` | `/apple:plan` |

--- a/skills/growth/store-growth-audit/audit-checklist-p0-p4.md
+++ b/skills/growth/store-growth-audit/audit-checklist-p0-p4.md
@@ -149,7 +149,7 @@ Evidence keys (`EV.*`) are defined in `detection-playbook.md`. IDs are stable �
 - detect: MCP `EV.reviews`
 - rule: ✅ 1–3★ reviews from the last 90 days have developer responses · 🟠 some answered · 🔴 none answered (updated ratings replace old scores — replies are recoverable stars)
 - new-app: defer — activates with first reviews
-- fix: app-store/review-response-writer → route replies via ASC (surfaced by /apple:learn-from-store)
+- fix: app-store/review-response-writer → /apple:ratings (gated replies via the ASC API)
 
 #### P4.3 Phased release + manual version release habit
 - detect: MANUAL Q7


### PR DESCRIPTION
Follow-up to [SwiftShip#56](https://github.com/rshankras/SwiftShip/pull/56) (`/apple:ratings`): the growth audit's P4.2 fix-route and the routing map now point review replies at the gated command instead of dead-ending at manual ASC, and the README stack-table row matches SwiftShip's 51 commands (keeps the local cross-repo count guard green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)