### PR TITLE
fix: drop displayName from marketplace.json — old clients hard-fail marketplace add

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -21,8 +21,7 @@
         "source": "url",
         "url": "https://github.com/rshankras/SwiftShip.git"
       },
-      "description": "SwiftShip \u2014 52 /apple:* workflow commands + 6 pinned agents: idea validation, roadmap, plan, build, review, TestFlight, App Store submission, and post-launch growth. Install apple-skills alongside it (its commands read that library).",
-      "displayName": "SwiftShip"
+      "description": "SwiftShip \u2014 52 /apple:* workflow commands + 6 pinned agents: idea validation, roadmap, plan, build, review, TestFlight, App Store submission, and post-launch growth. Install apple-skills alongside it (its commands read that library)."
     }
   ]
 }

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -21,6 +21,14 @@ jobs:
           chmod +x scripts/check-frontmatter.sh
           ./scripts/check-frontmatter.sh
 
+      # The plugin-validate job runs the latest CLI, which accepts these
+      # keys — only this grep protects clients a few versions behind.
+      - name: Marketplace — no plugin keys old Claude Code clients reject
+        run: |
+          chmod +x scripts/check-marketplace-compat.sh
+          ./scripts/check-marketplace-compat.sh --self-test
+          ./scripts/check-marketplace-compat.sh
+
       - name: Freshness — no recency claims against stale OS versions
         run: |
           chmod +x scripts/check-freshness.sh

--- a/scripts/check-marketplace-compat.sh
+++ b/scripts/check-marketplace-compat.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+# Marketplace compatibility tripwire — no plugin-entry keys that older
+# Claude Code clients hard-reject.
+# History: marketplace.json used `displayName` — a documented field, but one
+# that requires Claude Code >= 2.1.143. Older clients strict-parse the
+# manifest and fail the ENTIRE `/plugin marketplace add` with
+# 'Unrecognized key: "displayName"' (issue #49) — one cosmetic field made
+# the marketplace uninstallable for them. CI's `claude plugin validate`
+# runs the *latest* CLI, so it can never catch a key that only previous
+# client generations reject; this grep can.
+#
+# Rule: marketplace.json sticks to plugin-entry keys every client
+# understands. The keys below are documented but min-versioned — re-add one
+# only after consciously deciding the compat floor (and update this list +
+# the docs' min-version notes).
+#
+# Usage:  ./scripts/check-marketplace-compat.sh              # scan manifest
+#         ./scripts/check-marketplace-compat.sh --self-test  # embedded fixtures
+# Exit:   0 = clean, 1 = min-versioned key found (or self-test failure)
+
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_DIR" || exit 1
+
+# Documented marketplace plugin-entry keys with a min-version requirement
+# (per code.claude.com/docs/en/plugin-marketplaces):
+#   displayName    requires >= 2.1.143
+#   relevance      requires >= 2.1.152
+#   defaultEnabled requires >= 2.1.154
+MIN_VERSIONED_KEYS='displayName|relevance|defaultEnabled'
+
+scan() {
+    # Key position only ("key":) — the same word inside a description
+    # string must not flag.
+    grep -nE "\"(${MIN_VERSIONED_KEYS})\"[[:space:]]*:" "$1"
+}
+
+if [ "$1" = "--self-test" ]; then
+    TMP=$(mktemp)
+    trap 'rm -f "$TMP"' EXIT
+    printf '%s\n' '{ "plugins": [ { "name": "x", "displayName": "X" } ] }' > "$TMP"
+    if ! scan "$TMP" > /dev/null; then
+        echo "✗ self-test: fixture with displayName key was not flagged"
+        exit 1
+    fi
+    printf '%s\n' '{ "plugins": [ { "name": "x", "description": "mentions displayName in prose" } ] }' > "$TMP"
+    if scan "$TMP" > /dev/null; then
+        echo "✗ self-test: displayName inside a description string was flagged"
+        exit 1
+    fi
+    echo "✓ self-test passed"
+    exit 0
+fi
+
+MANIFEST=.claude-plugin/marketplace.json
+HITS=$(scan "$MANIFEST")
+if [ -n "$HITS" ]; then
+    echo "✗ $MANIFEST uses min-versioned plugin keys — older Claude Code"
+    echo "  clients hard-fail '/plugin marketplace add' on ANY unrecognized"
+    echo "  key (see issue #49), taking the whole marketplace down with it:"
+    printf '%s\n' "$HITS" | sed 's/^/    /'
+    exit 1
+fi
+echo "✓ $MANIFEST sticks to universally-recognized plugin keys"
+exit 0


### PR DESCRIPTION
Fixes #49

## Root cause

`/plugin marketplace add rshankras/claude-code-apple-skills` fails on some machines with:

```
✘ Failed to add marketplace: Invalid schema: plugins.1: Unrecognized key: "displayName"
```

`displayName` is a **documented** marketplace plugin field ([docs](https://code.claude.com/docs/en/plugin-marketplaces#optional-plugin-fields)) — but it requires **Claude Code >= 2.1.143**. Older clients strict-parse the manifest and reject the whole marketplace on any unrecognized key, so one cosmetic field (added in #22 to show "SwiftShip" in the plugin browser) made the marketplace uninstallable for anyone a few versions behind.

CI never caught it because the `plugin-validate` job runs the *latest* CLI, which accepts the key — validation and old-client `marketplace add` disagree on the schema.

## Fix

- **Remove `displayName`** from the SwiftShip entry. The branding survives: the description users read in the install prompt already leads with "SwiftShip — 52 /apple:* workflow commands…". Newer clients fall back to showing `apple` as the name, which matches the `/apple:*` command namespace anyway.
- **New guard** `scripts/check-marketplace-compat.sh` (+ CI step, with `--self-test`): greps marketplace.json for min-versioned plugin-entry keys (`displayName` ≥ 2.1.143, `relevance` ≥ 2.1.152, `defaultEnabled` ≥ 2.1.154) so this class of break can't be reintroduced — it's the only check that can protect clients the latest CLI no longer represents.

Checked the sibling SwiftShip repo's `.claude-plugin/plugin.json` — clean, no min-versioned keys there.

## Verification

- `check-marketplace-compat.sh --self-test` + main scan: ✅
- `check-counts.sh` (marketplace.json counts untouched): ✅
- `claude plugin validate .` (2.1.210): ✅ passes with the same pre-existing no-version warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)