### PR TITLE
fix: marketplace.json advertised 49 SwiftShip commands (real count 52) + guard it

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -21,7 +21,7 @@
         "source": "url",
         "url": "https://github.com/rshankras/SwiftShip.git"
       },
-      "description": "SwiftShip \u2014 49 /apple:* workflow commands + 6 pinned agents: idea validation, roadmap, plan, build, review, TestFlight, App Store submission, and post-launch growth. Install apple-skills alongside it (its commands read that library).",
+      "description": "SwiftShip \u2014 52 /apple:* workflow commands + 6 pinned agents: idea validation, roadmap, plan, build, review, TestFlight, App Store submission, and post-launch growth. Install apple-skills alongside it (its commands read that library).",
       "displayName": "SwiftShip"
     }
   ]

--- a/scripts/check-counts.sh
+++ b/scripts/check-counts.sh
@@ -157,19 +157,52 @@ for f in $(find skills -mindepth 3 -maxdepth 3 -name "SKILL.md" ! -path "skills/
 done
 echo "  checked $LISTED listing entries"
 
-# --- 5. Cross-repo: SwiftShip command count (skipped if no sibling checkout) --
+# --- 5. Cross-repo: SwiftShip command count ----------------------------------
 echo ""
-echo "== Cross-repo counts =="
-# SwiftShip's commands live at commands/*.md — the /apple: prefix comes from
-# the plugin name, not a subdirectory.
+echo "== Cross-repo counts (SwiftShip) =="
+# History: marketplace.json advertised "49 /apple:* workflow commands" while the
+# README said 52 — i.e. the copy users read *in the install prompt* was the one
+# that rotted. The old check missed it twice over: it grepped only README.md,
+# and its single grep -qF passed if ANY line matched, so a second stale README
+# mention would also have slid through. It also ran only when a sibling
+# SwiftShip checkout happened to exist — never true on CI — so in practice it
+# was dead code.
+#
+# Two arms now, and the first one always runs:
+#   a) internal consistency — every surface that states the count must state the
+#      SAME count. Needs no checkout, so CI enforces it.
+#   b) ground truth — when a SwiftShip checkout IS present (local dev, or CI if
+#      a checkout step is ever added), that agreed count must equal the real
+#      number of commands/*.md files.
+#
+# Surfaces state the count in two phrasings ("N /apple:* commands" in README,
+# "N /apple:* workflow commands" in marketplace.json), so match the common
+# "N /apple:*" prefix rather than either full phrase.
 SWIFTSHIP="${SWIFTSHIP_DIR:-$REPO_DIR/../SwiftShip}"
-if [ -d "$SWIFTSHIP/commands" ]; then
-    CMDS=$(ls "$SWIFTSHIP"/commands/*.md 2>/dev/null | wc -l | tr -d ' ')
-    grep -qF "$CMDS /apple:* commands" README.md \
-        || fail "README stack table: SwiftShip row says stale command count (checkout has $CMDS)"
-    echo "  SwiftShip: $CMDS commands"
+SS_SURFACES="README.md .claude-plugin/marketplace.json"
+# shellcheck disable=SC2086
+SS_MENTIONS=$(grep -ohE '[0-9]+ /apple:\*' $SS_SURFACES)
+SS_N=$(printf '%s\n' "$SS_MENTIONS" | grep -c '[0-9]')
+
+# Vacuity guard: if a rewording drops the phrase, this check must fail loudly
+# rather than quietly verify nothing. Today: README x2, marketplace.json x1.
+if [ "$SS_N" -lt 3 ]; then
+    fail "expected >=3 SwiftShip command-count mentions across $SS_SURFACES, found $SS_N — did the wording change? Update this check, don't delete it"
 else
-    echo "  (no SwiftShip checkout at $SWIFTSHIP — skipping command-count check)"
+    SS_STATED=$(printf '%s\n' "$SS_MENTIONS" | grep -oE '^[0-9]+' | sort -u)
+    if [ "$(printf '%s\n' "$SS_STATED" | wc -l | tr -d ' ')" -ne 1 ]; then
+        fail "SwiftShip command count disagrees across surfaces ($(printf '%s' "$SS_STATED" | tr '\n' '/')) — README.md and .claude-plugin/marketplace.json must state the same number"
+    else
+        echo "  $SS_N mentions agree on $SS_STATED commands"
+        if [ -d "$SWIFTSHIP/commands" ]; then
+            CMDS=$(find "$SWIFTSHIP/commands" -maxdepth 1 -name '*.md' | wc -l | tr -d ' ')
+            [ "$SS_STATED" -eq "$CMDS" ] \
+                || fail "docs say $SS_STATED SwiftShip commands but the checkout at $SWIFTSHIP has $CMDS"
+            echo "  ground truth: $SWIFTSHIP has $CMDS commands"
+        else
+            echo "  (no SwiftShip checkout at $SWIFTSHIP — internal consistency checked, ground truth skipped)"
+        fi
+    fi
 fi
 
 # --- Result -------------------------------------------------------------------


### PR DESCRIPTION
## Changes

- `.claude-plugin/marketplace.json`: SwiftShip plugin description said **49 /apple:\* workflow commands**; the real count is **52** (verified against a `SwiftShip` checkout — 52 files in `commands/`). The README was already correct at 52, so this was the manifest drifting alone.
- `scripts/check-counts.sh`: rewrote section 5 so this class of drift can't recur.

## Motivation

The marketplace description is the copy users read **in the plugin install prompt** — the worst surface for a stale number.

`check-counts.sh` already had a SwiftShip section that was supposed to catch this, but it couldn't fire, for three independent reasons:

1. It grepped only `README.md`, never the plugin manifests.
2. Its single `grep -qF` passed if **any** line matched — so a second, stale README mention would also have slid through.
3. It ran only when a sibling SwiftShip checkout happened to exist — never true on CI — so in practice it was dead code.

Running the old script immediately before this change confirms it: green, with `49` sitting in the manifest.

Section 5 now has two arms:

- **Internal consistency** — every surface stating the count must state the *same* count. Needs no checkout, so **CI enforces it**.
- **Ground truth** — that agreed count must equal the real `commands/*.md` count, whenever a checkout is present (local dev, or CI if a checkout step is ever added).

Plus a **vacuity guard**: if a rewording drops the phrase, the check fails loudly rather than quietly going back to verifying nothing.

## Testing

Clean state passes on both paths (with checkout, and the CI no-checkout path). Each drift mode was verified to **fail**, on a scratch copy:

| Drift mode | Result |
|---|---|
| Original bug re-introduced (manifest 49 vs README 52) | ✗ fails — "disagrees across surfaces (49/52)" |
| A *second* README mention goes stale (the `grep -qF` hole) | ✗ fails — "disagrees across surfaces (51/52)" |
| All surfaces agree on 60, real checkout has 52 | ✗ fails — ground-truth arm |
| Phrase reworded away | ✗ fails — vacuity guard |

Full suite green: `check-counts`, `check-frontmatter`, `check-freshness` (+ `--self-test`). `marketplace.json` still parses as valid JSON.

## Not done deliberately

No SwiftShip checkout step was added to `validate.yml`. It would give CI true ground truth, but it couples the repos — adding a command in SwiftShip would turn this repo's `main` red until someone bumped the number, breaking unrelated PRs. The existing hand-sync commits (e.g. `e003317`, "SwiftShip cross-count 51 -> 52") suggest that's a deliberate manual step. Easy to add if you'd rather CI own it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)