### PR TITLE
docs: replace "don't copy copyrighted material" with real harvest hygiene

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -222,8 +222,38 @@ Force unwrapping will crash if the value is nil. Guard provides safe unwrapping 
 - ❌ Use vague descriptions
 - ❌ Provide opinions without reasoning
 - ❌ Include outdated practices
-- ❌ Copy copyrighted material
+- ❌ Reproduce source material instead of distilling it (see Sourcing below)
 - ❌ Add project-specific details
+
+### Sourcing — harvest hygiene
+
+Most content here is *harvested*: WWDC sessions, Tech Talks, Apple's docs, and Apple's open-source repos get distilled into skills. That's legitimate, but only when done a particular way, and "don't copy copyrighted material" is too blunt a rule to steer by — taken literally it would forbid the short attributed quotes this library correctly relies on.
+
+The line that actually matters: **facts are free, expression is not.**
+
+**Do:**
+- ✅ Harvest **facts** — API names, signatures, defaults, limits, failure modes, deprecations. These aren't ownable, and restating them in your own words isn't copying.
+- ✅ Write the prose yourself, in this repo's format (activation triggers, ✅/❌ pairs, checklists).
+- ✅ Quote sparingly when Apple's exact phrasing carries the point ("like a stack of Swiss cheese slices") — short, in quotes, and attributed to the specific session or page.
+- ✅ Cite the source in **References**, always. It's how the next person re-verifies when the API moves.
+- ✅ Write your own code examples. Use your own domain, not the source's.
+
+**Don't:**
+- ❌ **Commit transcripts.** Not `.vtt`, not `.srt`, not a pasted session transcript in a markdown file. This is the bright line.
+- ❌ Let quotes grow from a sentence into paragraphs. If a quote is carrying a whole section, you haven't distilled it.
+- ❌ Paste another project's docs into `skills/`. Even a permissive license (Apache-2.0) means the copied text keeps *its* license, which quietly makes this MIT repo mixed-license.
+- ❌ Imply Apple (or any vendor) endorses this library.
+
+### Verify against the SDK, not the write-up
+
+When harvesting an API, check it against ground truth before writing:
+
+1. The **SDK itself** — `.swiftinterface` files in the Xcode SDK are authoritative and offline:
+   `find /Applications/Xcode.app/Contents/Developer/Platforms -name "*.swiftinterface" -path "*FrameworkName*"`
+2. **Apple's DocC JSON** — the docs site is a JavaScript app that scrapers can't read, but the JSON behind it is plain:
+   `https://developer.apple.com/tutorials/data/documentation/<framework>/<symbol>.json`
+
+Secondary sources — including Apple's own READMEs and sample repos — drift. A past harvest shipped a `catch GenerationError.cancelled` for a case that has never existed in any SDK. Checking the interface file would have caught it; reading the docs prose did not.
 
 ## Testing Your Changes
 


### PR DESCRIPTION
## Changes

Rewrites the sourcing guidance in `CONTRIBUTING.md`. Docs-only — no skills touched.

## Motivation

`CONTRIBUTING.md:225` said only:

> ❌ Copy copyrighted material

True, but too blunt to steer by. Read literally it forbids the short attributed WWDC quotes this library already relies on and *should* keep — while giving a contributor no way to see that committing a transcript is the actual problem. It stated a conclusion without the rule that produces it.

Most content here is harvested from WWDC sessions, Tech Talks, Apple's docs, and now Apple's open-source repos. That's legitimate, but only done a particular way, and the guidance should say which way.

## What's now written down

- **The rule that does the work:** facts are free, expression is not. API names, defaults, limits, failure modes, and deprecations aren't ownable — restating them in your own words isn't copying.
- **The bright line:** never commit transcripts (`.vtt`, `.srt`, or pasted into markdown).
- **The licensing trap:** pasting text from a permissively-licensed project (e.g. Apache-2.0) means the copied text keeps *its* license — quietly making this MIT repo mixed-license. Harvest facts, not paragraphs.
- **Quotes:** short, in quotes, attributed to the specific session or page. If a quote is carrying a whole section, you haven't distilled it.

## The part with teeth

A new **"Verify against the SDK, not the write-up"** step, with the two ground-truth sources:

1. The Xcode SDK's `.swiftinterface` files — authoritative and offline.
2. Apple's DocC JSON (`developer.apple.com/tutorials/data/documentation/<framework>/<symbol>.json`) — the docs site is a JS app that scrapers only see the title of; the JSON behind it is plain.

This isn't hypothetical. A past harvest shipped `catch GenerationError.cancelled` for a case that has **never existed in any SDK** — fixed in #46. Reading the docs prose missed it; reading the interface file would not have. Secondary sources drift, *including Apple's own* — their `foundation-models-utilities` README currently claims a `RandomAccessCollection` conformance their own code removed.

## Testing

`check-counts`, `check-frontmatter`, `check-freshness` (+ `--self-test`) all green. No skill content changed, so counts are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)