### PR TITLE
chore: SwiftShip cross-count 51 → 52 + fix stale '49 commands' line

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Four repos, four layers — use one or all:
 | Layer | Repo | What it is |
 |---|---|---|
 | Knowledge | **claude-code-apple-skills** ← you are here | 161 skills — how to build right |
-| Workflow | [SwiftShip](https://github.com/rshankras/SwiftShip) | 51 /apple:* commands — spec-driven idea → App Store |
+| Workflow | [SwiftShip](https://github.com/rshankras/SwiftShip) | 52 /apple:* commands — spec-driven idea → App Store |
 | Action | [indie-app-autopilot](https://github.com/rshankras/indie-app-autopilot) | 7 agents — GitHub issue → App Store |
 | Integration | [asc-metadata-mcp](https://github.com/rshankras/asc-metadata-mcp) | 65+ MCP tools — live App Store Connect API |
 
@@ -73,7 +73,7 @@ demand, so only 23 short descriptions sit in context. Update any time with
 always track `main`.
 
 Want the full workflow too? The same marketplace carries
-[SwiftShip](https://github.com/rshankras/SwiftShip)'s 49 `/apple:*` commands:
+[SwiftShip](https://github.com/rshankras/SwiftShip) — 52 /apple:* commands:
 
 ```
 /plugin install apple@indie-apple-stack


### PR DESCRIPTION
Companion to [SwiftShip#57](https://github.com/rshankras/SwiftShip/pull/57), which adds `/apple:accessibility` — the 52nd command, backed by the `ios/accessibility-audit` skill from #43 — and routes that skill through the existing commands.

Two one-line changes to `README.md`:

1. **Stack table: `51` → `52` `/apple:* commands`.** Required — `check-counts.sh` greps this line against SwiftShip's actual command-file count, so it goes red the moment SwiftShip#57 merges.
2. **The second SwiftShip mention said "49 commands"** — stale by two rounds, and *invisible to the checker*: the backticks around `` `/apple:*` `` broke `check-counts.sh`'s `grep -qF "$CMDS /apple:* commands"` pattern, so it silently rotted. Reworded so the checker now guards it too.

`./scripts/check-counts.sh` passes against a SwiftShip checkout with the new command (`SwiftShip: 52 commands`).

Land alongside SwiftShip#57 (either order — this repo's CI only cross-checks when a SwiftShip checkout is present).

🤖 Generated with [Claude Code](https://claude.com/claude-code)