### PR TITLE
feat: Foundation Models iOS 27 harvest — fix deprecated error API + utilities package

### DIFF
--- a/skills/apple-intelligence/foundation-models/SKILL.md
+++ b/skills/apple-intelligence/foundation-models/SKILL.md
@@ -6,7 +6,7 @@ allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion]
 
 # Foundation Models
 
-Integrate Apple's on-device LLM into your apps for privacy-preserving AI features. Companion references: **safety-and-guardrails.md** (model limits, prompt design, the four-layer safety stack) and **models-and-agents.md** (Private Cloud Compute, `LanguageModel` protocol, vision input, `DynamicProfile` agentic sessions — the iOS 27 wave).
+Integrate Apple's on-device LLM into your apps for privacy-preserving AI features. Companion references: **safety-and-guardrails.md** (model limits, prompt design, the four-layer safety stack), **models-and-agents.md** (Private Cloud Compute, `LanguageModel` protocol, vision input, `DynamicProfile` agentic sessions — the iOS 27 wave), and **utilities-package.md** (Apple's open-source utilities package: OpenAI-compatible endpoints, just-in-time Skills, history compression).
 
 ## When This Skill Activates
 
@@ -370,22 +370,62 @@ final class ChatViewModel {
 
 ## Error Handling
 
+⚠️ **`LanguageModelSession.GenerationError` is deprecated at iOS 27 and becomes _unavailable_ when you rebuild with Xcode 27.** This is a hard break, not a warning: Apple's deprecation note says apps built with Xcode 26 keep catching the old error until you rebuild, and you *must* move to the new types before submitting from Xcode 27. Its nine cases were split across **three** enums by concern.
+
 ```swift
 do {
     let response = try await session.respond(to: prompt)
-} catch LanguageModelSession.GenerationError.exceededContextWindowSize {
-    // Context too large — recover by carrying a condensed transcript (below)
-} catch LanguageModelSession.GenerationError.guardrailViolation {
+
+// ── LanguageModelError — model-level, backend-agnostic (any LanguageModel) ──
+} catch LanguageModelError.contextSizeExceeded(let e) {
+    // e.contextSize / e.tokenCount — recover by condensing the transcript (below)
+} catch LanguageModelError.guardrailViolation {
     // Safety block: proactive features ignore silently;
     // user-initiated features explain + offer alternatives (see safety-and-guardrails.md)
-} catch LanguageModelSession.GenerationError.unsupportedLanguageOrLocale {
+} catch LanguageModelError.refusal(let e) {
+    // NOT a safety block — the model declined for its own reasons.
+    // e.explanation (and .explanationStream) say why. Surface it; don't retry blindly.
+} catch LanguageModelError.rateLimited(let e) {
+    // Server-backed models only. e.resetDate tells you when to retry, when known.
+} catch LanguageModelError.unsupportedLanguageOrLocale {
     // Also pre-check SystemLanguageModel.default.supportedLanguages before prompting
-} catch LanguageModelSession.GenerationError.cancelled {
-    // Request was cancelled
+} catch LanguageModelError.unsupportedCapability(let e) {
+    // The backend doesn't do e.capability (tools / vision / reasoning / guided generation).
+    // Capabilities are NOT uniform across models — see models-and-agents.md.
+} catch LanguageModelError.timeout {
+
+// ── LanguageModelSession.Error — you drove the session wrong ──
+} catch LanguageModelSession.Error.concurrentRequests {
+    // Gate submit on session.isResponding — one request per session
+} catch LanguageModelSession.Error.transcriptMutationWhileResponding {
+    // Mutate session.transcript only while isResponding == false
+
+// ── SystemLanguageModel.Error — on-device assets ──
+} catch SystemLanguageModel.Error.assetsUnavailable {
+    // Model assets not on device — check availability first (see Quick Start)
+
 } catch {
     print("Unexpected error: \(error)")
 }
 ```
+
+### Migrating off `GenerationError`
+
+| iOS 26 `GenerationError` | iOS 27 replacement |
+|---|---|
+| `exceededContextWindowSize` | `LanguageModelError.contextSizeExceeded` — now carries `contextSize` **and** `tokenCount` |
+| `guardrailViolation` | `LanguageModelError.guardrailViolation` |
+| `refusal` | `LanguageModelError.refusal` |
+| `rateLimited` | `LanguageModelError.rateLimited` — now carries `resetDate` |
+| `unsupportedGuide` | `LanguageModelError.unsupportedGenerationGuide` (renamed) |
+| `unsupportedLanguageOrLocale` | `LanguageModelError.unsupportedLanguageOrLocale` |
+| `concurrentRequests` | `LanguageModelSession.Error.concurrentRequests` (moved) |
+| `assetsUnavailable` | `SystemLanguageModel.Error.assetsUnavailable` (moved) |
+| `decodingFailure` | No documented successor — don't assume one; keep a `catch`-all |
+
+New in iOS 27 with no iOS 26 equivalent: `LanguageModelError.timeout`, `.unsupportedCapability`, `.unsupportedTranscriptContent`, and `LanguageModelSession.Error.transcriptMutationWhileResponding`.
+
+❌ There is **no** `.cancelled` case — on any of these enums, in any OS version. Cancellation surfaces as Swift's `CancellationError`, so `catch is CancellationError` (or just let it propagate); don't write a `catch GenerationError.cancelled`, which never compiled.
 
 ### Context-Overflow Recovery: Condense, Don't Discard (WWDC25 301)
 
@@ -521,16 +561,18 @@ func processLargeDocument(_ document: String) async throws -> [Summary] {
 ```swift
 // Deterministic output: greedy sampling, not temperature 0
 let response = try await session.respond(to: prompt,
-    options: GenerationOptions(sampling: .greedy))
+    options: GenerationOptions(samplingMode: .greedy))
 
 // Variance dial (scale runs to 2.0 — WWDC25 301)
 let lowVariance  = GenerationOptions(temperature: 0.5)
 let highVariance = GenerationOptions(temperature: 2.0)
 ```
 
+⚠️ The `sampling:` label — `GenerationOptions(sampling:)` and the `sampling` property — is **deprecated**; use **`samplingMode`**. Same type, same `.greedy` / `.random(top:seed:)` / `.random(probabilityThreshold:seed:)` values, new name.
+
 | Setting | Use Case |
 |-------------|----------|
-| `sampling: .greedy` | Deterministic outputs (tests, caching) — deterministic only per model version; OS model updates change outputs |
+| `samplingMode: .greedy` | Deterministic outputs (tests, caching) — deterministic only per model version; OS model updates change outputs |
 | 0.3-0.7 | Factual extraction, balanced tasks |
 | 1.0-2.0 | Creative writing, brainstorming |
 
@@ -622,7 +664,8 @@ Before shipping:
 ## References
 
 - **safety-and-guardrails.md** (this skill) — model limits, prompt design, guardrails, Swiss-cheese safety stack, evals
-- **models-and-agents.md** (this skill) — PCC, LanguageModel protocol, vision input, DynamicProfile agents, tool-calling modes, KV-cache rules
+- **models-and-agents.md** (this skill) — PCC, LanguageModel protocol, capabilities, vision in/out, custom segments, DynamicProfile agents, tool-calling modes, KV-cache rules
+- **utilities-package.md** (this skill) — `apple/foundation-models-utilities`: chat-completions endpoints, JIT Skills, history-compression modifiers
 - [WWDC25 — Meet the Foundation Models framework](https://developer.apple.com/videos/play/wwdc2025/286/)
 - [WWDC25 — Deep dive into the Foundation Models framework](https://developer.apple.com/videos/play/wwdc2025/301/)
 - [WWDC26 — What's new in the Foundation Models framework](https://developer.apple.com/videos/play/wwdc2026/241/)

--- a/skills/apple-intelligence/foundation-models/models-and-agents.md
+++ b/skills/apple-intelligence/foundation-models/models-and-agents.md
@@ -12,6 +12,12 @@ The WWDC26 layer of the Foundation Models framework: Private Cloud Compute, the 
 | Anthropic / Google Swift packages; Chat-Completions model (utilities package) | varies | Frontier server models as drop-in `LanguageModel` conformers — you handle auth + billing |
 
 - The **`LanguageModel` protocol** abstracts the backend: pass any conformer to `LanguageModelSession` and "everything downstream stays the same" — guided generation, tools, streaming all work.
+
+### ⚠️ Capabilities are not uniform across backends
+
+Every model declares a `LanguageModelCapabilities` set — `.toolCalling`, `.vision`, `.reasoning`, `.guidedGeneration`. Swapping the backend can silently swap away a capability your feature depends on. Ask for one the model didn't declare and the **framework throws `LanguageModelError.unsupportedCapability` for you** — you don't write defensive checks, but you *do* have to handle it.
+
+✅ Pick the model per feature, then confirm the feature's needs are in its capability set — especially `.guidedGeneration`, which many non-Apple and local backends don't truly enforce.
 - ❌ Never ship private API keys in the binary; ✅ fetch tokens via OAuth-style flows and store in the **Keychain** (Apple's explicit warning for third-party models).
 - Choose per-feature models by **privacy boundaries, capabilities, and cost** — e.g. brainstorming on PCC (creativity, breadth), quick review passes on-device (no server cost).
 - Token accounting for billing/budgets: `response.usage.input.totalTokenCount` / `.cachedTokenCount`, `.output.totalTokenCount` / `.reasoningTokenCount`.
@@ -30,6 +36,18 @@ let response = try await session.respond {
 ```
 
 `Attachment` accepts `UIImage`, `NSImage`, `CGImage`, Core Image types, CoreVideo pixel buffers, and file URLs. Any size/aspect ratio works — but **larger images cost more tokens and latency**; downscale when responsiveness matters.
+
+### Images also come *out* — `AttachmentSegment`
+
+Vision isn't only an input story. A model can emit media **inline in its response** — a generated diagram, an edited image — as a `Transcript.AttachmentSegment` (`content: .image(...)`, plus an optional `label` for caption/alt text). The enum is designed to grow past images.
+
+Walk a response's segments and render any attachment you find rather than assuming responses are text-only. Note there is **no replace**: attachments are added, and superseding one means removing it and adding a fresh one.
+
+### `Transcript.CustomSegment` — structured payloads that survive the turn
+
+`CustomSegment` is a **protocol you conform to**, not a fixed type — for provider- or app-specific structured data that must be readable on later turns (citations, retrieval hits, search results, debug traces). Its `Content` is any `Sendable & Equatable & Codable` type you design, and its `PromptRepresentable` / `InstructionsRepresentable` conformances control how the segment folds back into a future prompt — so render it as something the model can actually read.
+
+Use it for structure you'll read back later. For free-form prose, plain text segments are still the right answer.
 
 ## Built-In System Tools (WWDC26 241)
 
@@ -71,7 +89,7 @@ This replaces the old pattern of one session per mode plus manual transcript sur
 |---|---|---|---|
 | **Baton-pass** | Profiles share the full transcript; a tool flips the active-profile state (`.onToolCall { orchestrator.mode = .tutorial }`) | Whoever holds the baton | Shared context + handoff of authorship |
 | **Phone-a-friend** | A tool spawns an isolated child `LanguageModelSession` with its own profile/transcript, returns the answer as tool output | Always the parent | Isolated sub-task whose result feeds back |
-| **Skills** (utilities package) | `Skill(name:description:prompt:)` payloads loaded into context only when activated | The single profile | Procedural context loading — big reference text on demand |
+| **Skills** (utilities package) | `Skill(name:description:prompt:)` payloads loaded into context only when activated — the model activates them via a tool call. Two flavors, and the choice is a KV-cache decision: see **utilities-package.md** | The single profile | Procedural context loading — big reference text on demand |
 
 ## Tool-Calling Mode (WWDC26 242)
 
@@ -107,7 +125,8 @@ The transcript *is* the model's context; different backends have different limit
 
 - **Lifecycle modifiers** run imperative code at defined points; **`onResponse`** is the sanctioned clean point to summarize earlier entries and reclaim context; `onToolCall` powers baton-passing.
 - **Session properties** (`@SessionPropertyEntry` macro in an `extension SessionPropertyValues`) are shared state visible to every tool and profile — mutable, initial value required. Pattern: `onResponse` writes a running summary; each profile injects it into its `Instructions` so context survives dropped entries.
-- `session.transcript` is now **mutable** — but only while `isResponding == false` (mutating mid-response is a programmer error). `TranscriptErrorHandlingPolicy`: `.revertTranscript` (default — roll back on tool errors/cancellation) vs `.preserveTranscript` (resume-after-cancel flows; *you* must restore a good state).
+- `session.transcript` is now **mutable** — but only while `isResponding == false`. Mutating mid-response throws `LanguageModelSession.Error.transcriptMutationWhileResponding` (a typed error as of iOS 27, not just a documented footgun). `TranscriptErrorHandlingPolicy`: `.revertTranscript` (default — roll back on tool errors/cancellation) vs `.preserveTranscript` (resume-after-cancel flows; *you* must restore a good state).
+- **`GenerationSchema` is `Codable`, and encodes to standard [JSON Schema](https://json-schema.org).** So does every `Transcript.ToolDefinition.parameters`. Hand either to a `JSONEncoder` and drop the result straight into a server model's structured-output or function-parameters field — no hand-written schema translation.
 
 ## Performance & Accuracy Rules (WWDC26 242)
 
@@ -131,3 +150,4 @@ The transcript *is* the model's context; different backends have different limit
 
 - [WWDC26 — What's new in the Foundation Models framework](https://developer.apple.com/videos/play/wwdc2026/241/)
 - [WWDC26 — Build agentic app experiences with the Foundation Models framework](https://developer.apple.com/videos/play/wwdc2026/242/)
+- [apple/foundation-models-utilities](https://github.com/apple/foundation-models-utilities) — Skills, history modifiers, and the chat-completions model. See **utilities-package.md**.

--- a/skills/apple-intelligence/foundation-models/safety-and-guardrails.md
+++ b/skills/apple-intelligence/foundation-models/safety-and-guardrails.md
@@ -42,10 +42,18 @@ Hallucination stakes rule: where facts are critical (user instructions), don't r
 ## Guardrails (WWDC25 248)
 
 - Apple-trained guardrails apply to **both input and output**: "Your instructions, prompts, and tool calls are all considered inputs… harmful model outputs are blocked, even if the prompts were crafted to bypass input guardrails."
-- Violations throw `LanguageModelSession.GenerationError.guardrailViolation`. Handle by feature type:
+- Violations throw `LanguageModelError.guardrailViolation` (iOS 27; was `LanguageModelSession.GenerationError.guardrailViolation`, deprecated — see the migration table in `SKILL.md`). Handle by feature type:
   - **Proactive feature** (not user-initiated): "simply ignore the error and not interrupt the UI."
   - **User-initiated feature**: explain the app can't process the request (alert) and offer alternatives (Image Playground offers undoing the offending prompt).
 - Guardrail false positives were reduced in the iOS 26.4 model update and refined again in the iOS 27 wave (WWDC26 241).
+
+### A guardrail block is not the only way the model says no
+
+`LanguageModelError.refusal` is a **separate, non-safety decline** — the model chose not to answer (out of scope, won't speculate), and nothing was flagged as harmful. It carries an `explanation` (and an `explanationStream`).
+
+Treat the two differently. A guardrail violation is a safety event: say little, offer an alternative, never echo the offending content back. A refusal is an ordinary conversational outcome: it's safe to surface `explanation` to the user, and the fix is usually a better prompt, not a safer one.
+
+❌ Don't fold `refusal` into your `guardrailViolation` branch — you'll show a scary safety message for a mundane "I don't have enough information to answer that."
 
 ## The Swiss-Cheese Safety Stack (WWDC25 248)
 
@@ -76,7 +84,7 @@ guard supportedLanguages.contains(Locale.current.language) else {
     // show unsupported-language disclaimer
     return
 }
-// …and still catch LanguageModelSession.GenerationError.unsupportedLanguageOrLocale
+// …and still catch LanguageModelError.unsupportedLanguageOrLocale
 ```
 
 ## Apple's Closing Safety Checklist (WWDC25 248, verbatim order)

--- a/skills/apple-intelligence/foundation-models/utilities-package.md
+++ b/skills/apple-intelligence/foundation-models/utilities-package.md
@@ -1,0 +1,151 @@
+# Foundation Models Utilities (the open-source package)
+
+Apple ships a companion Swift package — **`apple/foundation-models-utilities`** — that adds three things the framework itself leaves to you: a client for OpenAI-compatible endpoints, just-in-time **Skills**, and ready-made **history-compression** modifiers. It exists to move faster than the OS: Apple describes it as *emerging and experimental patterns*, and it updates **between** OS releases rather than at WWDC cadence.
+
+Treat it accordingly — it's a proving ground, not a frozen API. Pin a commit if you need stability.
+
+```swift
+// Package.swift
+.package(url: "https://github.com/apple/foundation-models-utilities", branch: "main")
+```
+
+Requires **iOS / macOS / visionOS / watchOS 27** (no tvOS); also builds on Linux. At the time of writing the repo has **no tagged releases**, so a `from: "1.0.0"` requirement — which its own README suggests — will not resolve. Depend on a branch or a revision.
+
+## When to reach for it
+
+| You want to… | Use |
+|---|---|
+| Run against a local or hosted OpenAI-compatible model through `LanguageModelSession` | `ChatCompletionsLanguageModel` |
+| Load a big reference document into context **only when the model needs it** | `Skills` |
+| Stop a long conversation from outgrowing the context window | `droppingCompletedToolCalls()` / `rollingWindow()` / `summarizeHistory()` |
+
+---
+
+## ChatCompletionsLanguageModel — any OpenAI-compatible endpoint
+
+Conforms to `LanguageModel`, so it drops into a session exactly like `SystemLanguageModel`. Guided generation, tools, and streaming keep working — the endpoint just changes.
+
+```swift
+let model = ChatCompletionsLanguageModel(
+    name: "qwen3-30b",                              // sent verbatim as the `model` field
+    url: URL(string: "http://localhost:8000/v1")!,  // base URL — no /chat/completions suffix
+    additionalHeaders: ["Authorization": "Bearer \(token)"],
+    supportsGuidedGeneration: false                 // most local servers can't enforce a schema
+)
+
+let session = LanguageModelSession(model: model)
+let response = try await session.respond(to: "Summarize this changelog.")
+```
+
+Under the hood it POSTs a streaming request, walks the transcript into `system`/`user`/`assistant`/`tool` messages, forwards `temperature` and `max_completion_tokens`, maps `toolCallingMode` onto `tool_choice`, and parses the SSE stream back into transcript entries.
+
+**Pitfalls**
+
+- ❌ **`supportsGuidedGeneration` defaults to `true`.** Against a server that ignores `response_format`, a `respond(to:generating:)` call will *not* fail — it will hand back free-form text where you expected a decoded `@Generable`. Set it to `false` explicitly for local servers; then the framework throws `unsupportedCapability` instead of lying to you.
+- ❌ **`additionalHeaders` replaces, it doesn't merge per-header.** Setting `Content-Type` or `User-Agent` clobbers the package's default for that header. In practice you only want to *add* `Authorization`.
+- ⚠️ **Base-URL rule:** if the URL already contains a `v1` path component the client appends `/chat/completions`; otherwise it appends `/v1/chat/completions`. Pass the base, never the full path.
+- Custom segments aren't supported — this executor throws `unsupportedTranscriptContent` for them.
+
+---
+
+## Skills — load context only when the model asks for it
+
+A `Skill` is a named, described block of guidance. Until the model activates it (**by issuing a tool call**), only its *name* and *description* sit in the prompt — the body stays out. That keeps the prompt small and time-to-first-token low, and it's the framework-blessed answer to "I have a 4,000-word style guide but only need it on some turns."
+
+```swift
+@Observable final class Assistant {
+    let activations = SkillActivations()   // one per session — never recreate per render
+}
+
+struct ReviewProfile: LanguageModelSession.DynamicProfile {
+    let assistant: Assistant
+
+    var body: some DynamicProfile {
+        Profile {
+            Instructions("You review pull requests for an iOS team.")
+
+            Skills(activations: assistant.activations) {
+                Skill(
+                    name: "swift-style",
+                    description: "The team's Swift style rules — apply when reviewing Swift",
+                    prompt: swiftStyleGuideMarkdown          // big; only when needed
+                )
+                Skill(
+                    name: "release-tone",
+                    description: "House tone for release notes",
+                    instructions: "Write release notes in second person, present tense.",
+                    allowsDeactivation: true                 // model may unload it later
+                )
+            }
+        }
+    }
+}
+```
+
+### The two flavors, and why the choice is a cache decision
+
+This is the part worth internalizing, because it's the practical application of the KV-cache rule in `models-and-agents.md`: **appending preserves the cache; rewriting the prefix invalidates it.**
+
+| Flavor | Where the body lands | KV cache | Model's obedience |
+|---|---|---|---|
+| `prompt:` | Returned as the **tool output** of the activation call — an *append* | ✅ Preserved | Normal — it's context, not instruction |
+| `instructions:` | Spliced into the **existing instructions entry** at the top of the transcript | ❌ Invalidated for the whole conversation | Higher — models are trained to weight instructions |
+
+✅ **Prefer `prompt:`** for anything large or single-turn — style guides, reference docs, retrieved passages. You pay nothing in cache.
+
+✅ **Reach for `instructions:`** only when the guidance is short and must bind across many turns, and you accept re-processing the prefix.
+
+`allowsDeactivation: true` (instructions-only) lets the model issue a second tool call to *unload* the skill and restore the original instructions. Pair it with `droppingCompletedToolCalls()` to evict the activation/deactivation pair too, and the context is genuinely reclaimed rather than merely ignored.
+
+### `SkillActivations`
+
+`Sendable`, observable, and mutation-safe across actors. It exposes `activeSkillNames` and `isActive(_:)`, plus `activate(_:)` / `deactivate(_:)` for restoring state from disk or writing tests — in normal use the synthesized tool drives it. Because it's observable, SwiftUI can show the user which skills the model pulled in.
+
+❌ **Don't recreate it per render.** It's a reference type holding live state; hold one on your `@Observable` model, or you lose activations and break observation.
+
+> ⚠️ Older docs describe `SkillActivations` as conforming to `RandomAccessCollection`. That conformance was **removed**; iterate `activeSkillNames` instead.
+
+---
+
+## History — keeping the transcript inside the context window
+
+Three `DynamicProfile` modifiers. They rewrite `history` before each generation.
+
+```swift
+Profile { Instructions("…") }
+    .summarizeHistory(entryThreshold: 50)   // heaviest — innermost, runs last
+    .rollingWindow(entries: 20)
+    .droppingCompletedToolCalls()           // cheapest — outermost, runs FIRST
+```
+
+⚠️ **Modifiers apply outside-in, so source order is the reverse of execution order.** The last one you write runs first. Put the cheap compression outermost so the expensive one sees an already-smaller transcript.
+
+| Modifier | What it does |
+|---|---|
+| `droppingCompletedToolCalls()` | Drops every tool-call/tool-output pair except the most recent. Cheap, lossless-ish, and the natural partner to deactivatable skills. |
+| `rollingWindow(entries:)` | Hard cap — keeps the last *N* entries. Predictable and free. |
+| `summarizeHistory(entryThreshold:model:instructions:summaryPostamble:)` | Once the transcript exceeds the threshold, runs a **second session** to compress the prior conversation into one summary entry. |
+
+**`summarizeHistory` footguns** — none of these are obvious, and all of them bite:
+
+- ❌ **`entryThreshold` counts entries, not tokens.** A chat with few but enormous entries may never trip it. Apple's own README implies a token threshold; the code does not. Add a `rollingWindow` as a size-bounded backstop.
+- ❌ **It's a silent no-op unless the trailing entry is a `.prompt`.** It will not fire mid-tool-call. Don't rely on it as your only defense against overflow.
+- ⚠️ **Once the threshold trips, the summarizer runs on every prompt** — a whole extra model round-trip on the user-facing critical path. Give it a small, fast `model:`; it defaults to `SystemLanguageModel()`.
+- The default `summaryPostamble` exists to stop the downstream model leaking *"Based on the summary provided…"* into its answers. If you override it, keep that instruction or the seam becomes visible to users.
+
+## Checklist
+
+- [ ] Package pinned to a branch/revision — there are no tagged releases
+- [ ] `supportsGuidedGeneration: false` set for any server that doesn't enforce a schema
+- [ ] `Authorization` added via `additionalHeaders`; no API key hardcoded in the binary (see `models-and-agents.md`)
+- [ ] Large or single-turn skill bodies use `prompt:` (cache-preserving), not `instructions:`
+- [ ] One `SkillActivations` per session, held on an `@Observable` model
+- [ ] History modifiers ordered with the cheapest outermost
+- [ ] `summarizeHistory` backed by a `rollingWindow` — entry-count thresholds don't bound tokens
+- [ ] Transcript strategy profiled with the Foundation Models Instrument (it flags cache invalidations)
+
+## References
+
+- [apple/foundation-models-utilities](https://github.com/apple/foundation-models-utilities) — the package (Apache-2.0)
+- [WWDC26 — Build agentic app experiences with the Foundation Models framework](https://developer.apple.com/videos/play/wwdc2026/242/)
+- [Foundation Models framework](https://developer.apple.com/documentation/foundationmodels)


### PR DESCRIPTION
Explored [apple/foundation-models-utilities](https://github.com/apple/foundation-models-utilities) (Apple's new Apache-2.0 package, created WWDC26 week) and compared it against our Foundation Models skills. That turned up **two of our examples that are broken**, plus a real content gap.

## 🔴 Our skills taught a deprecated API — and one that never existed

Everything below was verified against the **FoundationModels SDK** (`.swiftinterface` from Xcode 26.3) and **Apple's DocC JSON**, not against secondary sources.

**1. `LanguageModelSession.GenerationError` is deprecated at iOS 27 and becomes _unavailable_ under Xcode 27.** Not a soft warning — Apple's own note:

> "Apps built with Xcode 26 will continue to catch this error until you rebuild with Xcode 27. You must update to Xcode 27 to catch the new error types before submitting your app."

Our error-handling example taught exactly this enum. Its 9 cases were split across **three** new types, so this PR rewrites the section and adds a migration table:

| iOS 26 `GenerationError` | iOS 27 replacement |
|---|---|
| `exceededContextWindowSize` | `LanguageModelError.contextSizeExceeded` (now carries `contextSize` **and** `tokenCount`) |
| `rateLimited` | `LanguageModelError.rateLimited` (now carries `resetDate`) |
| `unsupportedGuide` | `LanguageModelError.unsupportedGenerationGuide` (renamed) |
| `concurrentRequests` | `LanguageModelSession.Error.concurrentRequests` (moved) |
| `assetsUnavailable` | `SystemLanguageModel.Error.assetsUnavailable` (moved) |
| `decodingFailure` | No documented successor — keep a catch-all |

**2. `catch GenerationError.cancelled` — that case has never existed.** It is not among the 9 cases in the shipping SDK. We invented it; it would not have compiled. Cancellation surfaces as Swift's `CancellationError`.

**3. `GenerationOptions(sampling:)` is deprecated** in favor of `samplingMode:`.

## 🟠 New: `utilities-package.md`

Apple's package is a staging ground that ships *between* OS releases. We referenced its features from WWDC sessions but never named the package, linked it, or documented its API. New reference file covers:

- **`ChatCompletionsLanguageModel`** — drive any OpenAI-compatible endpoint (local Ollama/llama.cpp/vLLM, or hosted) through the same `LanguageModelSession`. Key trap: `supportsGuidedGeneration` defaults to `true`, so against a server that ignores `response_format` you silently get free-form text where you expected a decoded `@Generable`.
- **Skills** — just-in-time context loaded by a model-issued tool call. **The prompt-vs-instructions choice is a KV-cache decision**: `prompt:` lands as tool output (appends → cache preserved), `instructions:` rewrites the prefix (cache invalidated, obedience higher). This completes the cache rule `models-and-agents.md` already asserts but doesn't act on.
- **History modifiers** — with the non-obvious footguns: `summarizeHistory` thresholds on **entry count, not tokens** (Apple's own README implies otherwise), is a **silent no-op unless the trailing entry is a `.prompt`**, and once tripped runs a whole extra model round-trip **on the user-facing critical path** every turn.

## 🟡 Also added

- `models-and-agents.md` — `LanguageModelCapabilities` (**capabilities are not uniform across backends**; swapping models can silently swap away tool calling or strict JSON), `AttachmentSegment` (models emit images, not just read them), `Transcript.CustomSegment`, `GenerationSchema` encodes to standard JSON Schema (hand it straight to `JSONEncoder`), and the now-typed `transcriptMutationWhileResponding`.
- `safety-and-guardrails.md` — **`.refusal` is a non-safety decline**, distinct from a guardrail violation. Don't show a scary safety message for a mundane "I don't have enough information."

## Licensing

Apple's repo is Apache-2.0; ours is MIT. Harvested **facts and API only** — all prose and examples here are original, their repo is cited in References, and none of their files are vendored. Same posture as our WWDC harvests.

Notably, their own docs have already drifted from their source (a `RandomAccessCollection` conformance their README still claims but their code removed), which is why everything here was checked against the SDK rather than their SKILL.md.

## Testing

- Skill count unchanged at **161** — `utilities-package.md` is a reference file, not a new `SKILL.md`.
- `check-counts`, `check-frontmatter`, `check-freshness` (+ `--self-test`): all green.
- No deprecated API remains anywhere in `skills/` except the intentional ❌ warning lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)