### PR TITLE
feat: blind-test skill audit harness (Task 1 of library overhaul)

### DIFF
--- a/tools/skill-audit/.gitignore
+++ b/tools/skill-audit/.gitignore
@@ -1,0 +1,7 @@
+# Per-run working data is bulky and reproducible; only AUDIT-REPORT.md and
+# summary.json (committed) are the record.
+results/*/state/
+results/*/raw/
+results/*/tmp-cwd/
+results/*/preflight.json
+results/.preflight-tmp/

--- a/tools/skill-audit/README.md
+++ b/tools/skill-audit/README.md
@@ -1,0 +1,99 @@
+# skill-audit — blind-test audit harness
+
+Answers one question per skill: **does this skill teach the runtime model
+anything it doesn't already know?** For each leaf skill it derives blind-test
+questions, asks them to a *bare* Claude session (no CLAUDE.md, no rules, no
+skills, no tools), grades the bare answers against claims extracted from the
+skill, and classifies the skill. The output is a human-approval report —
+**this tool never deletes or edits a skill.**
+
+A skill earns its place by encoding at least one of:
+(a) something the model gets wrong, (b) something the model can't know
+(post-cutoff APIs, review lore), (c) an opinionated choice. Skills that are
+none of these are DELETE/TRIM candidates.
+
+## Verdicts
+
+| Verdict | Meaning |
+|---|---|
+| `DELETE-candidate` | Bare model covered ≥0.80 of claims, no contradictions/suspects, and an Opus second-opinion regrade agreed. Human approves before anything happens. |
+| `TRIM` | Coverage 0.50–0.80 — keep only the deltas the bare model missed. |
+| `TRIM(prose)` | Track B only: the generator's prose guidance is redundant; templates untouched. |
+| `KEEP` | Coverage <0.50 — the skill demonstrably teaches things the model lacks. |
+| `FIX` | The skill itself looks wrong: a suspect claim confirmed against `scripts/api-symbols.txt` / `versions.env`, or a high-confidence contradiction where the model is right. |
+| `SKIPPED-router` / `SKIPPED-error` | Category index / pipeline error (errors retry on the next run). |
+
+## Two tracks
+
+- **Track A (92 advisory/workflow skills):** full pipeline — derive claims+questions
+  → bare answers → evidence-validated grading → verdict math in code (the judge
+  model never classifies). Coverage = (covered + 0.5·partial) / gradable claims.
+- **Track B (69 skills: all `generators/` + six `product/*-spec` document
+  generators, see `config.json` `track_overrides`):** their value is opinionated
+  templates, which a Q&A blind test cannot judge — a bare model can *talk* about
+  paywalls fine. Track B grades **prose guidance only** (2 calls/skill) and can
+  never emit DELETE. Template compilability is owned by
+  `scripts/check-swift-templates.sh`, not this tool.
+
+Skill enumeration reuses `scripts/check-counts.sh`'s exact counting rule
+(161 skills = leaf dirs + `CATEGORY_LEVEL_SKILLS`).
+
+## Isolation
+
+Bare calls run with `--safe-mode --setting-sources "" --strict-mcp-config
+--tools "" --disable-slash-commands` in an empty scratch cwd. A **preflight
+canary** runs before every batch (ping + "list your context: NONE" probe +
+a leak probe against distinctive lines from the local `~/.claude/CLAUDE.md`)
+and aborts the run if isolation fails — e.g. after a CLI update changes
+`--safe-mode` semantics.
+
+## Run-book
+
+```bash
+python3 tools/skill-audit/audit.py preflight              # isolation canary (3 calls)
+python3 tools/skill-audit/audit.py list                   # enumeration + track split, no calls
+python3 tools/skill-audit/audit.py run --category testing # one category (recommended batch size)
+python3 tools/skill-audit/audit.py run --skill ios/ui-review --skill ios/ipad-patterns
+python3 tools/skill-audit/audit.py run --all              # everything (resumable, ~750 calls)
+python3 tools/skill-audit/audit.py run --all --dry-run    # show selection, no calls
+python3 tools/skill-audit/audit.py report                 # regenerate report from state, no calls
+python3 tools/skill-audit/audit.py diff --against <old-model-id>
+```
+
+- **Resume:** re-issue the same `run` — per-question state under
+  `results/<model-id>/state/` skips finished work; a kill loses at most one call.
+  `--force` discards state for the selection (e.g. after editing a skill —
+  content-hash changes also invalidate automatically).
+- **New model release:** re-run everything; results land in a fresh
+  `results/<new-model-id>/` dir, then `diff --against` the previous one.
+- **Cost:** ~750 calls for a full run (≈1.5–2 h at concurrency 4; ~$35–50 if
+  API-key funded, or a large slice of a subscription window).
+  `max_calls_per_run` in `config.json` (default 400) hard-caps a single
+  invocation — a full pass takes 2–3 invocations by design.
+
+## What gets committed
+
+`results/<model-id>/AUDIT-REPORT.md` + `summary.json` (the record).
+`state/`, `raw/` transcripts, and `tmp-cwd/` are gitignored — bulky and
+reproducible.
+
+## Reading the report
+
+- Per-category tables: verdict, coverage, the failed questions (the evidence a
+  KEEP earns its keep), 1-line justification, flags.
+- `human-review:*` flags: borderline coverage (±0.05 of a threshold), unclear
+  contradictions, unverified suspects — read these rows yourself.
+- `workflow-heavy`: Q&A under-samples process orchestration; don't DELETE these
+  on coverage alone.
+- **Appendix B (DELETE dossiers)** is the approval surface: every covered claim
+  with the grader's evidence quotes, the Opus escalation outcome, and any
+  SwiftShip references (`⚠️ referenced by SwiftShip` rows need a paired
+  SwiftShip PR before deletion).
+
+## Relationship to existing checks
+
+Complements — does not replace — the structural auditor
+(`skills/shared/skill-auditor`, C-01…L-03) and the CI tripwires
+(`check-freshness.sh`, `check-api-symbols.sh`, `check-swift-templates.sh`).
+This tool judges *content redundancy and staleness against a live model*;
+those judge structure, recency claims, and API existence deterministically.

--- a/tools/skill-audit/audit.py
+++ b/tools/skill-audit/audit.py
@@ -1,0 +1,1164 @@
+#!/usr/bin/env python3
+"""Blind-test skill audit harness.
+
+For each leaf skill, derives blind-test questions, asks them to a bare
+(safe-mode, tool-less) Claude session, grades the bare answers against
+claims extracted from the skill, and classifies the skill
+DELETE-candidate / TRIM / KEEP / FIX. Nothing is deleted by this tool:
+the output is results/<model-id>/AUDIT-REPORT.md for human approval.
+
+Usage:
+  python3 tools/skill-audit/audit.py preflight
+  python3 tools/skill-audit/audit.py list
+  python3 tools/skill-audit/audit.py run --category testing [--dry-run] [--limit N]
+  python3 tools/skill-audit/audit.py run --skill generators/paywall-generator
+  python3 tools/skill-audit/audit.py run --all
+  python3 tools/skill-audit/audit.py report
+  python3 tools/skill-audit/audit.py diff --against <old-model-id>
+
+Runs are resumable: state is kept per skill per question under
+results/<model-id>/state/; re-issuing the same run skips finished work.
+A re-run under a new model release lands in a fresh results dir.
+"""
+
+import argparse
+import concurrent.futures
+import hashlib
+import json
+import re
+import os
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parents[1]
+SKILLS_DIR = ROOT / "skills"
+SCRIPTS_DIR = ROOT / "scripts"
+
+HARNESS_VERSION = 1
+
+DERIVE_SCHEMA = {
+    "type": "object",
+    "required": ["claims", "questions"],
+    "properties": {
+        "claims": {
+            "type": "array",
+            "minItems": 3,
+            "maxItems": 15,
+            "items": {
+                "type": "object",
+                "required": ["id", "text", "kind", "quote"],
+                "properties": {
+                    "id": {"type": "string"},
+                    "text": {"type": "string"},
+                    "kind": {"enum": ["fact", "number", "api", "procedure", "recommendation"]},
+                    "quote": {"type": "string"},
+                },
+            },
+        },
+        "questions": {
+            "type": "array",
+            "minItems": 3,
+            "maxItems": 5,
+            "items": {
+                "type": "object",
+                "required": ["id", "text", "claim_ids"],
+                "properties": {
+                    "id": {"type": "string"},
+                    "text": {"type": "string"},
+                    "claim_ids": {"type": "array", "items": {"type": "string"}},
+                },
+            },
+        },
+    },
+}
+
+GRADE_ITEM_PROPS = {
+    "claim_id": {"type": "string"},
+    "verdict": {"enum": ["covered", "partial", "missed", "contradicted"]},
+    "evidence": {"type": "string"},
+    "who_is_right": {"enum": ["skill", "model", "unclear"]},
+    "confidence": {"enum": ["low", "med", "high"]},
+    "suspect": {"type": "boolean"},
+    "suspect_reason": {"type": "string"},
+}
+
+GRADE_SCHEMA = {
+    "type": "object",
+    "required": ["grades"],
+    "properties": {
+        "grades": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": ["claim_id", "verdict"],
+                "properties": GRADE_ITEM_PROPS,
+            },
+        }
+    },
+}
+
+GENERATOR_GRADE_SCHEMA = {
+    "type": "object",
+    "required": ["claims"],
+    "properties": {
+        "claims": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": ["id", "text", "quote", "verdict"],
+                "properties": {
+                    "id": {"type": "string"},
+                    "text": {"type": "string"},
+                    "quote": {"type": "string"},
+                    "verdict": {"enum": ["covered", "partial", "missed", "contradicted"]},
+                    "evidence": {"type": "string"},
+                    "who_is_right": {"enum": ["skill", "model", "unclear"]},
+                    "confidence": {"enum": ["low", "med", "high"]},
+                    "suspect": {"type": "boolean"},
+                    "suspect_reason": {"type": "string"},
+                },
+            },
+        }
+    },
+}
+
+
+# --------------------------------------------------------------------------
+# Config / enumeration
+# --------------------------------------------------------------------------
+
+def load_config():
+    cfg = json.loads((HERE / "config.json").read_text())
+    cfg.setdefault("claude_bin", "claude")
+    return cfg
+
+
+def parse_category_level_skills():
+    txt = (SCRIPTS_DIR / "check-counts.sh").read_text()
+    m = re.search(r'^CATEGORY_LEVEL_SKILLS="([^"]*)"', txt, re.M)
+    if not m:
+        sys.exit("FATAL: CATEGORY_LEVEL_SKILLS not found in scripts/check-counts.sh")
+    return m.group(1).split()
+
+
+class Skill:
+    def __init__(self, sid, path, category, track, is_router):
+        self.sid = sid            # e.g. "ios/ui-review" or "security" (category-level)
+        self.path = path          # Path to SKILL.md
+        self.category = category
+        self.track = track        # "A" | "B"
+        self.is_router = is_router
+
+    def supporting_files(self):
+        return sorted(p for p in self.path.parent.glob("*.md") if p.name != "SKILL.md")
+
+
+ROUTER_HEADING = re.compile(r"^## Available (Skills|Modules)\s*$", re.M)
+
+
+def enumerate_skills(cfg):
+    """Reproduce scripts/check-counts.sh's counting rule exactly:
+    leaf skills at skills/<cat>/<skill>/SKILL.md plus the category-level
+    skills named in CATEGORY_LEVEL_SKILLS. Other category SKILL.md files
+    are routers and excluded."""
+    overrides = cfg.get("track_overrides", {})
+    skills = []
+    for p in sorted(SKILLS_DIR.glob("*/*/SKILL.md")):
+        cat = p.parent.parent.name
+        if cat == "_shared":
+            continue
+        sid = f"{cat}/{p.parent.name}"
+        track = "B" if (cat == "generators" or overrides.get(sid) == "B") else "A"
+        is_router = bool(ROUTER_HEADING.search(p.read_text(errors="replace")))
+        skills.append(Skill(sid, p, cat, track, is_router))
+    for cat in parse_category_level_skills():
+        p = SKILLS_DIR / cat / "SKILL.md"
+        if not p.exists():
+            sys.exit(f"FATAL: skills/{cat}/SKILL.md listed in CATEGORY_LEVEL_SKILLS but missing")
+        track = "B" if overrides.get(cat) == "B" else "A"
+        is_router = bool(ROUTER_HEADING.search(p.read_text(errors="replace")))
+        skills.append(Skill(cat, p, cat, track, is_router))
+    return skills
+
+
+# --------------------------------------------------------------------------
+# Content assembly
+# --------------------------------------------------------------------------
+
+def strip_frontmatter(text):
+    if text.startswith("---"):
+        end = text.find("\n---", 3)
+        if end != -1:
+            return text[end + 4:]
+    return text
+
+
+def collapse_code_blocks(text, max_lines=40):
+    out, in_block, block = [], False, []
+    for line in text.splitlines():
+        if line.strip().startswith("```"):
+            if in_block:
+                if len(block) > max_lines:
+                    out.extend(block[:5])
+                    out.append(f"… [{len(block) - 5} code lines collapsed]")
+                else:
+                    out.extend(block)
+                out.append(line)
+                in_block, block = False, []
+            else:
+                out.append(line)
+                in_block = True
+            continue
+        if in_block:
+            block.append(line)
+        else:
+            out.append(line)
+    out.extend(block)  # unterminated block
+    return "\n".join(out)
+
+
+def headings_outline(text):
+    return "\n".join(l for l in text.splitlines() if l.startswith("#"))
+
+
+def assemble_content(skill, cfg):
+    """Track A content: SKILL.md whole, supporting .md files whole until the
+    budget, then headings-only outline. Returns (content, truncated)."""
+    budget = cfg["content_budget_bytes"]
+    parts = [skill.path.read_text(errors="replace")]
+    used = len(parts[0].encode())
+    truncated = False
+    for p in skill.supporting_files():
+        body = p.read_text(errors="replace")
+        size = len(body.encode())
+        if used + size <= budget:
+            parts.append(f"\n\n<!-- supporting file: {p.name} -->\n{body}")
+            used += size
+        else:
+            parts.append(f"\n\n<!-- supporting file (outline only, truncated): {p.name} -->\n"
+                         + headings_outline(body))
+            truncated = True
+    return "".join(parts), truncated
+
+
+def content_hash(skill):
+    h = hashlib.sha256(skill.path.read_bytes())
+    for p in skill.supporting_files():
+        h.update(p.read_bytes())
+    return h.hexdigest()
+
+
+def normalize(s):
+    """Whitespace-collapse, lowercase, and strip markdown decoration — quote
+    validation must tolerate `**bold**`/backtick differences between what the
+    model wrote and how the grader quoted it, while still requiring the same
+    content words in the same order."""
+    s = re.sub(r"[*_`#>|]", "", s or "")
+    return re.sub(r"\s+", " ", s).strip().lower()
+
+
+# --------------------------------------------------------------------------
+# Claude invocation
+# --------------------------------------------------------------------------
+
+class CallError(RuntimeError):
+    pass
+
+
+class Budget:
+    def __init__(self, max_calls):
+        self.max_calls = max_calls
+        self.calls = 0
+        self.lock = threading.Lock()
+
+    def take(self):
+        with self.lock:
+            if self.calls >= self.max_calls:
+                raise CallError(f"max_calls_per_run ({self.max_calls}) reached")
+            self.calls += 1
+
+
+BARE_FLAGS = [
+    "--safe-mode",              # no CLAUDE.md, rules, skills, plugins, hooks, MCP
+    "--setting-sources", "",    # no user/project/local settings sources
+    "--strict-mcp-config",      # with no --mcp-config: zero MCP servers
+    "--tools", "",              # parametric knowledge only
+    "--disable-slash-commands",
+    "--no-session-persistence",
+]
+
+
+def run_claude(prompt, model, cfg, tmp_cwd, budget, schema=None):
+    cmd = [cfg["claude_bin"], "-p", "--model", model] + BARE_FLAGS + [
+        "--output-format", "json"]
+    if schema is not None:
+        cmd += ["--json-schema", json.dumps(schema)]
+    cmd.append(prompt)
+    delays = cfg.get("backoff_seconds", [10, 30, 90])
+    last_err = ""
+    for attempt in range(cfg.get("retries", 3)):
+        budget.take()
+        try:
+            p = subprocess.run(cmd, cwd=str(tmp_cwd), capture_output=True,
+                               text=True, timeout=cfg["call_timeout_seconds"])
+        except subprocess.TimeoutExpired:
+            last_err = "timeout"
+            time.sleep(delays[min(attempt, len(delays) - 1)])
+            continue
+        if p.returncode == 0:
+            try:
+                obj = json.loads(p.stdout)
+            except json.JSONDecodeError:
+                last_err = f"non-JSON stdout: {p.stdout[:200]}"
+                time.sleep(delays[min(attempt, len(delays) - 1)])
+                continue
+            if obj.get("is_error"):
+                last_err = f"is_error: {str(obj.get('result'))[:200]}"
+                time.sleep(delays[min(attempt, len(delays) - 1)])
+                continue
+            return obj
+        last_err = (p.stderr or p.stdout)[-300:]
+        wait = delays[min(attempt, len(delays) - 1)]
+        if re.search(r"rate.?limit|overloaded|529", last_err, re.I):
+            wait = max(wait, 60)
+        time.sleep(wait)
+    raise CallError(last_err or "unknown claude failure")
+
+
+def result_text(obj):
+    r = obj.get("result")
+    return r if isinstance(r, str) else json.dumps(r)
+
+
+def extract_structured(obj):
+    for key in ("structured_output", "structured_result", "structuredOutput"):
+        if isinstance(obj.get(key), (dict, list)):
+            return obj[key]
+    r = obj.get("result")
+    if isinstance(r, (dict, list)):
+        return r
+    if isinstance(r, str):
+        s = re.sub(r"^```(?:json)?\s*|\s*```$", "", r.strip())
+        try:
+            return json.loads(s)
+        except json.JSONDecodeError:
+            m = re.search(r"\{.*\}", s, re.S)
+            if m:
+                return json.loads(m.group(0))
+    raise CallError(f"no structured output in response: {str(r)[:200]}")
+
+
+def find_model_id(obj):
+    """The main model is the one carrying the conversation context; auxiliary
+    models (e.g. a small title generator) show tiny input/cache usage."""
+    mu = obj.get("modelUsage") or {}
+    if mu:
+        def weight(v):
+            return (v.get("inputTokens", 0) + v.get("cacheReadInputTokens", 0)
+                    + v.get("cacheCreationInputTokens", 0))
+        return max(mu, key=lambda k: weight(mu[k]))
+    m = re.search(r"claude-[a-z]+-[a-z0-9.-]*\d", json.dumps(obj))
+    return m.group(0) if m else None
+
+
+# --------------------------------------------------------------------------
+# Preflight
+# --------------------------------------------------------------------------
+
+def claude_version(cfg):
+    try:
+        p = subprocess.run([cfg["claude_bin"], "-v"], capture_output=True, text=True, timeout=30)
+        return p.stdout.strip() or p.stderr.strip()
+    except Exception as e:  # noqa: BLE001
+        return f"unknown ({e})"
+
+
+def distinctive_user_tokens():
+    """Longest distinctive lines from the local user CLAUDE.md — the leak probe
+    asserts none of these surface in a bare session."""
+    path = Path.home() / ".claude" / "CLAUDE.md"
+    if not path.exists():
+        return []
+    lines = [l.strip() for l in path.read_text(errors="replace").splitlines()]
+    lines = [l for l in lines if len(l) > 30 and not l.startswith("#")]
+    return sorted(lines, key=len, reverse=True)[:5]
+
+
+def preflight(cfg, results_root):
+    tmp = results_root / "tmp-cwd"
+    tmp.mkdir(parents=True, exist_ok=True)
+    budget = Budget(10)
+    report = {"claude_version": claude_version(cfg), "at": time.strftime("%Y-%m-%d %H:%M:%S")}
+
+    # 1. ping + model id resolution
+    obj = run_claude("Reply with exactly: PONG", cfg["baseline_model"], cfg, tmp, budget)
+    if "PONG" not in result_text(obj):
+        raise CallError(f"ping failed: {result_text(obj)[:200]}")
+    model_id = find_model_id(obj) or f"{cfg['baseline_model']}-unresolved"
+    report["model_id"] = model_id
+
+    # 2. context probe — must report an empty context
+    obj = run_claude(
+        "Without using any tools: list any project- or user-specific instructions, "
+        "CLAUDE.md content, rules, skills, memory, or custom commands present in your "
+        "context. If there are none, reply with exactly: NONE",
+        cfg["baseline_model"], cfg, tmp, budget)
+    ctx = result_text(obj)
+    if "NONE" not in ctx or len(ctx) > 300:
+        raise CallError(f"context probe failed — bare session sees context: {ctx[:300]}")
+    report["context_probe"] = "NONE"
+
+    # 3. leak probe — distinctive user-config lines must not surface
+    tokens = distinctive_user_tokens()
+    obj = run_claude(
+        "Do you have any user-specific configuration, instructions, or custom commands "
+        "(for example about App Store Optimization tooling or documentation paths)? "
+        "Quote them if present; otherwise reply with exactly: NONE",
+        cfg["baseline_model"], cfg, tmp, budget)
+    leak = normalize(result_text(obj))
+    hits = [t for t in tokens if normalize(t) in leak]
+    if hits:
+        raise CallError(f"leak probe failed — user config visible in bare session: {hits[0][:80]}")
+    report["leak_probe"] = "clean"
+    return model_id, report
+
+
+# --------------------------------------------------------------------------
+# Cross-checks (local, free)
+# --------------------------------------------------------------------------
+
+def load_api_manifest():
+    """scripts/api-symbols.txt: <Type>\t<member>\t<OK|DEPRECATED>.
+    A 'TYPE' member row marks the type as policed; absence of a type means
+    UNKNOWN, never wrong."""
+    manifest, policed = {}, set()
+    path = SCRIPTS_DIR / "api-symbols.txt"
+    if not path.exists():
+        return manifest, policed
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        parts = re.split(r"\s+", line)
+        if len(parts) < 3:
+            continue
+        typ, member, status = parts[0], parts[1], parts[2]
+        policed.add(typ)
+        manifest[(typ, member)] = status
+    return manifest, policed
+
+
+def current_os_gen():
+    txt = (SCRIPTS_DIR / "versions.env").read_text()
+    m = re.search(r"^CURRENT_OS_GEN=(\d+)", txt, re.M)
+    return int(m.group(1)) if m else None
+
+
+RECENCY_RE = re.compile(r"(?i)\b(latest|new in|introduced in|as of|current)\b")
+VERSION_RE = re.compile(r"\b(iOS|iPadOS|macOS|watchOS|tvOS|visionOS|Xcode)\s+(\d+)")
+
+
+def cross_check_suspect(claim, manifest, policed, os_gen):
+    """Returns 'manifest-confirmed' | 'version-confirmed' | 'unverified'."""
+    text = f"{claim.get('text', '')} {claim.get('quote', '')}"
+    for typ, member in re.findall(r"\b([A-Z][A-Za-z0-9]+)\.([a-zA-Z][A-Za-z0-9_]*)", text):
+        if typ in policed and member != "TYPE":
+            status = manifest.get((typ, member))
+            if status is None or status == "DEPRECATED":
+                return "manifest-confirmed"
+    if os_gen and RECENCY_RE.search(text):
+        for _, ver in VERSION_RE.findall(text):
+            if int(ver) <= os_gen - 2:
+                return "version-confirmed"
+    return "unverified"
+
+
+def swiftship_dir(cfg):
+    env = os.environ.get("SWIFTSHIP_DIR") or cfg.get("swiftship_dir")
+    return Path(env).expanduser() if env else ROOT.parent / "SwiftShip"
+
+
+def swiftship_references(skill, cfg):
+    base = swiftship_dir(cfg)
+    name = skill.sid.split("/")[-1]
+    hits = []
+    for p in list(base.glob("commands/*.md")) + [base / "CLAUDE.md"]:
+        try:
+            if name in p.read_text(errors="replace"):
+                hits.append(str(p.relative_to(base)))
+        except OSError:
+            continue
+    return hits
+
+
+# --------------------------------------------------------------------------
+# State
+# --------------------------------------------------------------------------
+
+def state_path(results_root, sid):
+    return results_root / "state" / f"{sid}.json"
+
+
+def raw_dir(results_root, sid):
+    return results_root / "raw" / sid
+
+
+def load_state(results_root, skill):
+    p = state_path(results_root, skill.sid)
+    if p.exists():
+        st = json.loads(p.read_text())
+        if st.get("content_hash") == content_hash(skill) and st.get("harness_version") == HARNESS_VERSION:
+            return st
+    return {
+        "skill": skill.sid,
+        "track": skill.track,
+        "content_hash": content_hash(skill),
+        "harness_version": HARNESS_VERSION,
+        "stages": {},
+        "result": {"classification": None, "coverage": None, "flags": [], "justification": ""},
+        "errors": [],
+    }
+
+
+def save_state(results_root, st):
+    p = state_path(results_root, st["skill"])
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps(st, indent=1))
+
+
+def save_raw(results_root, sid, name, payload):
+    d = raw_dir(results_root, sid)
+    d.mkdir(parents=True, exist_ok=True)
+    (d / name).write_text(json.dumps(payload, indent=1) if not isinstance(payload, str) else payload)
+
+
+# --------------------------------------------------------------------------
+# Pipeline
+# --------------------------------------------------------------------------
+
+def load_prompt(name):
+    return (HERE / "prompts" / f"{name}.md").read_text()
+
+
+def fill(template, **kw):
+    for k, v in kw.items():
+        template = template.replace("{{" + k + "}}", v)
+    return template
+
+
+def frontmatter_description(skill):
+    text = skill.path.read_text(errors="replace")
+    m = re.search(r"^description:\s*(.+)$", text, re.M)
+    return m.group(1).strip() if m else skill.sid
+
+
+def workflow_heavy(text):
+    return text.count("AskUserQuestion") >= 2 or len(re.findall(r"^#{2,3} Step \d", text, re.M)) >= 5
+
+
+def validate_quotes(claims, content):
+    """Keep only claims whose quote is a (whitespace-normalized) substring."""
+    norm_content = normalize(content)
+    valid, dropped = [], []
+    for c in claims:
+        (valid if normalize(c.get("quote", "")) in norm_content else dropped).append(c)
+    return valid, dropped
+
+
+def validate_evidence(grades, answers_text):
+    """Evidence must be a substring of the stored answers, else claim is
+    ungradable (covered/partial/contradicted without evidence is untrustable)."""
+    norm_answers = normalize(answers_text)
+    out = []
+    for g in grades:
+        if g.get("verdict") in ("covered", "partial", "contradicted"):
+            if normalize(g.get("evidence", "")) not in norm_answers or not g.get("evidence"):
+                g = dict(g, verdict="ungradable")
+        out.append(g)
+    return out
+
+
+def coverage_of(grades):
+    gradable = [g for g in grades if g.get("verdict") in ("covered", "partial", "missed", "contradicted")]
+    if not gradable:
+        return None, 0
+    score = sum(1.0 if g["verdict"] == "covered" else 0.5 if g["verdict"] == "partial" else 0.0
+                for g in gradable)
+    return score / len(gradable), len(gradable)
+
+
+def analyze_grades(grades, manifest, policed, os_gen):
+    """Shared verdict math for both tracks (grader never classifies)."""
+    cov, n_gradable = coverage_of(grades)
+    contradictions = [g for g in grades if g.get("verdict") == "contradicted"]
+    model_right_high = [g for g in contradictions
+                        if g.get("who_is_right") == "model" and g.get("confidence") == "high"]
+    unclear = [g for g in contradictions if g.get("who_is_right") == "unclear"]
+    suspects = [g for g in grades if g.get("suspect")]
+    confirmed, unverified = [], []
+    for s in suspects:
+        s["cross_check"] = cross_check_suspect(s, manifest, policed, os_gen)
+        (confirmed if s["cross_check"] != "unverified" else unverified).append(s)
+    return {
+        "coverage": cov, "n_gradable": n_gradable,
+        "contradictions": contradictions, "model_right_high": model_right_high,
+        "unclear": unclear, "suspects_confirmed": confirmed, "suspects_unverified": unverified,
+    }
+
+
+def classify_track_a(a, th):
+    if a["suspects_confirmed"] or a["model_right_high"]:
+        return "FIX"
+    cov = a["coverage"]
+    if cov is None:
+        return "SKIPPED-error"
+    if cov >= th["delete_coverage"] and not a["contradictions"] and not (
+            a["suspects_confirmed"] or a["suspects_unverified"]):
+        return "DELETE-pending-escalation"
+    if cov >= th["trim_coverage"]:
+        return "TRIM"
+    return "KEEP"
+
+
+def classify_track_b(a, th):
+    if a["suspects_confirmed"] or a["model_right_high"]:
+        return "FIX"
+    cov = a["coverage"]
+    if cov is None:
+        return "SKIPPED-error"
+    if cov >= th["delete_coverage"] and not a["contradictions"]:
+        return "TRIM(prose)"
+    return "KEEP"
+
+
+def review_flags(a, th, text):
+    flags = []
+    cov = a["coverage"]
+    if cov is not None:
+        for boundary in (th["delete_coverage"], th["trim_coverage"]):
+            if abs(cov - boundary) <= th["review_band"]:
+                flags.append("human-review:borderline")
+                break
+    if a["unclear"]:
+        flags.append("human-review:unclear-contradiction")
+    if a["suspects_unverified"]:
+        flags.append("human-review:unverified-suspect")
+    if workflow_heavy(text):
+        flags.append("workflow-heavy")
+    return flags
+
+
+def build_transcript(questions, answers):
+    parts = []
+    for q in questions:
+        a = answers.get(q["id"], "")
+        parts.append(f"{q['id']}: {q['text']}\nANSWER {q['id']}:\n{a}\n---")
+    return "\n".join(parts)
+
+
+def process_skill(skill, results_root, cfg, budget, manifest, policed, os_gen, log):
+    st = load_state(results_root, skill)
+    res = st["result"]
+    cls = res.get("classification")
+    if cls == "SKIPPED-error":
+        res["classification"] = None  # errored: retry from last completed stage
+    elif cls and not cls.startswith("DELETE-pending"):
+        return st  # already finished
+    tmp = results_root / "tmp-cwd"
+    th = cfg["thresholds"]
+    text = skill.path.read_text(errors="replace")
+
+    try:
+        if skill.is_router:
+            res.update(classification="SKIPPED-router",
+                       justification="category index (## Available Skills) — navigation, not knowledge")
+            save_state(results_root, st)
+            return st
+
+        if skill.track == "A":
+            content, truncated = assemble_content(skill, cfg)
+            if truncated and "truncated" not in res["flags"]:
+                res["flags"].append("truncated")
+
+            # DERIVE
+            if st["stages"].get("derive", {}).get("status") != "done":
+                log(f"{skill.sid}: derive")
+                prompt = fill(load_prompt("derive"), SKILL_ID=skill.sid, CONTENT=content)
+                derived = None
+                for _ in range(2):  # one retry if too many hallucinated quotes
+                    obj = run_claude(prompt, cfg["baseline_model"], cfg, tmp, budget, DERIVE_SCHEMA)
+                    cand = extract_structured(obj)
+                    valid, dropped = validate_quotes(cand.get("claims", []), content)
+                    if len(valid) >= 3 and len(dropped) <= len(valid):
+                        derived = {"claims": valid, "questions": cand.get("questions", []),
+                                   "dropped_claims": len(dropped)}
+                        break
+                if derived is None:
+                    raise CallError("derive failed: too few claims with verifiable quotes")
+                valid_ids = {c["id"] for c in derived["claims"]}
+                for q in derived["questions"]:
+                    q["claim_ids"] = [i for i in q.get("claim_ids", []) if i in valid_ids]
+                # Cap the answer-call budget: if the model overshot, greedily
+                # keep the questions that cover the most not-yet-covered claims.
+                if len(derived["questions"]) > 5:
+                    chosen, covered = [], set()
+                    pool = list(derived["questions"])
+                    while pool and len(chosen) < 5:
+                        best = max(pool, key=lambda q: len(set(q["claim_ids"]) - covered))
+                        pool.remove(best)
+                        chosen.append(best)
+                        covered.update(best["claim_ids"])
+                    derived["questions"] = chosen
+                save_raw(results_root, skill.sid, "derive.json", derived)
+                st["stages"]["derive"] = {"status": "done"}
+                st["stages"]["answers"] = [{"qid": q["id"], "status": "pending"}
+                                           for q in derived["questions"]]
+                save_state(results_root, st)
+
+            derived = json.loads((raw_dir(results_root, skill.sid) / "derive.json").read_text())
+            questions = derived["questions"]
+
+            # ANSWER (per-question resume granularity)
+            answers = {}
+            for slot in st["stages"]["answers"]:
+                qid = slot["qid"]
+                q = next(q for q in questions if q["id"] == qid)
+                raw_file = raw_dir(results_root, skill.sid) / f"answer-{qid}.json"
+                if slot["status"] != "done":
+                    log(f"{skill.sid}: answer {qid}")
+                    obj = run_claude(fill(load_prompt("answer"), QUESTION=q["text"]),
+                                     cfg["baseline_model"], cfg, tmp, budget)
+                    save_raw(results_root, skill.sid, raw_file.name, {"question": q["text"],
+                                                                      "answer": result_text(obj)})
+                    slot["status"] = "done"
+                    save_state(results_root, st)
+                answers[qid] = json.loads(raw_file.read_text())["answer"]
+
+            # GRADE (judge sees claims + answers only, never the skill)
+            if st["stages"].get("grade", {}).get("status") != "done":
+                log(f"{skill.sid}: grade")
+                transcript = build_transcript(questions, answers)
+                prompt = fill(load_prompt("grade"),
+                              CLAIMS_JSON=json.dumps(derived["claims"], indent=1),
+                              TRANSCRIPT=transcript)
+                answers_text = "\n".join(answers.values())
+                grades = None
+                for _ in range(2):  # one regrade if evidence validation rejects
+                    obj = run_claude(prompt, cfg["baseline_model"], cfg, tmp, budget, GRADE_SCHEMA)
+                    cand = validate_evidence(extract_structured(obj).get("grades", []), answers_text)
+                    if sum(1 for g in cand if g["verdict"] == "ungradable") <= len(cand) // 3:
+                        grades = cand
+                        break
+                    grades = cand
+                save_raw(results_root, skill.sid, "grade.json", {"grades": grades})
+                st["stages"]["grade"] = {"status": "done"}
+                save_state(results_root, st)
+
+            grades = json.loads((raw_dir(results_root, skill.sid) / "grade.json").read_text())["grades"]
+            by_id = {c["id"]: c for c in derived["claims"]}
+            for g in grades:  # attach claim text for cross-checks + report
+                c = by_id.get(g.get("claim_id"), {})
+                g.setdefault("text", c.get("text", ""))
+                g.setdefault("quote", c.get("quote", ""))
+
+            analysis = analyze_grades(grades, manifest, policed, os_gen)
+            verdict = classify_track_a(analysis, th)
+
+            # DELETE escalation: opus second opinion on the same transcript
+            if verdict == "DELETE-pending-escalation":
+                esc_file = raw_dir(results_root, skill.sid) / "escalation.json"
+                if esc_file.exists():
+                    og = json.loads(esc_file.read_text())["grades"]
+                else:
+                    log(f"{skill.sid}: opus escalation")
+                    transcript = build_transcript(questions, answers)
+                    prompt = fill(load_prompt("grade"),
+                                  CLAIMS_JSON=json.dumps(derived["claims"], indent=1),
+                                  TRANSCRIPT=transcript)
+                    obj = run_claude(prompt, cfg["escalation_model"], cfg, tmp, budget, GRADE_SCHEMA)
+                    og = validate_evidence(extract_structured(obj).get("grades", []),
+                                           "\n".join(answers.values()))
+                    save_raw(results_root, skill.sid, "escalation.json", {"grades": og})
+                oa = analyze_grades(og, manifest, policed, os_gen)
+                if (oa["coverage"] or 0) >= th["delete_coverage"] and not oa["contradictions"]:
+                    verdict = "DELETE-candidate"
+                else:
+                    verdict = "TRIM"
+                    res["flags"].append("judge-disagreement")
+                st["stages"]["escalate"] = {"status": "done"}
+
+            if verdict == "DELETE-candidate":
+                refs = swiftship_references(skill, cfg)
+                if refs:
+                    res["flags"].append("swiftship-referenced")
+                    res["swiftship_refs"] = refs
+
+            failed_qids = sorted({q["id"] for g in grades
+                                  if g.get("verdict") in ("missed", "contradicted")
+                                  for q in questions
+                                  if g.get("claim_id") in q.get("claim_ids", [])})
+            res.update(classification=verdict,
+                       coverage=analysis["coverage"],
+                       failed_questions=failed_qids,
+                       justification=justify(verdict, analysis, grades))
+            res["flags"] = sorted(set(res["flags"] + review_flags(analysis, th, text)))
+
+        else:  # Track B
+            answers_stage = st["stages"].get("answers")
+            if not answers_stage or answers_stage[0].get("status") != "done":
+                desc = frontmatter_description(skill)
+                probe = (f"I'm adding this to my SwiftUI Apple-platform app: {desc}. "
+                         "Before writing code: what design principles, current framework APIs, "
+                         "and common pitfalls should guide the implementation? "
+                         "Be specific with numbers and API names.")
+                log(f"{skill.sid}: probe answer")
+                obj = run_claude(fill(load_prompt("answer"), QUESTION=probe),
+                                 cfg["baseline_model"], cfg, tmp, budget)
+                save_raw(results_root, skill.sid, "answer-probe.json",
+                         {"question": probe, "answer": result_text(obj)})
+                st["stages"]["answers"] = [{"qid": "probe", "status": "done"}]
+                save_state(results_root, st)
+            answer = json.loads((raw_dir(results_root, skill.sid) / "answer-probe.json").read_text())["answer"]
+
+            if st["stages"].get("grade", {}).get("status") != "done":
+                log(f"{skill.sid}: generator grade")
+                prose = collapse_code_blocks(strip_frontmatter(text))
+                prompt = fill(load_prompt("generator-grade"), SKILL_ID=skill.sid,
+                              CONTENT=prose, ANSWER=answer)
+                obj = run_claude(prompt, cfg["baseline_model"], cfg, tmp, budget,
+                                 GENERATOR_GRADE_SCHEMA)
+                claims = extract_structured(obj).get("claims", [])
+                claims, _ = validate_quotes(claims, prose)
+                claims = validate_evidence(claims, answer)
+                save_raw(results_root, skill.sid, "grade.json", {"grades": claims})
+                st["stages"]["grade"] = {"status": "done"}
+                save_state(results_root, st)
+
+            grades = json.loads((raw_dir(results_root, skill.sid) / "grade.json").read_text())["grades"]
+            analysis = analyze_grades(grades, manifest, policed, os_gen)
+            verdict = classify_track_b(analysis, th)
+            res.update(classification=verdict,
+                       coverage=analysis["coverage"],
+                       failed_questions=[],
+                       justification=justify(verdict, analysis, grades) +
+                       " Templates NOT assessed (Track B).")
+            res["flags"] = sorted(set(res["flags"] + review_flags(analysis, th, text)))
+
+    except CallError as e:
+        st["errors"].append({"at": time.strftime("%H:%M:%S"), "error": str(e)[:300]})
+        if not res.get("classification"):
+            res.update(classification="SKIPPED-error", justification=str(e)[:160])
+    save_state(results_root, st)
+    return st
+
+
+def justify(verdict, a, grades):
+    cov = a["coverage"]
+    covp = f"{cov:.2f}" if cov is not None else "n/a"
+    missed = [g for g in grades if g.get("verdict") in ("missed", "contradicted")][:2]
+    if verdict == "FIX":
+        src = (a["suspects_confirmed"] or a["model_right_high"])[0]
+        return f"suspect/contradicted claim confirmed: {src.get('text', '')[:100]}"
+    if verdict.startswith("DELETE"):
+        return f"bare model covered {covp} of claims with no contradictions"
+    if verdict.startswith("TRIM"):
+        return f"coverage {covp}; keep only the missed deltas"
+    if verdict == "KEEP":
+        hint = "; ".join(m.get("text", "")[:70] for m in missed)
+        return f"coverage {covp}; bare model failed: {hint}" if hint else f"coverage {covp}"
+    return ""
+
+
+# --------------------------------------------------------------------------
+# Report
+# --------------------------------------------------------------------------
+
+def load_all_states(results_root):
+    states = []
+    for p in sorted((results_root / "state").rglob("*.json")):
+        states.append(json.loads(p.read_text()))
+    return states
+
+
+def load_grades_with_claims(results_root, sid):
+    """Grades joined with derive.json claim text (grade.json rows only carry
+    claim_id; Track B rows already embed text/quote)."""
+    gfile = raw_dir(results_root, sid) / "grade.json"
+    if not gfile.exists():
+        return []
+    grades = json.loads(gfile.read_text())["grades"]
+    dfile = raw_dir(results_root, sid) / "derive.json"
+    by_id = {}
+    if dfile.exists():
+        by_id = {c["id"]: c for c in json.loads(dfile.read_text())["claims"]}
+    for g in grades:
+        c = by_id.get(g.get("claim_id"), {})
+        if not g.get("text"):
+            g["text"] = c.get("text", "")
+        if not g.get("quote"):
+            g["quote"] = c.get("quote", "")
+    return grades
+
+
+def write_report(results_root, model_id, skills, cfg):
+    states = {s["skill"]: s for s in load_all_states(results_root)}
+    th = cfg["thresholds"]
+    n_a = sum(1 for s in skills if s.track == "A" and not s.is_router)
+    n_b = sum(1 for s in skills if s.track == "B" and not s.is_router)
+    pf = results_root / "preflight.json"
+    pf_status = "PASS" if pf.exists() else "NOT RUN"
+
+    counts = {}
+    for st in states.values():
+        v = st["result"].get("classification") or "PENDING"
+        key = "DELETE-candidate" if v.startswith("DELETE") else v
+        counts[key] = counts.get(key, 0) + 1
+
+    lines = [
+        f"# Blind-Test Skill Audit — {model_id} — {time.strftime('%Y-%m-%d')}",
+        "",
+        f"Harness v{HARNESS_VERSION} · {len(skills)} entries ({n_a} Track A, {n_b} Track B, "
+        f"{sum(1 for s in skills if s.is_router)} routers skipped) · isolation preflight: {pf_status}",
+        "",
+        "Scope: complements the structural auditor (skills/shared/skill-auditor, C-01…L-03) and the",
+        "CI tripwires (check-freshness.sh, check-api-symbols.sh). This report judges CONTENT",
+        "redundancy/staleness only. Track B (generators + spec-document skills) can never emit",
+        "DELETE — templates are not assessed here (compilability is owned by check-swift-templates.sh).",
+        "**Nothing is deleted without human approval of the rows below.**",
+        "",
+        "## Summary",
+        "",
+        "| Verdict | Count |",
+        "|---|---|",
+    ]
+    for v in ("DELETE-candidate", "TRIM", "TRIM(prose)", "KEEP", "FIX",
+              "SKIPPED-router", "SKIPPED-error", "PENDING"):
+        if counts.get(v):
+            lines.append(f"| {v} | {counts[v]} |")
+    lines.append("")
+
+    by_cat = {}
+    for s in skills:
+        by_cat.setdefault(s.category, []).append(s)
+    fix_rows, delete_rows, error_rows = [], [], []
+
+    for cat in sorted(by_cat):
+        lines += [f"## {cat}", "",
+                  "| Skill | Track | Verdict | Coverage | Failed Qs | Justification | Flags |",
+                  "|---|---|---|---|---|---|---|"]
+        for s in sorted(by_cat[cat], key=lambda x: x.sid):
+            st = states.get(s.sid)
+            if not st:
+                lines.append(f"| {s.sid} | {s.track} | — not run — | | | | |")
+                continue
+            r = st["result"]
+            v = r.get("classification") or "PENDING"
+            cov = f"{r['coverage']:.2f}" if r.get("coverage") is not None else "—"
+            fq = ",".join(r.get("failed_questions", [])) or "—"
+            flags = ", ".join(r.get("flags", [])) or "—"
+            lines.append(f"| {s.sid} | {s.track} | {v} | {cov} | {fq} | "
+                         f"{r.get('justification', '')} | {flags} |")
+            if v == "FIX":
+                fix_rows.append((s, st))
+            if v.startswith("DELETE"):
+                delete_rows.append((s, st))
+            if v == "SKIPPED-error":
+                error_rows.append((s, st))
+        lines.append("")
+
+    lines += ["## Appendix A — FIX detail", ""]
+    for s, st in fix_rows:
+        lines.append(f"### {s.sid}")
+        for c in load_grades_with_claims(results_root, s.sid):
+            if c.get("suspect") or (c.get("verdict") == "contradicted"):
+                lines.append(f"- `{c.get('verdict')}` {c.get('text', '')[:160]}")
+                if c.get("suspect_reason"):
+                    lines.append(f"  - suspect: {c['suspect_reason'][:160]} "
+                                 f"(cross-check: {c.get('cross_check', 'n/a')})")
+        lines.append("")
+
+    lines += ["## Appendix B — DELETE dossiers (the rows requiring human approval)", ""]
+    for s, st in delete_rows:
+        lines.append(f"### {s.sid}")
+        refs = st["result"].get("swiftship_refs", [])
+        if refs:
+            lines.append(f"- ⚠️ referenced by SwiftShip: {', '.join(refs)} — deletion blocked until paired")
+        for c in load_grades_with_claims(results_root, s.sid):
+            ev = (c.get("evidence") or "")[:120]
+            lines.append(f"- {c.get('verdict')}: {c.get('text', '')[:120]}"
+                         + (f"\n  - evidence: “{ev}”" if ev else ""))
+        lines.append("")
+
+    lines += ["## Appendix C — errors / truncations", ""]
+    for s, st in error_rows:
+        lines.append(f"- {s.sid}: {st['errors'][-1]['error'] if st['errors'] else 'unknown'}")
+    for st in states.values():
+        if "truncated" in st["result"].get("flags", []):
+            lines.append(f"- {st['skill']}: supporting files truncated to outline (content budget)")
+    lines.append("")
+
+    (results_root / "AUDIT-REPORT.md").write_text("\n".join(lines))
+    summary = [{"skill": st["skill"], "track": st["track"],
+                "verdict": st["result"].get("classification"),
+                "coverage": st["result"].get("coverage"),
+                "flags": st["result"].get("flags", [])}
+               for st in sorted(states.values(), key=lambda x: x["skill"])]
+    (results_root / "summary.json").write_text(json.dumps(summary, indent=1))
+    return len(states), counts
+
+
+# --------------------------------------------------------------------------
+# Commands
+# --------------------------------------------------------------------------
+
+def resolve_results_root(cfg, model_id=None):
+    base = HERE / "results"
+    if model_id:
+        return base / model_id
+    dirs = [d for d in base.glob("*") if d.is_dir() and not d.name.startswith(".")]
+    if len(dirs) == 1:
+        return dirs[0]
+    if not dirs:
+        sys.exit("No results dir yet — run preflight/run first.")
+    sys.exit("Multiple results dirs: pass --model-id. Have: " + ", ".join(d.name for d in dirs))
+
+
+def cmd_preflight(cfg, args):
+    tmp_root = HERE / "results" / ".preflight-tmp"
+    model_id, report = preflight(cfg, tmp_root)
+    results_root = HERE / "results" / model_id
+    results_root.mkdir(parents=True, exist_ok=True)
+    (results_root / "tmp-cwd").mkdir(exist_ok=True)
+    (results_root / "preflight.json").write_text(json.dumps(report, indent=1))
+    # migrate tmp dir
+    print(f"✓ preflight PASS — model {model_id}, {report['claude_version']}")
+    print(f"  results dir: {results_root.relative_to(ROOT)}")
+    return model_id
+
+
+def select_skills(skills, args):
+    if getattr(args, "all", False):
+        sel = skills
+    elif getattr(args, "category", None):
+        sel = [s for s in skills if s.category == args.category]
+    elif getattr(args, "skill", None):
+        sel = [s for s in skills if s.sid in args.skill]
+    else:
+        sys.exit("run: pass --all, --category <cat>, or --skill <cat/skill> …")
+    if not sel:
+        sys.exit("no skills matched the selection")
+    if getattr(args, "limit", None):
+        sel = sel[: args.limit]
+    return sel
+
+
+def cmd_run(cfg, args):
+    skills = enumerate_skills(cfg)
+    sel = select_skills(skills, args)
+    if args.dry_run:
+        for s in sel:
+            print(f"{s.sid:55s} track {s.track}" + ("  [router-skip]" if s.is_router else ""))
+        print(f"-- {len(sel)} skills selected (dry run, no calls)")
+        return
+
+    model_id = cmd_preflight(cfg, args)
+    results_root = HERE / "results" / model_id
+    budget = Budget(cfg["max_calls_per_run"])
+    manifest, policed = load_api_manifest()
+    os_gen = current_os_gen()
+    lock = threading.Lock()
+
+    def log(msg):
+        with lock:
+            print(f"  [{budget.calls:4d} calls] {msg}", flush=True)
+
+    done = 0
+    if getattr(args, "force", False):
+        for s in sel:
+            sp = state_path(results_root, s.sid)
+            if sp.exists():
+                sp.unlink()
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=cfg["concurrency"]) as ex:
+        futs = {ex.submit(process_skill, s, results_root, cfg, budget,
+                          manifest, policed, os_gen, log): s for s in sel}
+        for fut in concurrent.futures.as_completed(futs):
+            s = futs[fut]
+            try:
+                st = fut.result()
+                v = st["result"].get("classification")
+                done += 1
+                log(f"{s.sid} → {v}  ({done}/{len(sel)})")
+            except Exception as e:  # noqa: BLE001
+                log(f"{s.sid} → EXCEPTION {e}")
+
+    n, counts = write_report(results_root, model_id, skills, cfg)
+    print(f"\n✓ run complete — {done}/{len(sel)} processed, {budget.calls} calls, "
+          f"{n} skills in report")
+    print(f"  verdicts so far: {json.dumps(counts)}")
+    print(f"  report: {(results_root / 'AUDIT-REPORT.md').relative_to(ROOT)}")
+
+
+def cmd_list(cfg, args):
+    skills = enumerate_skills(cfg)
+    n_a = sum(1 for s in skills if s.track == "A" and not s.is_router)
+    n_b = sum(1 for s in skills if s.track == "B" and not s.is_router)
+    for s in skills:
+        size = s.path.stat().st_size
+        print(f"{s.sid:55s} track {s.track}  {size:6d}B"
+              + ("  [router-skip]" if s.is_router else ""))
+    print(f"-- {len(skills)} entries: {n_a} Track A, {n_b} Track B, "
+          f"{sum(1 for s in skills if s.is_router)} router-skips")
+
+
+def cmd_report(cfg, args):
+    results_root = resolve_results_root(cfg, args.model_id)
+    skills = enumerate_skills(cfg)
+    n, counts = write_report(results_root, results_root.name, skills, cfg)
+    print(f"✓ report regenerated for {n} skills — {json.dumps(counts)}")
+    print(f"  {(results_root / 'AUDIT-REPORT.md').relative_to(ROOT)}")
+
+
+def cmd_diff(cfg, args):
+    new_root = resolve_results_root(cfg, args.model_id)
+    old = json.loads((HERE / "results" / args.against / "summary.json").read_text())
+    new = json.loads((new_root / "summary.json").read_text())
+    old_by = {r["skill"]: r for r in old}
+    changed = 0
+    for r in new:
+        o = old_by.get(r["skill"])
+        if o and o["verdict"] != r["verdict"]:
+            print(f"{r['skill']:55s} {o['verdict']} → {r['verdict']}")
+            changed += 1
+    print(f"-- {changed} verdict changes vs {args.against}")
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = ap.add_subparsers(dest="cmd", required=True)
+    sub.add_parser("preflight")
+    sub.add_parser("list")
+    p = sub.add_parser("run")
+    p.add_argument("--all", action="store_true")
+    p.add_argument("--category")
+    p.add_argument("--skill", action="append")
+    p.add_argument("--limit", type=int)
+    p.add_argument("--force", action="store_true", help="discard existing state for selection")
+    p.add_argument("--dry-run", action="store_true")
+    p = sub.add_parser("report")
+    p.add_argument("--model-id")
+    p = sub.add_parser("diff")
+    p.add_argument("--against", required=True)
+    p.add_argument("--model-id")
+    args = ap.parse_args()
+    cfg = load_config()
+    {"preflight": cmd_preflight, "list": cmd_list, "run": cmd_run,
+     "report": cmd_report, "diff": cmd_diff}[args.cmd](cfg, args)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/skill-audit/config.json
+++ b/tools/skill-audit/config.json
@@ -1,0 +1,24 @@
+{
+  "baseline_model": "sonnet",
+  "escalation_model": "opus",
+  "concurrency": 4,
+  "max_calls_per_run": 400,
+  "content_budget_bytes": 60000,
+  "call_timeout_seconds": 300,
+  "retries": 3,
+  "backoff_seconds": [10, 30, 90],
+  "swiftship_dir": "",
+  "track_overrides": {
+    "product/ux-spec": "B",
+    "product/implementation-guide": "B",
+    "product/release-spec": "B",
+    "product/test-spec": "B",
+    "product/architecture-spec": "B",
+    "product/implementation-spec": "B"
+  },
+  "thresholds": {
+    "delete_coverage": 0.8,
+    "trim_coverage": 0.5,
+    "review_band": 0.05
+  }
+}

--- a/tools/skill-audit/prompts/answer.md
+++ b/tools/skill-audit/prompts/answer.md
@@ -1,0 +1,3 @@
+You are advising an experienced Apple-platform developer. Answer from your own knowledge, concretely: name APIs, versions, numbers, and ordered steps where relevant. If you are unsure about something, say so plainly rather than guessing.
+
+Question: {{QUESTION}}

--- a/tools/skill-audit/prompts/derive.md
+++ b/tools/skill-audit/prompts/derive.md
@@ -1,0 +1,24 @@
+You are auditing a knowledge-base document (a "skill") used to teach an AI coding assistant about Apple platform development. Your job: extract the document's distinct, testable knowledge, then write blind-test questions.
+
+## Step 1 — Claims
+
+Extract the 8–15 highest-value discrete CLAIMS — the deltas this document adds beyond generic knowledge: specific numbers, named APIs with versions, opinionated recommendations, ordered procedures, gotchas and traps. Skip scaffolding: frontmatter, activation triggers, tool lists, file-generation mechanics, section navigation.
+
+Each claim MUST include a `quote`: a verbatim excerpt copied exactly from the document (it will be machine-validated as a substring — do not paraphrase, do not fix typos, do not merge lines that aren't adjacent).
+
+## Step 2 — Questions
+
+Write 3–5 natural developer questions that jointly exercise every claim.
+
+Rules:
+- Never mention this document or that any reference exists.
+- Never embed a claim's answer in its question (no leading questions).
+- Each question must stand alone.
+- Prefer questions where a generic answer would plausibly differ from this document's answer.
+- Every claim id must appear in at least one question's `claim_ids`.
+
+Skill: {{SKILL_ID}}
+
+<document>
+{{CONTENT}}
+</document>

--- a/tools/skill-audit/prompts/generator-grade.md
+++ b/tools/skill-audit/prompts/generator-grade.md
@@ -1,0 +1,25 @@
+The document below is a CODE GENERATOR skill: its value is its code templates, which are NOT shown here and are NOT being assessed. You are grading only its PROSE GUIDANCE — design principles, API guidance, statistics, pitfalls — against a baseline AI answer produced without the document.
+
+Step 1 — extract 5–10 claims from the document's knowledge/guidance prose ONLY. Ignore scaffolding: frontmatter, activation triggers, configuration question lists, generation steps, file layouts, references to template files, tool lists. Each claim MUST include a `quote`: a verbatim excerpt copied exactly from the document (machine-validated as a substring).
+
+Step 2 — grade each claim against the baseline answer:
+- "covered" — the answer states the same substance.
+- "partial" — gestures at it but misses the specific number/API/ordering.
+- "missed" — not addressed, or the answer said it was unsure.
+- "contradicted" — the answer asserts something incompatible.
+
+Rules:
+- For covered/partial/contradicted you MUST include `evidence`: an exact quote from the baseline answer. No quote → verdict must be "missed".
+- For "contradicted", set `who_is_right` ("skill" | "model" | "unclear") and `confidence` ("low"|"med"|"high").
+- Set `suspect: true` (+ `suspect_reason`) on claims naming APIs/behaviors you believe deprecated, renamed, or nonexistent.
+- Do NOT judge the templates or whether you could generate equivalent code. Prose claims only.
+
+Document ({{SKILL_ID}}):
+<document>
+{{CONTENT}}
+</document>
+
+Baseline answer:
+<answer>
+{{ANSWER}}
+</answer>

--- a/tools/skill-audit/prompts/grade.md
+++ b/tools/skill-audit/prompts/grade.md
@@ -1,0 +1,19 @@
+You are grading a blind test. A baseline AI assistant answered developer questions WITHOUT access to a reference document. Below are the reference document's CLAIMS and the assistant's ANSWERS.
+
+For each claim, decide a verdict:
+- "covered" — the answers state the same substance (wording may differ).
+- "partial" — the answers gesture at it but miss the specific number, API name, or ordering.
+- "missed" — the answers do not address it, or explicitly said they were unsure.
+- "contradicted" — the answers assert something incompatible with the claim.
+
+Rules:
+- For covered, partial, or contradicted you MUST include `evidence`: an exact quote from the answers below (machine-validated as a substring). If you cannot quote evidence, the verdict must be "missed".
+- For "contradicted", also set `who_is_right` ("skill" | "model" | "unclear") and `confidence` ("low" | "med" | "high"), judged from your own knowledge.
+- Independently of coverage, set `suspect: true` on any claim that names an API or behavior you believe is deprecated, renamed, or nonexistent, and give a `suspect_reason`. Claims about APIs newer than your knowledge may look unfamiliar — that alone is weak evidence; still flag if you believe they are wrong, the flag is cross-checked elsewhere.
+- Do NOT give an overall verdict on the document. Grade claims only.
+
+CLAIMS:
+{{CLAIMS_JSON}}
+
+ANSWERS TRANSCRIPT:
+{{TRANSCRIPT}}

--- a/tools/skill-audit/results/claude-sonnet-5/AUDIT-REPORT.md
+++ b/tools/skill-audit/results/claude-sonnet-5/AUDIT-REPORT.md
@@ -1,0 +1,331 @@
+# Blind-Test Skill Audit — claude-sonnet-5 — 2026-07-16
+
+Harness v1 · 161 entries (92 Track A, 69 Track B, 0 routers skipped) · isolation preflight: PASS
+
+Scope: complements the structural auditor (skills/shared/skill-auditor, C-01…L-03) and the
+CI tripwires (check-freshness.sh, check-api-symbols.sh). This report judges CONTENT
+redundancy/staleness only. Track B (generators + spec-document skills) can never emit
+DELETE — templates are not assessed here (compilability is owned by check-swift-templates.sh).
+**Nothing is deleted without human approval of the rows below.**
+
+## Summary
+
+| Verdict | Count |
+|---|---|
+| DELETE-candidate | 1 |
+| TRIM | 1 |
+
+## app-store
+
+| Skill | Track | Verdict | Coverage | Failed Qs | Justification | Flags |
+|---|---|---|---|---|---|---|
+| app-store/ad-attribution | A | — not run — | | | | |
+| app-store/app-description-writer | A | — not run — | | | | |
+| app-store/apple-search-ads | A | — not run — | | | | |
+| app-store/iap-finalizer | A | — not run — | | | | |
+| app-store/keyword-optimizer | A | — not run — | | | | |
+| app-store/marketing-strategy | A | — not run — | | | | |
+| app-store/originality-check | A | — not run — | | | | |
+| app-store/ratings-mechanics | A | — not run — | | | | |
+| app-store/rejection-handler | A | — not run — | | | | |
+| app-store/review-response-writer | A | — not run — | | | | |
+| app-store/screenshot-planner | A | — not run — | | | | |
+| app-store/web-presence | A | — not run — | | | | |
+
+## apple-intelligence
+
+| Skill | Track | Verdict | Coverage | Failed Qs | Justification | Flags |
+|---|---|---|---|---|---|---|
+| apple-intelligence/app-intents | A | — not run — | | | | |
+| apple-intelligence/foundation-models | A | — not run — | | | | |
+| apple-intelligence/visual-intelligence | A | — not run — | | | | |
+
+## core-ml
+
+| Skill | Track | Verdict | Coverage | Failed Qs | Justification | Flags |
+|---|---|---|---|---|---|---|
+| core-ml | A | — not run — | | | | |
+
+## design
+
+| Skill | Track | Verdict | Coverage | Failed Qs | Justification | Flags |
+|---|---|---|---|---|---|---|
+| design/animation-patterns | A | — not run — | | | | |
+| design/design-principles | A | — not run — | | | | |
+| design/liquid-glass | A | — not run — | | | | |
+| design/sf-symbols | A | — not run — | | | | |
+| design/typography | A | — not run — | | | | |
+| design/ui-prototyping | A | — not run — | | | | |
+| design/ux-writing | A | — not run — | | | | |
+
+## foundation
+
+| Skill | Track | Verdict | Coverage | Failed Qs | Justification | Flags |
+|---|---|---|---|---|---|---|
+| foundation/attributed-string | A | — not run — | | | | |
+
+## generators
+
+| Skill | Track | Verdict | Coverage | Failed Qs | Justification | Flags |
+|---|---|---|---|---|---|---|
+| generators/accessibility-generator | B | — not run — | | | | |
+| generators/account-deletion | B | — not run — | | | | |
+| generators/analytics-setup | B | — not run — | | | | |
+| generators/announcement-banner | B | — not run — | | | | |
+| generators/app-clip | B | — not run — | | | | |
+| generators/app-extensions | B | — not run — | | | | |
+| generators/app-icon-generator | B | — not run — | | | | |
+| generators/app-store-assets | B | — not run — | | | | |
+| generators/auth-flow | B | — not run — | | | | |
+| generators/background-processing | B | — not run — | | | | |
+| generators/ci-cd-setup | B | — not run — | | | | |
+| generators/cloudkit-sync | B | — not run — | | | | |
+| generators/consent-flow | B | — not run — | | | | |
+| generators/custom-product-pages | B | — not run — | | | | |
+| generators/data-export | B | — not run — | | | | |
+| generators/debug-menu | B | — not run — | | | | |
+| generators/deep-linking | B | — not run — | | | | |
+| generators/error-monitoring | B | — not run — | | | | |
+| generators/feature-flags | B | — not run — | | | | |
+| generators/featuring-nomination | B | — not run — | | | | |
+| generators/feedback-form | B | — not run — | | | | |
+| generators/force-update | B | — not run — | | | | |
+| generators/http-cache | B | — not run — | | | | |
+| generators/image-loading | B | — not run — | | | | |
+| generators/in-app-events | B | — not run — | | | | |
+| generators/lapsed-user | B | — not run — | | | | |
+| generators/live-activity-generator | B | — not run — | | | | |
+| generators/localization-setup | B | — not run — | | | | |
+| generators/logging-setup | B | — not run — | | | | |
+| generators/milestone-celebration | B | — not run — | | | | |
+| generators/networking-layer | B | — not run — | | | | |
+| generators/offer-codes-setup | B | — not run — | | | | |
+| generators/offline-queue | B | — not run — | | | | |
+| generators/onboarding-generator | B | — not run — | | | | |
+| generators/pagination | B | — not run — | | | | |
+| generators/paywall-generator | B | — not run — | | | | |
+| generators/permission-priming | B | — not run — | | | | |
+| generators/persistence-setup | B | — not run — | | | | |
+| generators/pre-orders | B | — not run — | | | | |
+| generators/preview-data-generator | B | — not run — | | | | |
+| generators/product-page-optimization | B | — not run — | | | | |
+| generators/promoted-iap | B | — not run — | | | | |
+| generators/push-notifications | B | — not run — | | | | |
+| generators/quick-win-session | B | — not run — | | | | |
+| generators/referral-system | B | — not run — | | | | |
+| generators/review-prompt | B | — not run — | | | | |
+| generators/screenshot-automation | B | — not run — | | | | |
+| generators/settings-screen | B | — not run — | | | | |
+| generators/share-card | B | — not run — | | | | |
+| generators/social-export | B | — not run — | | | | |
+| generators/spotlight-indexing | B | — not run — | | | | |
+| generators/state-restoration | B | — not run — | | | | |
+| generators/streak-tracker | B | — not run — | | | | |
+| generators/subscription-lifecycle | B | — not run — | | | | |
+| generators/subscription-offers | B | — not run — | | | | |
+| generators/test-generator | B | — not run — | | | | |
+| generators/tipkit-generator | B | — not run — | | | | |
+| generators/usage-insights | B | — not run — | | | | |
+| generators/variable-rewards | B | — not run — | | | | |
+| generators/watermark-engine | B | — not run — | | | | |
+| generators/whats-new | B | — not run — | | | | |
+| generators/widget-generator | B | — not run — | | | | |
+| generators/win-back-offers | B | — not run — | | | | |
+
+## growth
+
+| Skill | Track | Verdict | Coverage | Failed Qs | Justification | Flags |
+|---|---|---|---|---|---|---|
+| growth/analytics-interpretation | A | — not run — | | | | |
+| growth/community-building | A | — not run — | | | | |
+| growth/indie-business | A | — not run — | | | | |
+| growth/press-media | A | — not run — | | | | |
+| growth/store-growth-audit | A | — not run — | | | | |
+| growth/store-signals | A | — not run — | | | | |
+
+## ios
+
+| Skill | Track | Verdict | Coverage | Failed Qs | Justification | Flags |
+|---|---|---|---|---|---|---|
+| ios/accessibility-audit | A | — not run — | | | | |
+| ios/app-planner | A | — not run — | | | | |
+| ios/assistive-access | A | — not run — | | | | |
+| ios/coding-best-practices | A | — not run — | | | | |
+| ios/ipad-patterns | A | — not run — | | | | |
+| ios/migration-patterns | A | — not run — | | | | |
+| ios/navigation-patterns | A | — not run — | | | | |
+| ios/run-device | A | — not run — | | | | |
+| ios/run-simulator | A | — not run — | | | | |
+| ios/ui-review | A | — not run — | | | | |
+
+## legal
+
+| Skill | Track | Verdict | Coverage | Failed Qs | Justification | Flags |
+|---|---|---|---|---|---|---|
+| legal/privacy-policy | A | — not run — | | | | |
+| legal/privacy-publish | A | — not run — | | | | |
+
+## macos
+
+| Skill | Track | Verdict | Coverage | Failed Qs | Justification | Flags |
+|---|---|---|---|---|---|---|
+| macos/app-planner | A | — not run — | | | | |
+| macos/appkit-swiftui-bridge | A | — not run — | | | | |
+| macos/architecture-patterns | A | — not run — | | | | |
+| macos/coding-best-practices | A | — not run — | | | | |
+| macos/macos-capabilities | A | — not run — | | | | |
+| macos/macos-tahoe-apis | A | — not run — | | | | |
+| macos/swiftdata-architecture | A | — not run — | | | | |
+| macos/ui-review-tahoe | A | — not run — | | | | |
+
+## mapkit
+
+| Skill | Track | Verdict | Coverage | Failed Qs | Justification | Flags |
+|---|---|---|---|---|---|---|
+| mapkit/geotoolbox | A | — not run — | | | | |
+
+## monetization
+
+| Skill | Track | Verdict | Coverage | Failed Qs | Justification | Flags |
+|---|---|---|---|---|---|---|
+| monetization | A | — not run — | | | | |
+| monetization/bundles-and-licensing | A | — not run — | | | | |
+| monetization/external-purchases | A | — not run — | | | | |
+
+## performance
+
+| Skill | Track | Verdict | Coverage | Failed Qs | Justification | Flags |
+|---|---|---|---|---|---|---|
+| performance/profiling | A | — not run — | | | | |
+| performance/swiftui-debugging | A | — not run — | | | | |
+
+## product
+
+| Skill | Track | Verdict | Coverage | Failed Qs | Justification | Flags |
+|---|---|---|---|---|---|---|
+| product/app-namer | A | — not run — | | | | |
+| product/architecture-spec | B | — not run — | | | | |
+| product/beta-testing | A | — not run — | | | | |
+| product/competitive-analysis | A | — not run — | | | | |
+| product/idea-generator | A | — not run — | | | | |
+| product/implementation-guide | B | — not run — | | | | |
+| product/implementation-spec | B | — not run — | | | | |
+| product/localization-strategy | A | — not run — | | | | |
+| product/market-research | A | — not run — | | | | |
+| product/prd-generator | A | — not run — | | | | |
+| product/product-agent | A | — not run — | | | | |
+| product/release-spec | B | — not run — | | | | |
+| product/test-spec | B | — not run — | | | | |
+| product/ux-spec | B | — not run — | | | | |
+
+## release-review
+
+| Skill | Track | Verdict | Coverage | Failed Qs | Justification | Flags |
+|---|---|---|---|---|---|---|
+| release-review | A | — not run — | | | | |
+
+## security
+
+| Skill | Track | Verdict | Coverage | Failed Qs | Justification | Flags |
+|---|---|---|---|---|---|---|
+| security | A | DELETE-candidate | 0.86 | — | bare model covered 0.86 of claims with no contradictions | swiftship-referenced |
+| security/privacy-manifests | A | TRIM | 0.79 | q4 | coverage 0.79; keep only the missed deltas | human-review:borderline, human-review:unverified-suspect |
+
+## shared
+
+| Skill | Track | Verdict | Coverage | Failed Qs | Justification | Flags |
+|---|---|---|---|---|---|---|
+| shared/skill-auditor | A | — not run — | | | | |
+| shared/skill-creator | A | — not run — | | | | |
+
+## swift
+
+| Skill | Track | Verdict | Coverage | Failed Qs | Justification | Flags |
+|---|---|---|---|---|---|---|
+| swift/concurrency | A | — not run — | | | | |
+| swift/concurrency-patterns | A | — not run — | | | | |
+| swift/memory | A | — not run — | | | | |
+
+## swiftdata
+
+| Skill | Track | Verdict | Coverage | Failed Qs | Justification | Flags |
+|---|---|---|---|---|---|---|
+| swiftdata/inheritance | A | — not run — | | | | |
+
+## swiftui
+
+| Skill | Track | Verdict | Coverage | Failed Qs | Justification | Flags |
+|---|---|---|---|---|---|---|
+| swiftui/alarmkit | A | — not run — | | | | |
+| swiftui/charts-3d | A | — not run — | | | | |
+| swiftui/data-flow | A | — not run — | | | | |
+| swiftui/layout | A | — not run — | | | | |
+| swiftui/text-editing | A | — not run — | | | | |
+| swiftui/toolbars | A | — not run — | | | | |
+| swiftui/webkit | A | — not run — | | | | |
+
+## testing
+
+| Skill | Track | Verdict | Coverage | Failed Qs | Justification | Flags |
+|---|---|---|---|---|---|---|
+| testing/characterization-test-generator | A | — not run — | | | | |
+| testing/flow-walkthrough | A | — not run — | | | | |
+| testing/integration-test-scaffold | A | — not run — | | | | |
+| testing/snapshot-test-setup | A | — not run — | | | | |
+| testing/tdd-bug-fix | A | — not run — | | | | |
+| testing/tdd-feature | A | — not run — | | | | |
+| testing/tdd-refactor-guard | A | — not run — | | | | |
+| testing/test-contract | A | — not run — | | | | |
+| testing/test-data-factory | A | — not run — | | | | |
+
+## visionos
+
+| Skill | Track | Verdict | Coverage | Failed Qs | Justification | Flags |
+|---|---|---|---|---|---|---|
+| visionos/spatial-design | A | — not run — | | | | |
+| visionos/widgets | A | — not run — | | | | |
+
+## watchos
+
+| Skill | Track | Verdict | Coverage | Failed Qs | Justification | Flags |
+|---|---|---|---|---|---|---|
+| watchos | A | — not run — | | | | |
+
+## Appendix A — FIX detail
+
+## Appendix B — DELETE dossiers (the rows requiring human approval)
+
+### security
+- ⚠️ referenced by SwiftShip: commands/help.md, commands/release.md, commands/build.md, commands/submit.md, commands/plan.md, commands/review.md, commands/security.md, CLAUDE.md — deletion blocked until paired
+- covered: Omitting NSFaceIDUsageDescription from Info.plist causes the app to crash when Face ID is requested.
+  - evidence: “The app doesn't get a graceful denial — it crashes at runtime.”
+- ungradable: Avoid the .biometryAny access control flag since it's too permissive (works even after new biometric enrollment); prefer
+  - evidence: “Avoid `.biometryAny` for high-security items. It lets the Keychain item remain accessible after the enrolled biometrics ”
+- covered: App Transport Security's default behavior requires HTTPS with TLS 1.2 or later.
+  - evidence: “ATS requires a minimum of **TLS 1.2** by default”
+- partial: Setting NSAllowsArbitraryLoads to disable ATS entirely will likely cause App Store rejection and exposes users to MITM a
+  - evidence: “it (a) requires written justification in App Store Connect that reviewers scrutinize and can reject, and (b) genuinely w”
+- ungradable: Certificate pinning is recommended as Required for banking/financial and healthcare apps, strongly recommended for apps 
+  - evidence: “Healthcare data app: Yes, strongly consider it. ... App that just calls third-party APIs ... Usually not worth it, and c”
+- covered: Public key pinning is preferred over certificate pinning because it survives certificate rotation better.
+  - evidence: “Public key (SPKI) pinning is more robust, for one concrete reason: key reuse across cert renewal.”
+- ungradable: kSecAttrAccessibleWhenUnlockedThisDeviceOnly is recommended for most Keychain use cases because it is not included in de
+  - evidence: “kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly is the standard recommendation for auth tokens... If your token truly o”
+- covered: kSecAttrAccessibleAlways should never be used for Keychain items because it is deprecated and insecure.
+  - evidence: “Deprecated/insecure constant to avoid: kSecAttrAccessibleAlways (and its kSecAttrAccessibleAlwaysThisDeviceOnly variant)”
+- partial: watchOS Keychain items are not automatically shared with a paired iPhone; Watch Connectivity must be used to sync creden
+  - evidence: “No, not automatically. Keychain items only propagate off-device via iCloud Keychain, which requires (a) the item explici”
+- covered: Secure Enclave signing keys are generated using kSecAttrKeyTypeECSECPrimeRandom with a key size of 256 bits.
+  - evidence: “kSecAttrKeyType: kSecAttrKeyTypeECSECPrimeRandom
+kSecAttrKeySizeInBits: 256”
+- partial: A sample app-lock pattern re-locks the app after 60 seconds in the background.
+  - evidence: “Moderate sensitivity (enterprise/MDM-managed apps): 30s–5min is typical; many MDM profiles default to 1–2 min.”
+- covered: A sample replay-attack prevention scheme treats signed requests as expired after a 5-minute (300 second) window.
+  - evidence: “60–300 seconds is the typical tolerance band”
+- covered: Jailbreak detection can be bypassed by determined attackers and should be used only as defense-in-depth, not the sole pr
+  - evidence: “Low. Treat it as a speed bump / telemetry signal, never a control gating access to secrets or as your sole security boun”
+- covered: On macOS 10.15+, kSecUseDataProtectionKeychain can be set to true to get iOS-like Keychain behavior.
+  - evidence: “Set kSecUseDataProtectionKeychain: kCFBooleanTrue in every SecItemAdd/SecItemCopyMatching/SecItemUpdate/SecItemDelete qu”
+
+## Appendix C — errors / truncations
+

--- a/tools/skill-audit/results/claude-sonnet-5/AUDIT-REPORT.md
+++ b/tools/skill-audit/results/claude-sonnet-5/AUDIT-REPORT.md
@@ -12,217 +12,220 @@ DELETE — templates are not assessed here (compilability is owned by check-swif
 
 | Verdict | Count |
 |---|---|
-| DELETE-candidate | 1 |
-| TRIM | 1 |
+| DELETE-candidate | 5 |
+| TRIM | 56 |
+| TRIM(prose) | 1 |
+| KEEP | 94 |
+| FIX | 5 |
 
 ## app-store
 
 | Skill | Track | Verdict | Coverage | Failed Qs | Justification | Flags |
 |---|---|---|---|---|---|---|
-| app-store/ad-attribution | A | — not run — | | | | |
-| app-store/app-description-writer | A | — not run — | | | | |
-| app-store/apple-search-ads | A | — not run — | | | | |
-| app-store/iap-finalizer | A | — not run — | | | | |
-| app-store/keyword-optimizer | A | — not run — | | | | |
-| app-store/marketing-strategy | A | — not run — | | | | |
-| app-store/originality-check | A | — not run — | | | | |
-| app-store/ratings-mechanics | A | — not run — | | | | |
-| app-store/rejection-handler | A | — not run — | | | | |
-| app-store/review-response-writer | A | — not run — | | | | |
-| app-store/screenshot-planner | A | — not run — | | | | |
-| app-store/web-presence | A | — not run — | | | | |
+| app-store/ad-attribution | A | KEEP | 0.43 | q3,q4,q5 | coverage 0.43; bare model failed: The first re-engagement conversion update must land within 48 hours; Click-through attribution requires calling appImpression.handleTap() w | — |
+| app-store/app-description-writer | A | TRIM | 0.79 | q3 | coverage 0.79; keep only the missed deltas | human-review:borderline |
+| app-store/apple-search-ads | A | KEEP | 0.46 | q1,q4,q5 | coverage 0.46; bare model failed: All Apple Search Ads placements price as cost-per-tap on a second-pric; Today Tab ads must come from a Custom Product Page with at least 4 por | human-review:borderline, human-review:unclear-contradiction |
+| app-store/iap-finalizer | A | TRIM | 0.62 | q1,q5 | coverage 0.62; keep only the missed deltas | workflow-heavy |
+| app-store/keyword-optimizer | A | TRIM | 0.54 | q2,q3,q5 | coverage 0.54; keep only the missed deltas | human-review:borderline, human-review:unverified-suspect |
+| app-store/marketing-strategy | A | KEEP | 0.43 | q2,q4,q5 | coverage 0.43; bare model failed: Custom Product Pages need roughly 5,000 impressions/month minimum traf; Win-Back Offers are only worth the setup effort once an app has around | human-review:unclear-contradiction, workflow-heavy |
+| app-store/originality-check | A | TRIM | 0.58 | q3,q5 | coverage 0.58; keep only the missed deltas | — |
+| app-store/ratings-mechanics | A | DELETE-candidate | 0.81 | — | bare model covered 0.81 of claims with no contradictions | human-review:borderline, swiftship-referenced |
+| app-store/rejection-handler | A | TRIM | 0.50 | q1,q5 | coverage 0.50; keep only the missed deltas | human-review:borderline, human-review:unclear-contradiction, workflow-heavy |
+| app-store/review-response-writer | A | TRIM | 0.50 | q2,q4 | coverage 0.50; keep only the missed deltas | human-review:borderline, human-review:unclear-contradiction, human-review:unverified-suspect |
+| app-store/screenshot-planner | A | KEEP | 0.38 | q4,q5 | coverage 0.38; bare model failed: Creative Assets, Product Page Header, and Custom Search Results visual; Assets pre-approved in the Asset Library can update the Product Page H | human-review:unclear-contradiction |
+| app-store/web-presence | A | TRIM | 0.68 | q5 | coverage 0.68; keep only the missed deltas | human-review:unclear-contradiction |
 
 ## apple-intelligence
 
 | Skill | Track | Verdict | Coverage | Failed Qs | Justification | Flags |
 |---|---|---|---|---|---|---|
-| apple-intelligence/app-intents | A | — not run — | | | | |
-| apple-intelligence/foundation-models | A | — not run — | | | | |
-| apple-intelligence/visual-intelligence | A | — not run — | | | | |
+| apple-intelligence/app-intents | A | KEEP | 0.43 | q1,q3,q4,q5 | coverage 0.43; bare model failed: Interactive Siri snippets have a max content height of 340pt; content ; A SnippetIntent's perform() method must never mutate state; mutations  | human-review:unverified-suspect, truncated |
+| apple-intelligence/foundation-models | A | KEEP | 0.23 | q2,q3,q4,q5 | coverage 0.23; bare model failed: LanguageModelSession.GenerationError is deprecated at iOS 27 and becom; None of the Foundation Models error enums ever had a .cancelled case i | human-review:unverified-suspect |
+| apple-intelligence/visual-intelligence | A | TRIM | 0.50 | q1,q4,q5 | coverage 0.50; keep only the missed deltas | human-review:borderline |
 
 ## core-ml
 
 | Skill | Track | Verdict | Coverage | Failed Qs | Justification | Flags |
 |---|---|---|---|---|---|---|
-| core-ml | A | — not run — | | | | |
+| core-ml | A | TRIM | 0.70 | q1 | coverage 0.70; keep only the missed deltas | truncated, workflow-heavy |
 
 ## design
 
 | Skill | Track | Verdict | Coverage | Failed Qs | Justification | Flags |
 |---|---|---|---|---|---|---|
-| design/animation-patterns | A | — not run — | | | | |
-| design/design-principles | A | — not run — | | | | |
-| design/liquid-glass | A | — not run — | | | | |
-| design/sf-symbols | A | — not run — | | | | |
-| design/typography | A | — not run — | | | | |
-| design/ui-prototyping | A | — not run — | | | | |
-| design/ux-writing | A | — not run — | | | | |
+| design/animation-patterns | A | TRIM | 0.83 | q2,q5 | coverage 0.83; keep only the missed deltas | human-review:borderline, human-review:unclear-contradiction, truncated |
+| design/design-principles | A | DELETE-candidate | 0.96 | — | bare model covered 0.96 of claims with no contradictions | swiftship-referenced |
+| design/liquid-glass | A | TRIM | 0.55 | q1,q2,q5 | coverage 0.55; keep only the missed deltas | human-review:borderline, human-review:unclear-contradiction, human-review:unverified-suspect |
+| design/sf-symbols | A | KEEP | 0.29 | q2,q3,q4,q5 | coverage 0.29; bare model failed: SF Symbols 7 introduced gradients: a smooth linear gradient generated ; Variable Draw (SF Symbols 7) renders the path at a percentage instead  | human-review:unverified-suspect |
+| design/typography | A | TRIM | 0.59 | q5 | coverage 0.59; keep only the missed deltas | — |
+| design/ui-prototyping | A | KEEP | 0.42 | q1,q3,q5 | coverage 0.42; bare model failed: Generate 6–10 genuinely divergent variations of a single screen when g; Tuning panels should be laid out side-by-side on a wide window rather  | human-review:unclear-contradiction, workflow-heavy |
+| design/ux-writing | A | TRIM | 0.79 | q1,q4 | coverage 0.79; keep only the missed deltas | human-review:borderline |
 
 ## foundation
 
 | Skill | Track | Verdict | Coverage | Failed Qs | Justification | Flags |
 |---|---|---|---|---|---|---|
-| foundation/attributed-string | A | — not run — | | | | |
+| foundation/attributed-string | A | TRIM | 0.62 | q1,q5 | coverage 0.62; keep only the missed deltas | — |
 
 ## generators
 
 | Skill | Track | Verdict | Coverage | Failed Qs | Justification | Flags |
 |---|---|---|---|---|---|---|
-| generators/accessibility-generator | B | — not run — | | | | |
-| generators/account-deletion | B | — not run — | | | | |
-| generators/analytics-setup | B | — not run — | | | | |
-| generators/announcement-banner | B | — not run — | | | | |
-| generators/app-clip | B | — not run — | | | | |
-| generators/app-extensions | B | — not run — | | | | |
-| generators/app-icon-generator | B | — not run — | | | | |
-| generators/app-store-assets | B | — not run — | | | | |
-| generators/auth-flow | B | — not run — | | | | |
-| generators/background-processing | B | — not run — | | | | |
-| generators/ci-cd-setup | B | — not run — | | | | |
-| generators/cloudkit-sync | B | — not run — | | | | |
-| generators/consent-flow | B | — not run — | | | | |
-| generators/custom-product-pages | B | — not run — | | | | |
-| generators/data-export | B | — not run — | | | | |
-| generators/debug-menu | B | — not run — | | | | |
-| generators/deep-linking | B | — not run — | | | | |
-| generators/error-monitoring | B | — not run — | | | | |
-| generators/feature-flags | B | — not run — | | | | |
-| generators/featuring-nomination | B | — not run — | | | | |
-| generators/feedback-form | B | — not run — | | | | |
-| generators/force-update | B | — not run — | | | | |
-| generators/http-cache | B | — not run — | | | | |
-| generators/image-loading | B | — not run — | | | | |
-| generators/in-app-events | B | — not run — | | | | |
-| generators/lapsed-user | B | — not run — | | | | |
-| generators/live-activity-generator | B | — not run — | | | | |
-| generators/localization-setup | B | — not run — | | | | |
-| generators/logging-setup | B | — not run — | | | | |
-| generators/milestone-celebration | B | — not run — | | | | |
-| generators/networking-layer | B | — not run — | | | | |
-| generators/offer-codes-setup | B | — not run — | | | | |
-| generators/offline-queue | B | — not run — | | | | |
-| generators/onboarding-generator | B | — not run — | | | | |
-| generators/pagination | B | — not run — | | | | |
-| generators/paywall-generator | B | — not run — | | | | |
-| generators/permission-priming | B | — not run — | | | | |
-| generators/persistence-setup | B | — not run — | | | | |
-| generators/pre-orders | B | — not run — | | | | |
-| generators/preview-data-generator | B | — not run — | | | | |
-| generators/product-page-optimization | B | — not run — | | | | |
-| generators/promoted-iap | B | — not run — | | | | |
-| generators/push-notifications | B | — not run — | | | | |
-| generators/quick-win-session | B | — not run — | | | | |
-| generators/referral-system | B | — not run — | | | | |
-| generators/review-prompt | B | — not run — | | | | |
-| generators/screenshot-automation | B | — not run — | | | | |
-| generators/settings-screen | B | — not run — | | | | |
-| generators/share-card | B | — not run — | | | | |
-| generators/social-export | B | — not run — | | | | |
-| generators/spotlight-indexing | B | — not run — | | | | |
-| generators/state-restoration | B | — not run — | | | | |
-| generators/streak-tracker | B | — not run — | | | | |
-| generators/subscription-lifecycle | B | — not run — | | | | |
-| generators/subscription-offers | B | — not run — | | | | |
-| generators/test-generator | B | — not run — | | | | |
-| generators/tipkit-generator | B | — not run — | | | | |
-| generators/usage-insights | B | — not run — | | | | |
-| generators/variable-rewards | B | — not run — | | | | |
-| generators/watermark-engine | B | — not run — | | | | |
-| generators/whats-new | B | — not run — | | | | |
-| generators/widget-generator | B | — not run — | | | | |
-| generators/win-back-offers | B | — not run — | | | | |
+| generators/accessibility-generator | B | KEEP | 0.40 | — | coverage 0.40; bare model failed: Use UIAccessibility.buttonShapesEnabled and its change notification to; Bold Text support is free with system text styles, but custom fonts mu Templates NOT assessed (Track B). | — |
+| generators/account-deletion | B | KEEP | 0.65 | — | coverage 0.65; bare model failed: CloudKit private database records are tied to the user's iCloud accoun; Offering data export before deletion is a privacy best practice that b Templates NOT assessed (Track B). | workflow-heavy |
+| generators/analytics-setup | B | KEEP | 0.50 | — | coverage 0.50; bare model failed: The AnalyticsService protocol is a stable interface that never changes; Firebase setup also requires a GoogleService-Info.plist file in additi Templates NOT assessed (Track B). | human-review:borderline, human-review:unverified-suspect, workflow-heavy |
+| generators/announcement-banner | B | KEEP | 0.79 | — | coverage 0.79; bare model failed: If a user navigates away mid-animation, ensure the banner state resets Templates NOT assessed (Track B). | human-review:borderline, workflow-heavy |
+| generators/app-clip | B | KEEP | 0.50 | — | coverage 0.50; bare model failed: App Clip binary must be under 10 MB; App Clip data is deleted after 8 hours of inactivity Templates NOT assessed (Track B). | human-review:borderline, human-review:unverified-suspect, workflow-heavy |
+| generators/app-extensions | B | KEEP | 0.60 | — | coverage 0.60; bare model failed: Safari Web Extension content scripts have approximately a 6 MB memory ; Safari Web Extension content scripts run in an isolated world and cann Templates NOT assessed (Track B). | workflow-heavy |
+| generators/app-icon-generator | B | KEEP | 0.20 | — | coverage 0.20; bare model failed: watchOS uses a 1088×1088 canvas (not 1024×1024) to deliberately oversh; Layer filenames should be prefixed with a Z-order number so stacking i Templates NOT assessed (Track B). | workflow-heavy |
+| generators/app-store-assets | B | KEEP | 0.70 | — | coverage 0.70; bare model failed: Production checklist should confirm assets are tested on actual device Templates NOT assessed (Track B). | workflow-heavy |
+| generators/auth-flow | B | KEEP | 0.50 | — | coverage 0.50; bare model failed: The generated AuthenticationManager should be implemented using the @O; Testing Sign in with Apple should use a sandbox Apple ID Templates NOT assessed (Track B). | human-review:borderline, human-review:unverified-suspect, workflow-heavy |
+| generators/background-processing | B | KEEP | 0.88 | — | coverage 0.88; bare model failed: If BGTaskScheduler.register(forTaskWithIdentifier:) is called after di Templates NOT assessed (Track B). | workflow-heavy |
+| generators/ci-cd-setup | B | KEEP | 0.25 | — | coverage 0.25; bare model failed: The App Store Connect API Key used for CI should be generated with the; The .p8 private key file for the App Store Connect API key is only ava Templates NOT assessed (Track B). | — |
+| generators/cloudkit-sync | B | KEEP | 0.60 | — | coverage 0.60; bare model failed: Record types are auto-created when you first save a CKRecord of that t; Indexes are required for queryable fields and must be added in the Clo Templates NOT assessed (Track B). | workflow-heavy |
+| generators/consent-flow | B | KEEP | 0.38 | — | coverage 0.38; bare model failed: Consent must be as easy to withdraw as to grant (GDPR Article 7(3)); Different regulations have different age thresholds (GDPR 16/13, CCPA  Templates NOT assessed (Track B). | workflow-heavy |
+| generators/custom-product-pages | B | KEEP | 0.14 | — | coverage 0.14; bare model failed: Under 2,000 monthly impressions: don't create CPPs, focus on optimizin; Exception: CPPs are valuable even at low organic volume if running pai Templates NOT assessed (Track B). | workflow-heavy |
+| generators/data-export | B | TRIM(prose) | 0.81 | — | coverage 0.81; keep only the missed deltas Templates NOT assessed (Track B). | human-review:borderline, workflow-heavy |
+| generators/debug-menu | B | KEEP | 0.72 | — | coverage 0.72; bare model failed: Shake gesture for debug menu can conflict with UIKit's system shake-to; Swift 5.9+ is required for the generated code. Templates NOT assessed (Track B). | workflow-heavy |
+| generators/deep-linking | B | KEEP | 0.38 | — | coverage 0.38; bare model failed: When testing the AASA file with curl, it should return Content-Type: a; Content entities should be indexed with CSSearchableIndex for Spotligh Templates NOT assessed (Track B). | — |
+| generators/error-monitoring | B | KEEP | 0.50 | — | coverage 0.50; bare model failed: For GDPR compliance, use the NoOp monitoring implementation for EU use; Use App Tracking Transparency if combining crash monitoring with analy Templates NOT assessed (Track B). | human-review:borderline, workflow-heavy |
+| generators/feature-flags | B | KEEP | 0.38 | — | coverage 0.38; bare model failed: After a feature is fully rolled out, remove the flag enum case and rel; When a flag controls a UI branch, write tests for both the enabled and Templates NOT assessed (Track B). | workflow-heavy |
+| generators/featuring-nomination | B | KEEP | 0.29 | — | coverage 0.29; bare model failed: Nominations should be submitted 6-8 weeks before the desired featuring; Apple reviews and plans its editorial calendar well in advance, with s Templates NOT assessed (Track B). | human-review:unclear-contradiction, workflow-heavy |
+| generators/feedback-form | B | KEEP | 0.50 | — | coverage 0.50; bare model failed: Consider blurring or redacting sensitive data (passwords, financial in; If offline when feedback is submitted, queue the entry to disk and ret Templates NOT assessed (Track B). | human-review:borderline, workflow-heavy |
+| generators/force-update | B | KEEP | 0.70 | — | coverage 0.70; bare model failed: If the user hasn't completed onboarding, defer the force update check  Templates NOT assessed (Track B). | workflow-heavy |
+| generators/http-cache | B | KEEP | 0.57 | — | coverage 0.57; bare model failed: Recommends Medium cache storage sizing (25 MB memory / 100 MB disk) as; When an existing networking-layer's APIClient protocol is detected, th Templates NOT assessed (Track B). | workflow-heavy |
+| generators/image-loading | B | KEEP | 0.67 | — | coverage 0.67; bare model failed: If a third-party image loading library (Kingfisher, SDWebImage, Nuke) ; The generator should determine whether it's targeting iOS (UIImage), m Templates NOT assessed (Track B). | workflow-heavy |
+| generators/in-app-events | B | KEEP | 0.15 | — | coverage 0.15; bare model failed: Event duration must be between 15 minutes and 31 days; Concurrent limits: 10 approved events / 5 published simultaneously acr Templates NOT assessed (Track B). | human-review:unverified-suspect, workflow-heavy |
+| generators/lapsed-user | B | KEEP | 0.12 | — | coverage 0.12; bare model failed: To avoid false positives from background app refresh, pair scenePhase ; Day calculations for inactivity should use Calendar.current rather tha Templates NOT assessed (Track B). | workflow-heavy |
+| generators/live-activity-generator | B | KEEP | 0.55 | — | coverage 0.55; bare model failed: Lock Screen presentation should use 14pt margins on all edges, matchin; StandBy scales the presentation to 200% and won't draw under the senso Templates NOT assessed (Track B). | human-review:unverified-suspect, workflow-heavy |
+| generators/localization-setup | B | KEEP | 0.50 | — | coverage 0.50; bare model failed: String Catalogs require iOS 16+ / macOS 13+ deployment target; Key naming should be descriptive and hierarchical rather than vague or Templates NOT assessed (Track B). | human-review:borderline, human-review:unverified-suspect |
+| generators/logging-setup | B | KEEP | 0.69 | — | coverage 0.69; bare model failed: Debug logs are compiled out in Release builds (as a benefit of Logger ; .sensitive privacy annotation always redacts data such as passwords an Templates NOT assessed (Track B). | human-review:unverified-suspect, workflow-heavy |
+| generators/milestone-celebration | B | KEEP | 0.50 | — | coverage 0.50; bare model failed: Confetti particle count should be capped (birthRate 50-80) to maintain; Use emitterCells with only 3-5 distinct shapes to reduce GPU draw call Templates NOT assessed (Track B). | human-review:borderline, workflow-heavy |
+| generators/networking-layer | B | KEEP | 0.50 | — | coverage 0.50; bare model failed: async/await requires Swift 5.5+; Use @concurrent to offload heavy processing onto a background thread Templates NOT assessed (Track B). | human-review:borderline, workflow-heavy |
+| generators/offer-codes-setup | B | KEEP | 0.05 | — | coverage 0.05; bare model failed: Up to 10 active offers per subscription SKU; One-time use codes are generated in batches of 500 to 25,000 Templates NOT assessed (Track B). | human-review:unclear-contradiction, workflow-heavy |
+| generators/offline-queue | B | KEEP | 0.42 | — | coverage 0.42; bare model failed: The queue processes operations in FIFO order by default, with an expli; For long offline periods, add a TTL to operations (e.g., 24 hours) and Templates NOT assessed (Track B). | workflow-heavy |
+| generators/onboarding-generator | B | KEEP | 0.79 | — | coverage 0.79; bare model failed: To test onboarding on first launch, delete the app from the simulator  Templates NOT assessed (Track B). | human-review:borderline, workflow-heavy |
+| generators/pagination | B | KEEP | 0.50 | — | coverage 0.50; bare model failed: Project should target Swift 5.9+; When a networking-layer generator was already used, pagination data so Templates NOT assessed (Track B). | human-review:borderline, workflow-heavy |
+| generators/paywall-generator | B | FIX | 0.20 | — | suspect/contradicted claim confirmed: Transaction.currentEntitlements(for:) is a new API for entitlements as of iOS 18.4. Templates NOT assessed (Track B). | human-review:unverified-suspect, workflow-heavy |
+| generators/permission-priming | B | KEEP | 0.69 | — | coverage 0.69; bare model failed: Pre-permission priming dramatically increases permission grant rates v Templates NOT assessed (Track B). | workflow-heavy |
+| generators/persistence-setup | B | KEEP | 0.56 | — | coverage 0.56; bare model failed: Repository pattern is recommended because it allows easy testing; Default CloudKit quota is generous (free tier: 100MB asset storage) Templates NOT assessed (Track B). | workflow-heavy |
+| generators/pre-orders | B | KEEP | 0.11 | — | coverage 0.11; bare model failed: On release day, the app auto-downloads within ~24 hours; Pre-orders count toward launch day download numbers Templates NOT assessed (Track B). | human-review:unclear-contradiction, human-review:unverified-suspect, workflow-heavy |
+| generators/preview-data-generator | B | KEEP | 0.56 | — | coverage 0.56; bare model failed: Where a test-data factory (Model.fixture()) already exists, the previe; The correct preview API is chosen by deployment target: iOS 17+ uses t Templates NOT assessed (Track B). | human-review:unverified-suspect, workflow-heavy |
+| generators/product-page-optimization | B | KEEP | 0.35 | — | coverage 0.35; bare model failed: Traffic proportion for PPO tests is 1–50% of page traffic, split evenl; No confidence is shown for the first 7 days; 90% confidence is the dec Templates NOT assessed (Track B). | human-review:unclear-contradiction, workflow-heavy |
+| generators/promoted-iap | B | KEEP | 0.50 | — | coverage 0.50; bare model failed: Choose your most compelling IAP as the first promoted product; Apple may also feature your IAPs in editorial content beyond the produ Templates NOT assessed (Track B). | human-review:borderline, workflow-heavy |
+| generators/push-notifications | B | KEEP | 0.28 | — | coverage 0.28; bare model failed: Use provisional authorization for passive content, reserving the expli; Every notification must carry a specific message or completable task,  Templates NOT assessed (Track B). | — |
+| generators/quick-win-session | B | KEEP | 0.30 | — | coverage 0.30; bare model failed: Provide a Skip button and never show the quick win again after complet; The quick win should produce a real artifact, not feel like a demo/tut Templates NOT assessed (Track B). | workflow-heavy |
+| generators/referral-system | B | KEEP | 0.50 | — | coverage 0.50; bare model failed: Each invitee should only be able to redeem one referral code ever; Referral systems must not manipulate App Store ratings or reviews (Gui Templates NOT assessed (Track B). | human-review:borderline, workflow-heavy |
+| generators/review-prompt | B | KEEP | 0.62 | — | coverage 0.62; bare model failed: This skill only applies to App Store distributed apps (StoreKit review; On macOS, detect App Store distribution by checking whether the app's  Templates NOT assessed (Track B). | human-review:unverified-suspect, workflow-heavy |
+| generators/screenshot-automation | B | KEEP | 0.30 | — | coverage 0.30; bare model failed: Marketing captions should be short (3-6 words) and benefit-focused; The first screenshot is the most important for App Store search result Templates NOT assessed (Track B). | workflow-heavy |
+| generators/settings-screen | B | KEEP | 0.75 | — | coverage 0.75; bare model failed: Verification should include confirming VoiceOver navigation works on t; iOS settings should use NavigationStack with List Templates NOT assessed (Track B). | human-review:unclear-contradiction, workflow-heavy |
+| generators/share-card | B | KEEP | 0.25 | — | coverage 0.25; bare model failed: Image format guidance: use JPEG at high quality for Instagram to avoid; A 1080x1920 card at @3x scale consumes roughly 75 MB in memory Templates NOT assessed (Track B). | human-review:unverified-suspect, workflow-heavy |
+| generators/social-export | B | KEEP | 0.62 | — | coverage 0.62; bare model failed: Instagram Stories image export has a max file size of ~12 MB; The source_application parameter must be the Facebook App ID Templates NOT assessed (Track B). | workflow-heavy |
+| generators/spotlight-indexing | B | KEEP | 0.39 | — | coverage 0.39; bare model failed: CSSearchableIndex has no hard documented limit, but Apple recommends k; CSSearchableIndex.default() returns a singleton but its methods are NO Templates NOT assessed (Track B). | workflow-heavy |
+| generators/state-restoration | B | KEEP | 0.67 | — | coverage 0.67; bare model failed: Never persist passwords, tokens, or PII in state restoration files; us; Use String tags instead of Int for tab selection for readability and s Templates NOT assessed (Track B). | workflow-heavy |
+| generators/streak-tracker | B | KEEP | 0.17 | — | coverage 0.17; bare model failed: For midnight edge cases, the raw timestamp should be recorded alongsid; To mitigate device clock manipulation, store createdAt timestamps alon Templates NOT assessed (Track B). | workflow-heavy |
+| generators/subscription-lifecycle | B | KEEP | 0.20 | — | coverage 0.20; bare model failed: Commission compounds from 70% net in year one to 85% once a subscriber; Specific retention math example: from 10,000 subscribers, 12 months la Templates NOT assessed (Track B). | human-review:unverified-suspect, workflow-heavy |
+| generators/subscription-offers | B | KEEP | 0.25 | — | coverage 0.25; bare model failed: Promotional offer baseline eligibility is deliberately broad — any cur; Promotional offer pay-up-front prices are deliberately NOT price-valid Templates NOT assessed (Track B). | workflow-heavy |
+| generators/test-generator | B | KEEP | 0.28 | — | coverage 0.28; bare model failed: Swift Testing requires a minimum deployment target of iOS 16+ / macOS ; Top mistake: testing implementation details instead of behavior, since Templates NOT assessed (Track B). | — |
+| generators/tipkit-generator | B | KEEP | 0.23 | — | coverage 0.23; bare model failed: Tip title should be a direct action phrase naming the feature, not a g; Tips should never be used for promotion/upsells Templates NOT assessed (Track B). | workflow-heavy |
+| generators/usage-insights | B | KEEP | 0.65 | — | coverage 0.65; bare model failed: Handle timezone changes gracefully by storing timestamps in UTC and di; Use .chartYScale(domain:) to prevent the axis from starting at a misle Templates NOT assessed (Track B). | workflow-heavy |
+| generators/variable-rewards | B | KEEP | 0.50 | — | coverage 0.50; bare model failed: RewardPool accepts a seed parameter for deterministic testing of rando; Slot-style spins and near-miss animations can read as simulated gambli Templates NOT assessed (Track B). | human-review:borderline, workflow-heavy |
+| generators/watermark-engine | B | KEEP | 0.31 | — | coverage 0.31; bare model failed: CoreGraphics contexts must account for screen scale; watermarks look b; Rendering watermarks on very large (48MP) photos allocates significant Templates NOT assessed (Track B). | workflow-heavy |
+| generators/whats-new | B | KEEP | 0.50 | — | coverage 0.50; bare model failed: Features should be grouped/accumulated per release version so users wh; Content can be fetched from a remote server (with local fallback) to u Templates NOT assessed (Track B). | human-review:borderline, human-review:unclear-contradiction, workflow-heavy |
+| generators/widget-generator | B | KEEP | 0.45 | — | coverage 0.45; bare model failed: Widget extensions are killed if they exceed the 40MB memory limit; Small widgets should have max ~4 pieces of information and exactly one Templates NOT assessed (Track B). | human-review:borderline, workflow-heavy |
+| generators/win-back-offers | B | KEEP | 0.10 | — | coverage 0.10; bare model failed: Churn volume thresholds: under 50 churned subscribers isn't worth the ; When picking a native win-back offer, the first ID in eligibleWinBackO Templates NOT assessed (Track B). | workflow-heavy |
 
 ## growth
 
 | Skill | Track | Verdict | Coverage | Failed Qs | Justification | Flags |
 |---|---|---|---|---|---|---|
-| growth/analytics-interpretation | A | — not run — | | | | |
-| growth/community-building | A | — not run — | | | | |
-| growth/indie-business | A | — not run — | | | | |
-| growth/press-media | A | — not run — | | | | |
-| growth/store-growth-audit | A | — not run — | | | | |
-| growth/store-signals | A | — not run — | | | | |
+| growth/analytics-interpretation | A | KEEP | 0.36 | q1,q2,q3,q4 | coverage 0.36; bare model failed: A peer group in App Store Connect benchmarks is defined by category + ; As of WWDC25, up to 7 filters can be stacked per metric in App Store C | human-review:unclear-contradiction, human-review:unverified-suspect, workflow-heavy |
+| growth/community-building | A | TRIM | 0.54 | q1,q3,q5 | coverage 0.54; keep only the missed deltas | human-review:borderline, human-review:unclear-contradiction, workflow-heavy |
+| growth/indie-business | A | TRIM | 0.75 | q1 | coverage 0.75; keep only the missed deltas | workflow-heavy |
+| growth/press-media | A | TRIM | 0.58 | q2,q4,q5 | coverage 0.58; keep only the missed deltas | human-review:unclear-contradiction, workflow-heavy |
+| growth/store-growth-audit | A | KEEP | 0.47 | q1,q2,q5 | coverage 0.47; bare model failed: Exactly 13 checklist items across the whole audit are flagged as phase; Enabling both Billing Grace Period and Billing Retry is estimated to r | human-review:borderline, human-review:unclear-contradiction, human-review:unverified-suspect, workflow-heavy |
+| growth/store-signals | A | KEEP | 0.35 | q3,q4,q5 | coverage 0.35; bare model failed: On-strategy findings go to the backlog; off-strategy findings are list; A move of less than 3 percentage points on a retention/conversion metr | human-review:unclear-contradiction |
 
 ## ios
 
 | Skill | Track | Verdict | Coverage | Failed Qs | Justification | Flags |
 |---|---|---|---|---|---|---|
-| ios/accessibility-audit | A | — not run — | | | | |
-| ios/app-planner | A | — not run — | | | | |
-| ios/assistive-access | A | — not run — | | | | |
-| ios/coding-best-practices | A | — not run — | | | | |
-| ios/ipad-patterns | A | — not run — | | | | |
-| ios/migration-patterns | A | — not run — | | | | |
-| ios/navigation-patterns | A | — not run — | | | | |
-| ios/run-device | A | — not run — | | | | |
-| ios/run-simulator | A | — not run — | | | | |
-| ios/ui-review | A | — not run — | | | | |
+| ios/accessibility-audit | A | TRIM | 0.73 | q1 | coverage 0.73; keep only the missed deltas | human-review:unclear-contradiction, human-review:unverified-suspect |
+| ios/app-planner | A | KEEP | 0.46 | q1,q5 | coverage 0.46; bare model failed: Existing app codebase size is categorized as small (<10 screens), medi; The recommended improvement roadmap for an existing app begins with a  | human-review:borderline, human-review:unclear-contradiction, truncated, workflow-heavy |
+| ios/assistive-access | A | KEEP | 0.38 | q1,q2,q3,q4,q5 | coverage 0.38; bare model failed: Assistive Access has three integration levels: no adoption (reduced fr; Assistive Access mode itself shipped with iOS 17, but the AssistiveAcc | — |
+| ios/coding-best-practices | A | TRIM | 0.50 | q1,q2,q3,q4,q5 | coverage 0.50; keep only the missed deltas | human-review:borderline |
+| ios/ipad-patterns | A | TRIM | 0.89 | — | coverage 0.89; keep only the missed deltas | judge-disagreement |
+| ios/migration-patterns | A | FIX | 0.58 | q1,q3,q5 | suspect/contradicted claim confirmed: SwiftData's @Model macro does not synthesize an initializer; you must write one explicitly, unlike N | human-review:unverified-suspect, truncated |
+| ios/navigation-patterns | A | TRIM | 0.83 | Q2 | coverage 0.83; keep only the missed deltas | human-review:borderline, human-review:unclear-contradiction |
+| ios/run-device | A | KEEP | 0.36 | q1,q3,q5 | coverage 0.36; bare model failed: xcodebuild matches devices by hardware UDID, not the devicectl CoreDev; Build for a device using -destination 'generic/platform=iOS' instead o | human-review:unverified-suspect |
+| ios/run-simulator | A | TRIM | 0.79 | q1 | coverage 0.79; keep only the missed deltas | human-review:borderline |
+| ios/ui-review | A | TRIM | 0.64 | q1,q4,q5 | coverage 0.64; keep only the missed deltas | human-review:unclear-contradiction, human-review:unverified-suspect |
 
 ## legal
 
 | Skill | Track | Verdict | Coverage | Failed Qs | Justification | Flags |
 |---|---|---|---|---|---|---|
-| legal/privacy-policy | A | — not run — | | | | |
-| legal/privacy-publish | A | — not run — | | | | |
+| legal/privacy-policy | A | TRIM | 0.68 | q5 | coverage 0.68; keep only the missed deltas | workflow-heavy |
+| legal/privacy-publish | A | TRIM | 0.58 | q2,q3,q4,q5 | coverage 0.58; keep only the missed deltas | workflow-heavy |
 
 ## macos
 
 | Skill | Track | Verdict | Coverage | Failed Qs | Justification | Flags |
 |---|---|---|---|---|---|---|
-| macos/app-planner | A | — not run — | | | | |
-| macos/appkit-swiftui-bridge | A | — not run — | | | | |
-| macos/architecture-patterns | A | — not run — | | | | |
-| macos/coding-best-practices | A | — not run — | | | | |
-| macos/macos-capabilities | A | — not run — | | | | |
-| macos/macos-tahoe-apis | A | — not run — | | | | |
-| macos/swiftdata-architecture | A | — not run — | | | | |
-| macos/ui-review-tahoe | A | — not run — | | | | |
+| macos/app-planner | A | TRIM | 0.50 | q1,q3,q4,q5 | coverage 0.50; keep only the missed deltas | human-review:borderline, human-review:unclear-contradiction |
+| macos/appkit-swiftui-bridge | A | TRIM | 0.73 | q1,q5 | coverage 0.73; keep only the missed deltas | — |
+| macos/architecture-patterns | A | TRIM | 0.94 | — | coverage 0.94; keep only the missed deltas | judge-disagreement |
+| macos/coding-best-practices | A | TRIM | 0.69 | q4 | coverage 0.69; keep only the missed deltas | truncated |
+| macos/macos-capabilities | A | TRIM | 0.88 | q4 | coverage 0.88; keep only the missed deltas | — |
+| macos/macos-tahoe-apis | A | FIX | 0.50 | Q1,Q3,Q4 | suspect/contradicted claim confirmed: The document imports Foundation Models text generation/summarization APIs via a module called 'Apple | human-review:borderline, human-review:unverified-suspect |
+| macos/swiftdata-architecture | A | TRIM | 0.69 | Q2,Q4,Q5 | coverage 0.69; keep only the missed deltas | — |
+| macos/ui-review-tahoe | A | TRIM | 0.73 | q1,q5 | coverage 0.73; keep only the missed deltas | human-review:unverified-suspect, truncated |
 
 ## mapkit
 
 | Skill | Track | Verdict | Coverage | Failed Qs | Justification | Flags |
 |---|---|---|---|---|---|---|
-| mapkit/geotoolbox | A | — not run — | | | | |
+| mapkit/geotoolbox | A | TRIM | 0.62 | q1,q5 | coverage 0.62; keep only the missed deltas | — |
 
 ## monetization
 
 | Skill | Track | Verdict | Coverage | Failed Qs | Justification | Flags |
 |---|---|---|---|---|---|---|
-| monetization | A | — not run — | | | | |
-| monetization/bundles-and-licensing | A | — not run — | | | | |
-| monetization/external-purchases | A | — not run — | | | | |
+| monetization | A | KEEP | 0.32 | q2,q3,q4,q5 | coverage 0.32; bare model failed: Health/fitness tracking apps should use a 14-day free trial because us; A readiness score of 5-6 ready signals means an app should monetize no | human-review:unclear-contradiction, workflow-heavy |
+| monetization/bundles-and-licensing | A | KEEP | 0.42 | q1,q2,q4,q5 | coverage 0.42; bare model failed: Bundle pricing should aim for the second app ~half off and third+ apps; Enabling Family Sharing is a one-way door: it takes effect within hour | — |
+| monetization/external-purchases | A | TRIM | 0.75 | — | coverage 0.75; keep only the missed deltas | — |
 
 ## performance
 
 | Skill | Track | Verdict | Coverage | Failed Qs | Justification | Flags |
 |---|---|---|---|---|---|---|
-| performance/profiling | A | — not run — | | | | |
-| performance/swiftui-debugging | A | — not run — | | | | |
+| performance/profiling | A | KEEP | 0.32 | q1,q2,q3,q4,q5 | coverage 0.32; bare model failed: MetricKit/Xcode automatically generate a disk-write exception report (; Xcode Organizer aggregates performance metrics from consented user dev | human-review:unclear-contradiction, human-review:unverified-suspect, truncated |
+| performance/swiftui-debugging | A | TRIM | 0.61 | Q1,Q2,Q4,Q5 | coverage 0.61; keep only the missed deltas | human-review:unclear-contradiction |
 
 ## product
 
 | Skill | Track | Verdict | Coverage | Failed Qs | Justification | Flags |
 |---|---|---|---|---|---|---|
-| product/app-namer | A | — not run — | | | | |
-| product/architecture-spec | B | — not run — | | | | |
-| product/beta-testing | A | — not run — | | | | |
-| product/competitive-analysis | A | — not run — | | | | |
-| product/idea-generator | A | — not run — | | | | |
-| product/implementation-guide | B | — not run — | | | | |
-| product/implementation-spec | B | — not run — | | | | |
-| product/localization-strategy | A | — not run — | | | | |
-| product/market-research | A | — not run — | | | | |
-| product/prd-generator | A | — not run — | | | | |
-| product/product-agent | A | — not run — | | | | |
-| product/release-spec | B | — not run — | | | | |
-| product/test-spec | B | — not run — | | | | |
-| product/ux-spec | B | — not run — | | | | |
+| product/app-namer | A | TRIM | 0.75 | q4 | coverage 0.75; keep only the missed deltas | workflow-heavy |
+| product/architecture-spec | B | KEEP | 0.00 | — | coverage 0.00; bare model failed: For simple apps (1-3 core features, basic CRUD), MVVM with SwiftUI is ; Unit testing coverage target of 70%+ for business logic Templates NOT assessed (Track B). | human-review:unclear-contradiction |
+| product/beta-testing | A | KEEP | 0.42 | q3,q5 | coverage 0.42; bare model failed: Do not offer cash payment for beta testing since it attracts the wrong; Surveys should be capped at 5 questions because completion rate drops  | human-review:unclear-contradiction, human-review:unverified-suspect, workflow-heavy |
+| product/competitive-analysis | A | KEEP | 0.15 | q1,q2,q4,q5 | coverage 0.15; bare model failed: The workflow begins by running the product-agent skill for discovery a; When verifying with App Store data, read recent reviews from only the  | human-review:unclear-contradiction |
+| product/idea-generator | A | KEEP | 0.17 | q1,q2,q3,q4,q5 | coverage 0.17; bare model failed: The five brainstorming lenses (Skills & Interests, Problem-First, Tech; The overall feasibility score is a weighted average on a 1-10 scale, w | workflow-heavy |
+| product/implementation-guide | B | KEEP | 0.00 | — | coverage 0.00; bare model failed: Minimize third-party dependencies; use native frameworks when possible; Use `final` for classes that don't need subclassing, for performance r Templates NOT assessed (Track B). | — |
+| product/implementation-spec | B | KEEP | 0.00 | — | coverage 0.00; bare model failed: User decision gates must never be skipped; the orchestrator should nev; Consistency across specs requires that PRD features match Architecture Templates NOT assessed (Track B). | workflow-heavy |
+| product/localization-strategy | A | TRIM | 0.62 | q2,q5 | coverage 0.62; keep only the missed deltas | human-review:unclear-contradiction, workflow-heavy |
+| product/market-research | A | KEEP | 0.42 | q1,q2,q4 | coverage 0.42; bare model failed: SOM (Serviceable Obtainable Market) should be calculated as the realis; For indie developers, a SOM above $5M is a good opportunity, $1-5M is  | human-review:unclear-contradiction, workflow-heavy |
+| product/prd-generator | A | TRIM | 0.75 | q3 | coverage 0.75; keep only the missed deltas | human-review:unclear-contradiction |
+| product/product-agent | A | KEEP | 0.05 | q1,q2,q3,q4,q5 | coverage 0.05; bare model failed: Severity score bands are defined as 1-3 weak/low urgency, 4-6 moderate; The recommendation field must use one of three verdicts: BUILD, PROCEE | — |
+| product/release-spec | B | KEEP | 0.25 | — | coverage 0.25; bare model failed: App preview video should be 15-30 seconds, under 500MB, in portrait or; Bitcode should not be enabled since it is deprecated by Apple Templates NOT assessed (Track B). | human-review:unverified-suspect |
+| product/test-spec | B | KEEP | 0.39 | — | coverage 0.39; bare model failed: Test pyramid should be roughly 70% unit tests / 20% integration tests ; Cold app launch time target should be under 1.5 seconds Templates NOT assessed (Track B). | human-review:unclear-contradiction |
+| product/ux-spec | B | KEEP | 0.25 | — | coverage 0.25; bare model failed: Empty states should use ContentUnavailableView, available iOS 17+; Tab bars should have 3-5 tabs maximum Templates NOT assessed (Track B). | — |
 
 ## release-review
 
 | Skill | Track | Verdict | Coverage | Failed Qs | Justification | Flags |
 |---|---|---|---|---|---|---|
-| release-review | A | — not run — | | | | |
+| release-review | A | TRIM | 0.73 | q1,q4,q5 | coverage 0.73; keep only the missed deltas | human-review:unclear-contradiction, human-review:unverified-suspect |
 
 ## security
 
@@ -235,65 +238,169 @@ DELETE — templates are not assessed here (compilability is owned by check-swif
 
 | Skill | Track | Verdict | Coverage | Failed Qs | Justification | Flags |
 |---|---|---|---|---|---|---|
-| shared/skill-auditor | A | — not run — | | | | |
-| shared/skill-creator | A | — not run — | | | | |
+| shared/skill-auditor | A | KEEP | 0.00 | q1,q2,q3,q4,q5 | coverage 0.00; bare model failed: As of the 2026-07-11 baseline, the known-current version constants are; A single-file skill is flagged as oversized (M-04) only if it exceeds  | — |
+| shared/skill-creator | A | KEEP | 0.40 | q1,q2,q3 | coverage 0.40; bare model failed: A skill should be modularized into supporting reference files once the; SKILL.md files have an ideal size of 200-300 lines and a max of 400 li | — |
 
 ## swift
 
 | Skill | Track | Verdict | Coverage | Failed Qs | Justification | Flags |
 |---|---|---|---|---|---|---|
-| swift/concurrency | A | — not run — | | | | |
-| swift/concurrency-patterns | A | — not run — | | | | |
-| swift/memory | A | — not run — | | | | |
+| swift/concurrency | A | TRIM | 0.75 | q2,q5 | coverage 0.75; keep only the missed deltas | human-review:unverified-suspect |
+| swift/concurrency-patterns | A | TRIM | 0.71 | q3,q4,q5 | coverage 0.71; keep only the missed deltas | human-review:unverified-suspect, truncated |
+| swift/memory | A | TRIM | 0.50 | q1,q2,q3,q5 | coverage 0.50; keep only the missed deltas | human-review:borderline, human-review:unclear-contradiction, human-review:unverified-suspect |
 
 ## swiftdata
 
 | Skill | Track | Verdict | Coverage | Failed Qs | Justification | Flags |
 |---|---|---|---|---|---|---|
-| swiftdata/inheritance | A | — not run — | | | | |
+| swiftdata/inheritance | A | TRIM | 0.55 | q4,q5 | coverage 0.55; keep only the missed deltas | human-review:unclear-contradiction, human-review:unverified-suspect |
 
 ## swiftui
 
 | Skill | Track | Verdict | Coverage | Failed Qs | Justification | Flags |
 |---|---|---|---|---|---|---|
-| swiftui/alarmkit | A | — not run — | | | | |
-| swiftui/charts-3d | A | — not run — | | | | |
-| swiftui/data-flow | A | — not run — | | | | |
-| swiftui/layout | A | — not run — | | | | |
-| swiftui/text-editing | A | — not run — | | | | |
-| swiftui/toolbars | A | — not run — | | | | |
-| swiftui/webkit | A | — not run — | | | | |
+| swiftui/alarmkit | A | FIX | 0.71 | q1,q4,q5 | suspect/contradicted claim confirmed: All AlarmKit APIs listed (AlarmManager, Alarm, AlarmPresentation, AlarmAttributes, AlarmMetadata, Al | human-review:unclear-contradiction, human-review:unverified-suspect |
+| swiftui/charts-3d | A | TRIM | 0.92 | — | coverage 0.92; keep only the missed deltas | judge-disagreement |
+| swiftui/data-flow | A | TRIM | 0.77 | q1 | coverage 0.77; keep only the missed deltas | human-review:borderline, human-review:unclear-contradiction |
+| swiftui/layout | A | TRIM | 0.61 | q4,q5 | coverage 0.61; keep only the missed deltas | human-review:unverified-suspect |
+| swiftui/text-editing | A | TRIM | 0.67 | q1,q5 | coverage 0.67; keep only the missed deltas | — |
+| swiftui/toolbars | A | TRIM | 0.67 | q1,q2,q3,q4 | coverage 0.67; keep only the missed deltas | human-review:unverified-suspect |
+| swiftui/webkit | A | TRIM | 0.68 | q2,q4,q5 | coverage 0.68; keep only the missed deltas | human-review:unclear-contradiction, human-review:unverified-suspect |
 
 ## testing
 
 | Skill | Track | Verdict | Coverage | Failed Qs | Justification | Flags |
 |---|---|---|---|---|---|---|
-| testing/characterization-test-generator | A | — not run — | | | | |
-| testing/flow-walkthrough | A | — not run — | | | | |
-| testing/integration-test-scaffold | A | — not run — | | | | |
-| testing/snapshot-test-setup | A | — not run — | | | | |
-| testing/tdd-bug-fix | A | — not run — | | | | |
-| testing/tdd-feature | A | — not run — | | | | |
-| testing/tdd-refactor-guard | A | — not run — | | | | |
-| testing/test-contract | A | — not run — | | | | |
-| testing/test-data-factory | A | — not run — | | | | |
+| testing/characterization-test-generator | A | TRIM | 0.68 | — | coverage 0.68; keep only the missed deltas | — |
+| testing/flow-walkthrough | A | KEEP | 0.36 | Q4,Q5 | coverage 0.36; bare model failed: UI/UX bugs fall into three distinct failure classes, each caught by a ; For every @Model with a Create path, there must be both a Read and an  | — |
+| testing/integration-test-scaffold | A | DELETE-candidate | 0.83 | — | bare model covered 0.83 of claims with no contradictions | human-review:borderline, swiftship-referenced, workflow-heavy |
+| testing/snapshot-test-setup | A | TRIM | 0.73 | q1,q4 | coverage 0.73; keep only the missed deltas | human-review:unclear-contradiction, workflow-heavy |
+| testing/tdd-bug-fix | A | TRIM | 0.68 | q5 | coverage 0.68; keep only the missed deltas | — |
+| testing/tdd-feature | A | KEEP | 0.42 | q1,q4,q5 | coverage 0.42; bare model failed: Tests should be written in order: Construction, Happy path, State veri; Writing too many tests before implementing is overwhelming and hides p | human-review:unclear-contradiction |
+| testing/tdd-refactor-guard | A | DELETE-candidate | 0.80 | — | bare model covered 0.80 of claims with no contradictions | human-review:borderline, swiftship-referenced, workflow-heavy |
+| testing/test-contract | A | TRIM | 0.75 | q1,q5 | coverage 0.75; keep only the missed deltas | — |
+| testing/test-data-factory | A | TRIM | 0.75 | q3,q4 | coverage 0.75; keep only the missed deltas | human-review:unclear-contradiction, workflow-heavy |
 
 ## visionos
 
 | Skill | Track | Verdict | Coverage | Failed Qs | Justification | Flags |
 |---|---|---|---|---|---|---|
-| visionos/spatial-design | A | — not run — | | | | |
-| visionos/widgets | A | — not run — | | | | |
+| visionos/spatial-design | A | KEEP | 0.42 | q1,q3,q5 | coverage 0.42; bare model failed: Hover effects should use a subtle ~5% scale change, with a reveal dela; Ornaments should overlap the window's bottom edge by 20pt, with border | human-review:unverified-suspect |
+| visionos/widgets | A | TRIM | 0.50 | q1,q2,q4 | coverage 0.50; keep only the missed deltas | human-review:borderline |
 
 ## watchos
 
 | Skill | Track | Verdict | Coverage | Failed Qs | Justification | Flags |
 |---|---|---|---|---|---|---|
-| watchos | A | — not run — | | | | |
+| watchos | A | FIX | 0.53 | q2,q4,q5 | suspect/contradicted claim confirmed: All new watch complications should use WidgetKit; ClockKit is deprecated as of watchOS 9 and removed | human-review:borderline, human-review:unclear-contradiction, human-review:unverified-suspect, truncated |
 
 ## Appendix A — FIX detail
 
+### generators/paywall-generator
+- `missed` iOS 18.4+ introduces SubscriptionOfferView, a new SwiftUI view for merchandising subscriptions, alongside a subscriptionStatusTask modifier for tracking subscri
+  - suspect: SubscriptionOfferView does not match known StoreKit SwiftUI API names (SubscriptionStoreView, ProductView, StoreView); likely a hallucinated or misremembered AP (cross-check: n/a)
+- `partial` Transaction.currentEntitlements(for:) is a new API for entitlements as of iOS 18.4.
+  - suspect: Real StoreKit API has plural Transaction.currentEntitlements as a parameterless AsyncSequence, and a separate singular Transaction.currentEntitlement(for:) that (cross-check: n/a)
+
+### ios/migration-patterns
+- `contradicted` When migrating both app code and tests, migrate the tests to Swift Testing first to establish a safety net before migrating the app code.
+- `contradicted` Each framework migration should be its own PR; don't combine e.g. CoreData->SwiftData and ObservableObject->@Observable in the same pull request.
+- `contradicted` SwiftData's @Model macro does not synthesize an initializer; you must write one explicitly, unlike NSManagedObject subclasses.
+  - suspect: The reference claim that @Model does not synthesize an initializer appears factually wrong — Apple's documented SwiftData behavior is that @Model does generate  (cross-check: n/a)
+
+### macos/macos-tahoe-apis
+- `contradicted` The document imports Foundation Models text generation/summarization APIs via a module called 'AppleIntelligence', which it explicitly flags as hypothetical (no
+- `contradicted` The document claims macOS 26's on-device AI stack includes MCP (Model Context Protocol) support alongside Foundation Models.
+  - suspect: No Apple framework or SDK ships MCP support alongside Foundation Models; this appears to be a fabricated feature. (cross-check: n/a)
+- `contradicted` Setting an EKReminder's priority to 1 is described as triggering the macOS 26 'urgent' reminder flag.
+  - suspect: EKReminderPriority has no 'urgent' case or flag; priority=1 maps to .high, not a distinct urgent state. (cross-check: n/a)
+- `contradicted` Control Center customization is described as system-level only; apps cannot add their own Control Center entries directly and must instead expose functionality 
+  - suspect: Claim describes Control Center as system-level-only with no direct app entries, but Apple's Controls/ControlWidget API (extended to macOS) does let apps add dir (cross-check: n/a)
+- `contradicted` Setting a Foundation Model's processingLocation to .onDevice is claimed to ensure privacy.
+  - suspect: No processingLocation property exists on Foundation Models APIs; the framework only exposes the on-device model with no such switch. (cross-check: n/a)
+
+### swiftui/alarmkit
+- `contradicted` The Info.plist key NSAlarmKitUsageDescription must be added before calling requestAuthorization(), or the request fails silently
+- `contradicted` Secondary alert buttons are created via factory methods .snoozeButton(), .openAppButton(), and .repeatButton()
+  - suspect: AlarmKit is a very new framework (iOS 26); I cannot confirm with certainty whether AlarmButton exposes static factory methods like .snoozeButton()/.openAppButto (cross-check: n/a)
+- `contradicted` All AlarmKit APIs listed (AlarmManager, Alarm, AlarmPresentation, AlarmAttributes, AlarmMetadata, AlarmButton, CountdownDuration, alarmUpdates, authorizationUpd
+  - suspect: AlarmKit was introduced at WWDC 2025 for iOS 26; a stated minimum of iOS 18 for AlarmManager and related AlarmKit APIs appears incorrect. (cross-check: n/a)
+
+### watchos
+- `partial` All new watch complications should use WidgetKit; ClockKit is deprecated as of watchOS 9 and removed entirely in watchOS 11.
+  - suspect: Claim asserts ClockKit is fully removed in watchOS 11; I'm not confident Apple has actually removed ClockKit entirely as of watchOS 11 (it was deprecated in wat (cross-check: n/a)
+- `partial` WidgetCenter.shared.reloadTimelines is budget-limited and should not be called more than 4 times per hour.
+  - suspect: Apple has never published an exact reload budget number for WidgetCenter.reloadTimelines; the specific '4 times per hour' figure isn't something I can confirm i (cross-check: n/a)
+- `partial` A WKExtendedRuntimeSession of type .selfCare (or .mindfulness) is capped at up to 10 minutes.
+  - suspect: The case name '.selfCare' doesn't match the WKExtendedRuntimeSessionType case I know of, which is '.mindfulness'; '.selfCare' may not be a real case name. (cross-check: n/a)
+- `contradicted` Interactive controls on watchOS should use a minimum touch target height of 38pt.
+  - suspect: 38pt is an unusual figure I don't recognize from Apple's HIG, which more commonly cites 44pt as the minimum tappable target size; not confident either number is (cross-check: n/a)
+- `contradicted` AssistiveTouch maps specific hand gestures to watch actions: clench for tap, double-clench for the action menu, pinch to move to the next element, and double-pi
+  - suspect: My recollection of Apple's AssistiveTouch for Apple Watch support documentation is that Pinch = tap/select and Clench = move to next item, which is the opposite (cross-check: n/a)
+- `contradicted` Complication timeline providers should supply at most 4-8 timeline entries rather than generating an entry for every minute.
+- `contradicted` For HealthKit read-type authorization, checking authorizationStatus always reports .notDetermined regardless of whether the user actually granted or denied read
+- `partial` The watchOS toolbar's More button is a circular ellipsis rendered white at 85% opacity with a 1pt black outer glow at 50%, and should hold only secondary action
+  - suspect: The precise styling spec (white at 85% opacity, 1pt black outer glow at 50%) is very specific undocumented visual detail not present in Apple's public HIG; uncl (cross-check: n/a)
+
 ## Appendix B — DELETE dossiers (the rows requiring human approval)
+
+### app-store/ratings-mechanics
+- ⚠️ referenced by SwiftShip: commands/ratings.md, commands/ship.md, CLAUDE.md — deletion blocked until paired
+- covered: Ratings are isolated per App Store storefront; a rating built up in one country shows as no rating at all in another unt
+  - evidence: “When you launch in Japan, the JP storefront starts at 0 ratings / no stars shown until Japanese users actually rate the ”
+- partial: The written-review pool is also per-storefront, so fresh markets will show empty review sections that need to be seeded 
+  - evidence: “they'll see an empty or sparse review list until JP users start writing their own”
+- partial: Resetting the ratings summary in ASC discards both the count and the average, and the count can only be rebuilt one rati
+  - evidence: “you'd be trading 3,000 data points of social proof and an above-average score for a rating count of zero the moment your”
+- partial: A near-exception to the never-reset rule is a catastrophic launch (sub-3★, low count, root cause fixed) on an app with a
+  - evidence: “The rating is dragged down by a specific, now-fixed defect (e.g., an app sitting at 2.3 stars because of a crash bug tha”
+- covered: When a user updates their review after receiving a developer reply, the new score replaces the old one in the average, m
+  - evidence: “If the star rating changes, Apple removes the old rating value and substitutes the new one in the aggregate; it isn't ad”
+- covered: Apple's phased release is a 7-day staged rollout to auto-update users following the schedule 1% → 2% → 5% → 10% → 20% → 
+  - evidence: “Phased-rollout percentages (Apple's fixed schedule, days 1–7): 1% → 2% → 5% → 10% → 20% → 50% → 100%.”
+- covered: Manual version release means App Review approval does not automatically trigger release, letting a developer choose to r
+  - evidence: “The only thing manual release changes is the moment the approved build goes live: instead of auto-releasing the instant ”
+- partial: A crashing build caught on day 1-2 of a phased rollout has already reached roughly 3% of users at that point in the sche
+  - evidence: “actual exposure on day 1–2 is higher than that headline number and isn't something you can bound precisely from App Stor”
+- covered: Pausing a phased release only stops new deliveries to additional users — it does not roll back users who already receive
+  - evidence: “It doesn't roll back anyone who already auto-updated — there's no way to un-push a version to a device.”
+- covered: The recommended default posture for every release is phased release on, manual release on, and monitoring day-1 crash ra
+  - evidence: “Should you default to manual release + phased release on? Yes, generally reasonable for an app with a meaningful auto-up”
+- partial: requestReview prompts should be aimed at success moments, with frequency capped and the definition of 'success' localize
+  - evidence: “Never fire on first launch or during onboarding — Apple's HIG is explicit that the prompt should appear after the user h”
+- covered: requestReview prompt triggers should be weighted by storefront maturity, since a market with only 12 ratings needs promp
+  - evidence: “Statistically, each new rating in the 12-count market moves the average ~8.3%; in the 5,000-count market it moves it ~0.”
+- covered: Unanswered negative reviews should be tracked per storefront rather than globally, since a storefront with only 5 review
+  - evidence: “In the 5,000-rating market you can batch/triage; in the 12-rating market treat every negative review as an incident.”
+
+### design/design-principles
+- ⚠️ referenced by SwiftShip: commands/visual-qa.md, commands/build.md, commands/plan.md, commands/walkthrough.md, commands/review.md, CLAUDE.md — deletion blocked until paired
+- covered: Every screen must let a user immediately answer three questions: Where am I? What can I do here? Where can I go from her
+  - evidence: “1. **Where am I?** — Clear indication of context/location in the app's hierarchy”
+- covered: Personal data should only be requested at the moment it's needed, never at app launch.
+  - evidence: “Core rule: request in context, not at launch. Never front-load permissions during onboarding.”
+- partial: Delight in design is defined as a byproduct of getting purpose, agency, familiarity, and craft right, not decorative flo
+  - evidence: “Treat delight as a **byproduct of getting fundamentals right, not an independent goal to design toward.**”
+- covered: iOS gestures typically require a movement threshold of about 10 points before committing to a directional gesture (hyste
+  - evidence: “**Drag commit threshold:** ~10 points of movement before a pan is disambiguated into a directional gesture.”
+- covered: Hamburger menus are discouraged for primary features because users don't know what's inside them; tab bars are preferred
+  - evidence: “hamburger menus hide navigation behind an icon that has no visual preview of what's inside, requires an extra tap to eve”
+- covered: Custom gestures should only be accelerators — a visible primary path to the same action must always exist.
+  - evidence: “HIG's rule of thumb is that gestures are accelerators for people who already know the app, not the only path to a featur”
+- covered: Tabs should represent content categories, never actions — per HIG there should be no 'Add' tab, since primary actions be
+  - evidence: “On "Add" as a tab: no, don't make an action item a tab. Tabs represent persistent, mutually exclusive destinations/views”
+- covered: Animations should be tuned as springs (using damping for overshoot and response for speed) rather than fixed durations.
+  - evidence: “Tune with **damping ratio**, not duration: ~1.0 for a settle with no overshoot, ~0.7–0.85 for a slight, natural bounce.”
+- covered: Following the 80/20 rule, the rarely-used 80% of features should be de-emphasized while the visible 20% does the work.
+  - evidence: “about 20% of features (the primary, high-frequency tasks) live in top-level, always-visible navigation (tab bar, home sc”
+- covered: Scrollable content should rubber-band (soft boundary) at edges rather than stopping abruptly.
+  - evidence: “**Overscroll / edge behavior:** rubber-banding, not a hard stop.”
+- covered: The idea-to-interface process starts by inventorying everything the app does before judging or removing anything.
+  - evidence: “**First step:** Do a full feature/content inventory and card-sort it against actual usage data (analytics + support tick”
+- covered: For scannable, structured information, a List layout is preferred over a Grid.
+  - evidence: “If in doubt and the content has any textual detail to scan, default to list.”
+- covered: Colors should be referenced via semantic names (like 'label' or 'secondarySystemBackground') rather than by appearance, 
+  - evidence: “Prefer **semantic system colors** where they fit your case: `Color.primary`/`Color.secondary`, `UIColor.label`/`.seconda”
 
 ### security
 - ⚠️ referenced by SwiftShip: commands/help.md, commands/release.md, commands/build.md, commands/submit.md, commands/plan.md, commands/review.md, commands/security.md, CLAUDE.md — deletion blocked until paired
@@ -327,5 +434,66 @@ kSecAttrKeySizeInBits: 256”
 - covered: On macOS 10.15+, kSecUseDataProtectionKeychain can be set to true to get iOS-like Keychain behavior.
   - evidence: “Set kSecUseDataProtectionKeychain: kCFBooleanTrue in every SecItemAdd/SecItemCopyMatching/SecItemUpdate/SecItemDelete qu”
 
+### testing/integration-test-scaffold
+- ⚠️ referenced by SwiftShip: commands/roadmap.md, commands/build.md, commands/plan.md, commands/test.md, CLAUDE.md — deletion blocked until paired
+- covered: MockURLProtocol.canInit(with:) always returns true so it intercepts every URLSession request.
+  - evidence: “Return `true` for every request you want the mock to intercept — typically all of them in a test double”
+- covered: The mock URLSession is built with URLSessionConfiguration.ephemeral and its protocolClasses set to [MockURLProtocol.self
+  - evidence: “configuration.protocolClasses = [MockURLProtocol.self]”
+- covered: In-memory SwiftData testing uses ModelConfiguration(isStoredInMemoryOnly: true).
+  - evidence: “let config = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)”
+- covered: Three mock strategy options are offered for configuration: URLProtocol-based mock server, protocol-based mock (swap impl
+  - evidence: “Protocol-based service boundary”
+- covered: If a requested path has no registered mock response, MockURLProtocol defaults to a 404 status code with empty Data.
+  - evidence: “Status: **404 Not Found**
+- Body: empty `Data()`”
+- covered: MockServer.respondWithError defaults to a 500 status code.
+  - evidence: “Status: **500 Internal Server Error** is the near-universal default”
+- partial: The scaffold process finds module dependencies by grepping for "import |@testable import" before mapping integration bou
+  - evidence: “grep -rl "^import ModuleX" Sources/ModuleY”
+- partial: Integration tests are distinguished from unit tests as testing multiple things together, which is described as realistic
+  - evidence: “Integration test: exercises real collaborators together, verifies the *contract* between them holds”
+- partial: Generated test infrastructure is organized under Tests/Infrastructure for shared test infrastructure, separate from Inte
+  - evidence: “Pull shared test doubles, fixtures, and harness code (mock URLProtocols, in-memory Core Data stacks, fixture loaders) in”
+- covered: Auth token integration tests verify the Authorization header is formatted as a Bearer token, e.g. "Bearer test-token".
+  - evidence: “XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer \(expectedToken)")”
+- partial: MockURLProtocol simulates network latency by calling Thread.sleep(forTimeInterval:) with a configurable responseDelay be
+  - evidence: “the cleaner approach is an async delay so you don't tie up a loading-system thread”
+- covered: Mock responses are delivered with a cacheStoragePolicy of .notAllowed.
+  - evidence: “Cache storage policy**: use `.notAllowed`.”
+
+### testing/tdd-refactor-guard
+- ⚠️ referenced by SwiftShip: CLAUDE.md — deletion blocked until paired
+- covered: Test coverage above 80% of public methods (with happy + error path tests) is rated 'Good' and the guard proceeds with re
+  - evidence: “Good (safe to refactor with normal care): ~80%+ line coverage”
+- covered: Coverage between 40-80% is rated 'Partial' and requires adding characterization tests for uncovered methods before refac
+  - evidence: “Partial (refactor with a safety net you build yourself first): ~40-80%”
+- covered: When no tests exist at all (0% coverage), the guard says to STOP and create characterization tests before any refactorin
+  - evidence: “Write characterization tests against the original code, not the refactor.”
+- covered: A test quality checklist item flags assertions like #expect(true) as always-passing and testing nothing, and recommends 
+  - evidence: “#expect(true) (or XCTAssertTrue(true)) is a no-op assertion.”
+- partial: Renaming a variable/method/type, extracting a method, inlining a temporary variable, moving a method to another type, an
+  - evidence: “Inline method/variable — Same caveats as extraction, reversed.”
+- partial: Changing a method signature, reordering operations, replacing an algorithm, merging/splitting classes, changing a data s
+  - evidence: “Splitting or merging classes/protocols”
+- partial: Architecture changes (MVC → MVVM), framework migrations (UIKit → SwiftUI), storage migrations (UserDefaults → SwiftData)
+  - evidence: “Migrating frameworks (Core Data → SwiftData, UIKit → SwiftUI, delegate patterns → Combine/async streams)”
+- covered: Post-refactor verification recommends running xcodebuild test with the -only-testing flag scoped to the characterization
+  - evidence: “-only-testing:MyAppTests/CharacterizationTests”
+- covered: The document cites Martin Fowler's book 'Refactoring: Improving the Design of Existing Code' as a reference for this gua
+  - evidence: “Martin Fowler's Refactoring (2nd ed., 2018) is the companion reference for the catalog of refactoring moves themselves”
+- partial: The guard produces a three-tier verdict — Green Light (proceed), Yellow Light (needs tests), or Red Light (stop) — as th
+  - evidence: “not as a green light on their own”
+
 ## Appendix C — errors / truncations
 
+- apple-intelligence/app-intents: supporting files truncated to outline (content budget)
+- core-ml: supporting files truncated to outline (content budget)
+- design/animation-patterns: supporting files truncated to outline (content budget)
+- ios/app-planner: supporting files truncated to outline (content budget)
+- ios/migration-patterns: supporting files truncated to outline (content budget)
+- macos/coding-best-practices: supporting files truncated to outline (content budget)
+- macos/ui-review-tahoe: supporting files truncated to outline (content budget)
+- performance/profiling: supporting files truncated to outline (content budget)
+- swift/concurrency-patterns: supporting files truncated to outline (content budget)
+- watchos: supporting files truncated to outline (content budget)

--- a/tools/skill-audit/results/claude-sonnet-5/summary.json
+++ b/tools/skill-audit/results/claude-sonnet-5/summary.json
@@ -1,5 +1,1249 @@
 [
  {
+  "skill": "app-store/ad-attribution",
+  "track": "A",
+  "verdict": "KEEP",
+  "coverage": 0.42857142857142855,
+  "flags": []
+ },
+ {
+  "skill": "app-store/app-description-writer",
+  "track": "A",
+  "verdict": "TRIM",
+  "coverage": 0.7916666666666666,
+  "flags": [
+   "human-review:borderline"
+  ]
+ },
+ {
+  "skill": "app-store/apple-search-ads",
+  "track": "A",
+  "verdict": "KEEP",
+  "coverage": 0.46153846153846156,
+  "flags": [
+   "human-review:borderline",
+   "human-review:unclear-contradiction"
+  ]
+ },
+ {
+  "skill": "app-store/iap-finalizer",
+  "track": "A",
+  "verdict": "TRIM",
+  "coverage": 0.625,
+  "flags": [
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "app-store/keyword-optimizer",
+  "track": "A",
+  "verdict": "TRIM",
+  "coverage": 0.5384615384615384,
+  "flags": [
+   "human-review:borderline",
+   "human-review:unverified-suspect"
+  ]
+ },
+ {
+  "skill": "app-store/marketing-strategy",
+  "track": "A",
+  "verdict": "KEEP",
+  "coverage": 0.42857142857142855,
+  "flags": [
+   "human-review:unclear-contradiction",
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "app-store/originality-check",
+  "track": "A",
+  "verdict": "TRIM",
+  "coverage": 0.5833333333333334,
+  "flags": []
+ },
+ {
+  "skill": "app-store/ratings-mechanics",
+  "track": "A",
+  "verdict": "DELETE-candidate",
+  "coverage": 0.8076923076923077,
+  "flags": [
+   "human-review:borderline",
+   "swiftship-referenced"
+  ]
+ },
+ {
+  "skill": "app-store/rejection-handler",
+  "track": "A",
+  "verdict": "TRIM",
+  "coverage": 0.5,
+  "flags": [
+   "human-review:borderline",
+   "human-review:unclear-contradiction",
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "app-store/review-response-writer",
+  "track": "A",
+  "verdict": "TRIM",
+  "coverage": 0.5,
+  "flags": [
+   "human-review:borderline",
+   "human-review:unclear-contradiction",
+   "human-review:unverified-suspect"
+  ]
+ },
+ {
+  "skill": "app-store/screenshot-planner",
+  "track": "A",
+  "verdict": "KEEP",
+  "coverage": 0.375,
+  "flags": [
+   "human-review:unclear-contradiction"
+  ]
+ },
+ {
+  "skill": "app-store/web-presence",
+  "track": "A",
+  "verdict": "TRIM",
+  "coverage": 0.6818181818181818,
+  "flags": [
+   "human-review:unclear-contradiction"
+  ]
+ },
+ {
+  "skill": "apple-intelligence/app-intents",
+  "track": "A",
+  "verdict": "KEEP",
+  "coverage": 0.42857142857142855,
+  "flags": [
+   "human-review:unverified-suspect",
+   "truncated"
+  ]
+ },
+ {
+  "skill": "apple-intelligence/foundation-models",
+  "track": "A",
+  "verdict": "KEEP",
+  "coverage": 0.23333333333333334,
+  "flags": [
+   "human-review:unverified-suspect"
+  ]
+ },
+ {
+  "skill": "apple-intelligence/visual-intelligence",
+  "track": "A",
+  "verdict": "TRIM",
+  "coverage": 0.5,
+  "flags": [
+   "human-review:borderline"
+  ]
+ },
+ {
+  "skill": "core-ml",
+  "track": "A",
+  "verdict": "TRIM",
+  "coverage": 0.7,
+  "flags": [
+   "truncated",
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "design/animation-patterns",
+  "track": "A",
+  "verdict": "TRIM",
+  "coverage": 0.8333333333333334,
+  "flags": [
+   "human-review:borderline",
+   "human-review:unclear-contradiction",
+   "truncated"
+  ]
+ },
+ {
+  "skill": "design/design-principles",
+  "track": "A",
+  "verdict": "DELETE-candidate",
+  "coverage": 0.9615384615384616,
+  "flags": [
+   "swiftship-referenced"
+  ]
+ },
+ {
+  "skill": "design/liquid-glass",
+  "track": "A",
+  "verdict": "TRIM",
+  "coverage": 0.5454545454545454,
+  "flags": [
+   "human-review:borderline",
+   "human-review:unclear-contradiction",
+   "human-review:unverified-suspect"
+  ]
+ },
+ {
+  "skill": "design/sf-symbols",
+  "track": "A",
+  "verdict": "KEEP",
+  "coverage": 0.2916666666666667,
+  "flags": [
+   "human-review:unverified-suspect"
+  ]
+ },
+ {
+  "skill": "design/typography",
+  "track": "A",
+  "verdict": "TRIM",
+  "coverage": 0.5909090909090909,
+  "flags": []
+ },
+ {
+  "skill": "design/ui-prototyping",
+  "track": "A",
+  "verdict": "KEEP",
+  "coverage": 0.4166666666666667,
+  "flags": [
+   "human-review:unclear-contradiction",
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "design/ux-writing",
+  "track": "A",
+  "verdict": "TRIM",
+  "coverage": 0.7857142857142857,
+  "flags": [
+   "human-review:borderline"
+  ]
+ },
+ {
+  "skill": "foundation/attributed-string",
+  "track": "A",
+  "verdict": "TRIM",
+  "coverage": 0.625,
+  "flags": []
+ },
+ {
+  "skill": "generators/accessibility-generator",
+  "track": "B",
+  "verdict": "KEEP",
+  "coverage": 0.4,
+  "flags": []
+ },
+ {
+  "skill": "generators/account-deletion",
+  "track": "B",
+  "verdict": "KEEP",
+  "coverage": 0.65,
+  "flags": [
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "generators/analytics-setup",
+  "track": "B",
+  "verdict": "KEEP",
+  "coverage": 0.5,
+  "flags": [
+   "human-review:borderline",
+   "human-review:unverified-suspect",
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "generators/announcement-banner",
+  "track": "B",
+  "verdict": "KEEP",
+  "coverage": 0.7857142857142857,
+  "flags": [
+   "human-review:borderline",
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "generators/app-clip",
+  "track": "B",
+  "verdict": "KEEP",
+  "coverage": 0.5,
+  "flags": [
+   "human-review:borderline",
+   "human-review:unverified-suspect",
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "generators/app-extensions",
+  "track": "B",
+  "verdict": "KEEP",
+  "coverage": 0.6,
+  "flags": [
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "generators/app-icon-generator",
+  "track": "B",
+  "verdict": "KEEP",
+  "coverage": 0.2,
+  "flags": [
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "generators/app-store-assets",
+  "track": "B",
+  "verdict": "KEEP",
+  "coverage": 0.7,
+  "flags": [
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "generators/auth-flow",
+  "track": "B",
+  "verdict": "KEEP",
+  "coverage": 0.5,
+  "flags": [
+   "human-review:borderline",
+   "human-review:unverified-suspect",
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "generators/background-processing",
+  "track": "B",
+  "verdict": "KEEP",
+  "coverage": 0.875,
+  "flags": [
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "generators/ci-cd-setup",
+  "track": "B",
+  "verdict": "KEEP",
+  "coverage": 0.25,
+  "flags": []
+ },
+ {
+  "skill": "generators/cloudkit-sync",
+  "track": "B",
+  "verdict": "KEEP",
+  "coverage": 0.6,
+  "flags": [
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "generators/consent-flow",
+  "track": "B",
+  "verdict": "KEEP",
+  "coverage": 0.375,
+  "flags": [
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "generators/custom-product-pages",
+  "track": "B",
+  "verdict": "KEEP",
+  "coverage": 0.14285714285714285,
+  "flags": [
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "generators/data-export",
+  "track": "B",
+  "verdict": "TRIM(prose)",
+  "coverage": 0.8125,
+  "flags": [
+   "human-review:borderline",
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "generators/debug-menu",
+  "track": "B",
+  "verdict": "KEEP",
+  "coverage": 0.7222222222222222,
+  "flags": [
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "generators/deep-linking",
+  "track": "B",
+  "verdict": "KEEP",
+  "coverage": 0.375,
+  "flags": []
+ },
+ {
+  "skill": "generators/error-monitoring",
+  "track": "B",
+  "verdict": "KEEP",
+  "coverage": 0.5,
+  "flags": [
+   "human-review:borderline",
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "generators/feature-flags",
+  "track": "B",
+  "verdict": "KEEP",
+  "coverage": 0.375,
+  "flags": [
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "generators/featuring-nomination",
+  "track": "B",
+  "verdict": "KEEP",
+  "coverage": 0.2857142857142857,
+  "flags": [
+   "human-review:unclear-contradiction",
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "generators/feedback-form",
+  "track": "B",
+  "verdict": "KEEP",
+  "coverage": 0.5,
+  "flags": [
+   "human-review:borderline",
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "generators/force-update",
+  "track": "B",
+  "verdict": "KEEP",
+  "coverage": 0.7,
+  "flags": [
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "generators/http-cache",
+  "track": "B",
+  "verdict": "KEEP",
+  "coverage": 0.5714285714285714,
+  "flags": [
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "generators/image-loading",
+  "track": "B",
+  "verdict": "KEEP",
+  "coverage": 0.6666666666666666,
+  "flags": [
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "generators/in-app-events",
+  "track": "B",
+  "verdict": "KEEP",
+  "coverage": 0.15,
+  "flags": [
+   "human-review:unverified-suspect",
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "generators/lapsed-user",
+  "track": "B",
+  "verdict": "KEEP",
+  "coverage": 0.125,
+  "flags": [
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "generators/live-activity-generator",
+  "track": "B",
+  "verdict": "KEEP",
+  "coverage": 0.55,
+  "flags": [
+   "human-review:unverified-suspect",
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "generators/localization-setup",
+  "track": "B",
+  "verdict": "KEEP",
+  "coverage": 0.5,
+  "flags": [
+   "human-review:borderline",
+   "human-review:unverified-suspect"
+  ]
+ },
+ {
+  "skill": "generators/logging-setup",
+  "track": "B",
+  "verdict": "KEEP",
+  "coverage": 0.6875,
+  "flags": [
+   "human-review:unverified-suspect",
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "generators/milestone-celebration",
+  "track": "B",
+  "verdict": "KEEP",
+  "coverage": 0.5,
+  "flags": [
+   "human-review:borderline",
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "generators/networking-layer",
+  "track": "B",
+  "verdict": "KEEP",
+  "coverage": 0.5,
+  "flags": [
+   "human-review:borderline",
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "generators/offer-codes-setup",
+  "track": "B",
+  "verdict": "KEEP",
+  "coverage": 0.045454545454545456,
+  "flags": [
+   "human-review:unclear-contradiction",
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "generators/offline-queue",
+  "track": "B",
+  "verdict": "KEEP",
+  "coverage": 0.4166666666666667,
+  "flags": [
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "generators/onboarding-generator",
+  "track": "B",
+  "verdict": "KEEP",
+  "coverage": 0.7857142857142857,
+  "flags": [
+   "human-review:borderline",
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "generators/pagination",
+  "track": "B",
+  "verdict": "KEEP",
+  "coverage": 0.5,
+  "flags": [
+   "human-review:borderline",
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "generators/paywall-generator",
+  "track": "B",
+  "verdict": "FIX",
+  "coverage": 0.2,
+  "flags": [
+   "human-review:unverified-suspect",
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "generators/permission-priming",
+  "track": "B",
+  "verdict": "KEEP",
+  "coverage": 0.6875,
+  "flags": [
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "generators/persistence-setup",
+  "track": "B",
+  "verdict": "KEEP",
+  "coverage": 0.5555555555555556,
+  "flags": [
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "generators/pre-orders",
+  "track": "B",
+  "verdict": "KEEP",
+  "coverage": 0.1111111111111111,
+  "flags": [
+   "human-review:unclear-contradiction",
+   "human-review:unverified-suspect",
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "generators/preview-data-generator",
+  "track": "B",
+  "verdict": "KEEP",
+  "coverage": 0.5625,
+  "flags": [
+   "human-review:unverified-suspect",
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "generators/product-page-optimization",
+  "track": "B",
+  "verdict": "KEEP",
+  "coverage": 0.35,
+  "flags": [
+   "human-review:unclear-contradiction",
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "generators/promoted-iap",
+  "track": "B",
+  "verdict": "KEEP",
+  "coverage": 0.5,
+  "flags": [
+   "human-review:borderline",
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "generators/push-notifications",
+  "track": "B",
+  "verdict": "KEEP",
+  "coverage": 0.2777777777777778,
+  "flags": []
+ },
+ {
+  "skill": "generators/quick-win-session",
+  "track": "B",
+  "verdict": "KEEP",
+  "coverage": 0.3,
+  "flags": [
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "generators/referral-system",
+  "track": "B",
+  "verdict": "KEEP",
+  "coverage": 0.5,
+  "flags": [
+   "human-review:borderline",
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "generators/review-prompt",
+  "track": "B",
+  "verdict": "KEEP",
+  "coverage": 0.625,
+  "flags": [
+   "human-review:unverified-suspect",
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "generators/screenshot-automation",
+  "track": "B",
+  "verdict": "KEEP",
+  "coverage": 0.3,
+  "flags": [
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "generators/settings-screen",
+  "track": "B",
+  "verdict": "KEEP",
+  "coverage": 0.75,
+  "flags": [
+   "human-review:unclear-contradiction",
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "generators/share-card",
+  "track": "B",
+  "verdict": "KEEP",
+  "coverage": 0.25,
+  "flags": [
+   "human-review:unverified-suspect",
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "generators/social-export",
+  "track": "B",
+  "verdict": "KEEP",
+  "coverage": 0.625,
+  "flags": [
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "generators/spotlight-indexing",
+  "track": "B",
+  "verdict": "KEEP",
+  "coverage": 0.3888888888888889,
+  "flags": [
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "generators/state-restoration",
+  "track": "B",
+  "verdict": "KEEP",
+  "coverage": 0.6666666666666666,
+  "flags": [
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "generators/streak-tracker",
+  "track": "B",
+  "verdict": "KEEP",
+  "coverage": 0.16666666666666666,
+  "flags": [
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "generators/subscription-lifecycle",
+  "track": "B",
+  "verdict": "KEEP",
+  "coverage": 0.2,
+  "flags": [
+   "human-review:unverified-suspect",
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "generators/subscription-offers",
+  "track": "B",
+  "verdict": "KEEP",
+  "coverage": 0.25,
+  "flags": [
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "generators/test-generator",
+  "track": "B",
+  "verdict": "KEEP",
+  "coverage": 0.2777777777777778,
+  "flags": []
+ },
+ {
+  "skill": "generators/tipkit-generator",
+  "track": "B",
+  "verdict": "KEEP",
+  "coverage": 0.22727272727272727,
+  "flags": [
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "generators/usage-insights",
+  "track": "B",
+  "verdict": "KEEP",
+  "coverage": 0.65,
+  "flags": [
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "generators/variable-rewards",
+  "track": "B",
+  "verdict": "KEEP",
+  "coverage": 0.5,
+  "flags": [
+   "human-review:borderline",
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "generators/watermark-engine",
+  "track": "B",
+  "verdict": "KEEP",
+  "coverage": 0.3125,
+  "flags": [
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "generators/whats-new",
+  "track": "B",
+  "verdict": "KEEP",
+  "coverage": 0.5,
+  "flags": [
+   "human-review:borderline",
+   "human-review:unclear-contradiction",
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "generators/widget-generator",
+  "track": "B",
+  "verdict": "KEEP",
+  "coverage": 0.45,
+  "flags": [
+   "human-review:borderline",
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "generators/win-back-offers",
+  "track": "B",
+  "verdict": "KEEP",
+  "coverage": 0.1,
+  "flags": [
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "growth/analytics-interpretation",
+  "track": "A",
+  "verdict": "KEEP",
+  "coverage": 0.35714285714285715,
+  "flags": [
+   "human-review:unclear-contradiction",
+   "human-review:unverified-suspect",
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "growth/community-building",
+  "track": "A",
+  "verdict": "TRIM",
+  "coverage": 0.5416666666666666,
+  "flags": [
+   "human-review:borderline",
+   "human-review:unclear-contradiction",
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "growth/indie-business",
+  "track": "A",
+  "verdict": "TRIM",
+  "coverage": 0.75,
+  "flags": [
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "growth/press-media",
+  "track": "A",
+  "verdict": "TRIM",
+  "coverage": 0.5769230769230769,
+  "flags": [
+   "human-review:unclear-contradiction",
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "growth/store-growth-audit",
+  "track": "A",
+  "verdict": "KEEP",
+  "coverage": 0.4666666666666667,
+  "flags": [
+   "human-review:borderline",
+   "human-review:unclear-contradiction",
+   "human-review:unverified-suspect",
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "growth/store-signals",
+  "track": "A",
+  "verdict": "KEEP",
+  "coverage": 0.34615384615384615,
+  "flags": [
+   "human-review:unclear-contradiction"
+  ]
+ },
+ {
+  "skill": "ios/accessibility-audit",
+  "track": "A",
+  "verdict": "TRIM",
+  "coverage": 0.7307692307692307,
+  "flags": [
+   "human-review:unclear-contradiction",
+   "human-review:unverified-suspect"
+  ]
+ },
+ {
+  "skill": "ios/app-planner",
+  "track": "A",
+  "verdict": "KEEP",
+  "coverage": 0.46153846153846156,
+  "flags": [
+   "human-review:borderline",
+   "human-review:unclear-contradiction",
+   "truncated",
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "ios/assistive-access",
+  "track": "A",
+  "verdict": "KEEP",
+  "coverage": 0.38461538461538464,
+  "flags": []
+ },
+ {
+  "skill": "ios/coding-best-practices",
+  "track": "A",
+  "verdict": "TRIM",
+  "coverage": 0.5,
+  "flags": [
+   "human-review:borderline"
+  ]
+ },
+ {
+  "skill": "ios/ipad-patterns",
+  "track": "A",
+  "verdict": "TRIM",
+  "coverage": 0.8928571428571429,
+  "flags": [
+   "judge-disagreement"
+  ]
+ },
+ {
+  "skill": "ios/migration-patterns",
+  "track": "A",
+  "verdict": "FIX",
+  "coverage": 0.5769230769230769,
+  "flags": [
+   "human-review:unverified-suspect",
+   "truncated"
+  ]
+ },
+ {
+  "skill": "ios/navigation-patterns",
+  "track": "A",
+  "verdict": "TRIM",
+  "coverage": 0.8333333333333334,
+  "flags": [
+   "human-review:borderline",
+   "human-review:unclear-contradiction"
+  ]
+ },
+ {
+  "skill": "ios/run-device",
+  "track": "A",
+  "verdict": "KEEP",
+  "coverage": 0.36363636363636365,
+  "flags": [
+   "human-review:unverified-suspect"
+  ]
+ },
+ {
+  "skill": "ios/run-simulator",
+  "track": "A",
+  "verdict": "TRIM",
+  "coverage": 0.7916666666666666,
+  "flags": [
+   "human-review:borderline"
+  ]
+ },
+ {
+  "skill": "ios/ui-review",
+  "track": "A",
+  "verdict": "TRIM",
+  "coverage": 0.6428571428571429,
+  "flags": [
+   "human-review:unclear-contradiction",
+   "human-review:unverified-suspect"
+  ]
+ },
+ {
+  "skill": "legal/privacy-policy",
+  "track": "A",
+  "verdict": "TRIM",
+  "coverage": 0.6818181818181818,
+  "flags": [
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "legal/privacy-publish",
+  "track": "A",
+  "verdict": "TRIM",
+  "coverage": 0.5833333333333334,
+  "flags": [
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "macos/app-planner",
+  "track": "A",
+  "verdict": "TRIM",
+  "coverage": 0.5,
+  "flags": [
+   "human-review:borderline",
+   "human-review:unclear-contradiction"
+  ]
+ },
+ {
+  "skill": "macos/appkit-swiftui-bridge",
+  "track": "A",
+  "verdict": "TRIM",
+  "coverage": 0.7272727272727273,
+  "flags": []
+ },
+ {
+  "skill": "macos/architecture-patterns",
+  "track": "A",
+  "verdict": "TRIM",
+  "coverage": 0.9444444444444444,
+  "flags": [
+   "judge-disagreement"
+  ]
+ },
+ {
+  "skill": "macos/coding-best-practices",
+  "track": "A",
+  "verdict": "TRIM",
+  "coverage": 0.6923076923076923,
+  "flags": [
+   "truncated"
+  ]
+ },
+ {
+  "skill": "macos/macos-capabilities",
+  "track": "A",
+  "verdict": "TRIM",
+  "coverage": 0.8846153846153846,
+  "flags": []
+ },
+ {
+  "skill": "macos/macos-tahoe-apis",
+  "track": "A",
+  "verdict": "FIX",
+  "coverage": 0.5,
+  "flags": [
+   "human-review:borderline",
+   "human-review:unverified-suspect"
+  ]
+ },
+ {
+  "skill": "macos/swiftdata-architecture",
+  "track": "A",
+  "verdict": "TRIM",
+  "coverage": 0.6923076923076923,
+  "flags": []
+ },
+ {
+  "skill": "macos/ui-review-tahoe",
+  "track": "A",
+  "verdict": "TRIM",
+  "coverage": 0.7307692307692307,
+  "flags": [
+   "human-review:unverified-suspect",
+   "truncated"
+  ]
+ },
+ {
+  "skill": "mapkit/geotoolbox",
+  "track": "A",
+  "verdict": "TRIM",
+  "coverage": 0.625,
+  "flags": []
+ },
+ {
+  "skill": "monetization",
+  "track": "A",
+  "verdict": "KEEP",
+  "coverage": 0.32142857142857145,
+  "flags": [
+   "human-review:unclear-contradiction",
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "monetization/bundles-and-licensing",
+  "track": "A",
+  "verdict": "KEEP",
+  "coverage": 0.4166666666666667,
+  "flags": []
+ },
+ {
+  "skill": "monetization/external-purchases",
+  "track": "A",
+  "verdict": "TRIM",
+  "coverage": 0.75,
+  "flags": []
+ },
+ {
+  "skill": "performance/profiling",
+  "track": "A",
+  "verdict": "KEEP",
+  "coverage": 0.3181818181818182,
+  "flags": [
+   "human-review:unclear-contradiction",
+   "human-review:unverified-suspect",
+   "truncated"
+  ]
+ },
+ {
+  "skill": "performance/swiftui-debugging",
+  "track": "A",
+  "verdict": "TRIM",
+  "coverage": 0.6071428571428571,
+  "flags": [
+   "human-review:unclear-contradiction"
+  ]
+ },
+ {
+  "skill": "product/app-namer",
+  "track": "A",
+  "verdict": "TRIM",
+  "coverage": 0.75,
+  "flags": [
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "product/architecture-spec",
+  "track": "B",
+  "verdict": "KEEP",
+  "coverage": 0.0,
+  "flags": [
+   "human-review:unclear-contradiction"
+  ]
+ },
+ {
+  "skill": "product/beta-testing",
+  "track": "A",
+  "verdict": "KEEP",
+  "coverage": 0.4230769230769231,
+  "flags": [
+   "human-review:unclear-contradiction",
+   "human-review:unverified-suspect",
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "product/competitive-analysis",
+  "track": "A",
+  "verdict": "KEEP",
+  "coverage": 0.15,
+  "flags": [
+   "human-review:unclear-contradiction"
+  ]
+ },
+ {
+  "skill": "product/idea-generator",
+  "track": "A",
+  "verdict": "KEEP",
+  "coverage": 0.16666666666666666,
+  "flags": [
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "product/implementation-guide",
+  "track": "B",
+  "verdict": "KEEP",
+  "coverage": 0.0,
+  "flags": []
+ },
+ {
+  "skill": "product/implementation-spec",
+  "track": "B",
+  "verdict": "KEEP",
+  "coverage": 0.0,
+  "flags": [
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "product/localization-strategy",
+  "track": "A",
+  "verdict": "TRIM",
+  "coverage": 0.6153846153846154,
+  "flags": [
+   "human-review:unclear-contradiction",
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "product/market-research",
+  "track": "A",
+  "verdict": "KEEP",
+  "coverage": 0.4230769230769231,
+  "flags": [
+   "human-review:unclear-contradiction",
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "product/prd-generator",
+  "track": "A",
+  "verdict": "TRIM",
+  "coverage": 0.75,
+  "flags": [
+   "human-review:unclear-contradiction"
+  ]
+ },
+ {
+  "skill": "product/product-agent",
+  "track": "A",
+  "verdict": "KEEP",
+  "coverage": 0.045454545454545456,
+  "flags": []
+ },
+ {
+  "skill": "product/release-spec",
+  "track": "B",
+  "verdict": "KEEP",
+  "coverage": 0.25,
+  "flags": [
+   "human-review:unverified-suspect"
+  ]
+ },
+ {
+  "skill": "product/test-spec",
+  "track": "B",
+  "verdict": "KEEP",
+  "coverage": 0.3888888888888889,
+  "flags": [
+   "human-review:unclear-contradiction"
+  ]
+ },
+ {
+  "skill": "product/ux-spec",
+  "track": "B",
+  "verdict": "KEEP",
+  "coverage": 0.25,
+  "flags": []
+ },
+ {
+  "skill": "release-review",
+  "track": "A",
+  "verdict": "TRIM",
+  "coverage": 0.7307692307692307,
+  "flags": [
+   "human-review:unclear-contradiction",
+   "human-review:unverified-suspect"
+  ]
+ },
+ {
   "skill": "security",
   "track": "A",
   "verdict": "DELETE-candidate",
@@ -16,6 +1260,233 @@
   "flags": [
    "human-review:borderline",
    "human-review:unverified-suspect"
+  ]
+ },
+ {
+  "skill": "shared/skill-auditor",
+  "track": "A",
+  "verdict": "KEEP",
+  "coverage": 0.0,
+  "flags": []
+ },
+ {
+  "skill": "shared/skill-creator",
+  "track": "A",
+  "verdict": "KEEP",
+  "coverage": 0.4,
+  "flags": []
+ },
+ {
+  "skill": "swift/concurrency",
+  "track": "A",
+  "verdict": "TRIM",
+  "coverage": 0.75,
+  "flags": [
+   "human-review:unverified-suspect"
+  ]
+ },
+ {
+  "skill": "swift/concurrency-patterns",
+  "track": "A",
+  "verdict": "TRIM",
+  "coverage": 0.7142857142857143,
+  "flags": [
+   "human-review:unverified-suspect",
+   "truncated"
+  ]
+ },
+ {
+  "skill": "swift/memory",
+  "track": "A",
+  "verdict": "TRIM",
+  "coverage": 0.5,
+  "flags": [
+   "human-review:borderline",
+   "human-review:unclear-contradiction",
+   "human-review:unverified-suspect"
+  ]
+ },
+ {
+  "skill": "swiftdata/inheritance",
+  "track": "A",
+  "verdict": "TRIM",
+  "coverage": 0.55,
+  "flags": [
+   "human-review:unclear-contradiction",
+   "human-review:unverified-suspect"
+  ]
+ },
+ {
+  "skill": "swiftui/alarmkit",
+  "track": "A",
+  "verdict": "FIX",
+  "coverage": 0.7142857142857143,
+  "flags": [
+   "human-review:unclear-contradiction",
+   "human-review:unverified-suspect"
+  ]
+ },
+ {
+  "skill": "swiftui/charts-3d",
+  "track": "A",
+  "verdict": "TRIM",
+  "coverage": 0.9166666666666666,
+  "flags": [
+   "judge-disagreement"
+  ]
+ },
+ {
+  "skill": "swiftui/data-flow",
+  "track": "A",
+  "verdict": "TRIM",
+  "coverage": 0.7666666666666667,
+  "flags": [
+   "human-review:borderline",
+   "human-review:unclear-contradiction"
+  ]
+ },
+ {
+  "skill": "swiftui/layout",
+  "track": "A",
+  "verdict": "TRIM",
+  "coverage": 0.6071428571428571,
+  "flags": [
+   "human-review:unverified-suspect"
+  ]
+ },
+ {
+  "skill": "swiftui/text-editing",
+  "track": "A",
+  "verdict": "TRIM",
+  "coverage": 0.6666666666666666,
+  "flags": []
+ },
+ {
+  "skill": "swiftui/toolbars",
+  "track": "A",
+  "verdict": "TRIM",
+  "coverage": 0.6666666666666666,
+  "flags": [
+   "human-review:unverified-suspect"
+  ]
+ },
+ {
+  "skill": "swiftui/webkit",
+  "track": "A",
+  "verdict": "TRIM",
+  "coverage": 0.6785714285714286,
+  "flags": [
+   "human-review:unclear-contradiction",
+   "human-review:unverified-suspect"
+  ]
+ },
+ {
+  "skill": "testing/characterization-test-generator",
+  "track": "A",
+  "verdict": "TRIM",
+  "coverage": 0.6818181818181818,
+  "flags": []
+ },
+ {
+  "skill": "testing/flow-walkthrough",
+  "track": "A",
+  "verdict": "KEEP",
+  "coverage": 0.35714285714285715,
+  "flags": []
+ },
+ {
+  "skill": "testing/integration-test-scaffold",
+  "track": "A",
+  "verdict": "DELETE-candidate",
+  "coverage": 0.8333333333333334,
+  "flags": [
+   "human-review:borderline",
+   "swiftship-referenced",
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "testing/snapshot-test-setup",
+  "track": "A",
+  "verdict": "TRIM",
+  "coverage": 0.7272727272727273,
+  "flags": [
+   "human-review:unclear-contradiction",
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "testing/tdd-bug-fix",
+  "track": "A",
+  "verdict": "TRIM",
+  "coverage": 0.6818181818181818,
+  "flags": []
+ },
+ {
+  "skill": "testing/tdd-feature",
+  "track": "A",
+  "verdict": "KEEP",
+  "coverage": 0.4166666666666667,
+  "flags": [
+   "human-review:unclear-contradiction"
+  ]
+ },
+ {
+  "skill": "testing/tdd-refactor-guard",
+  "track": "A",
+  "verdict": "DELETE-candidate",
+  "coverage": 0.8,
+  "flags": [
+   "human-review:borderline",
+   "swiftship-referenced",
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "testing/test-contract",
+  "track": "A",
+  "verdict": "TRIM",
+  "coverage": 0.75,
+  "flags": []
+ },
+ {
+  "skill": "testing/test-data-factory",
+  "track": "A",
+  "verdict": "TRIM",
+  "coverage": 0.75,
+  "flags": [
+   "human-review:unclear-contradiction",
+   "workflow-heavy"
+  ]
+ },
+ {
+  "skill": "visionos/spatial-design",
+  "track": "A",
+  "verdict": "KEEP",
+  "coverage": 0.4230769230769231,
+  "flags": [
+   "human-review:unverified-suspect"
+  ]
+ },
+ {
+  "skill": "visionos/widgets",
+  "track": "A",
+  "verdict": "TRIM",
+  "coverage": 0.5,
+  "flags": [
+   "human-review:borderline"
+  ]
+ },
+ {
+  "skill": "watchos",
+  "track": "A",
+  "verdict": "FIX",
+  "coverage": 0.5333333333333333,
+  "flags": [
+   "human-review:borderline",
+   "human-review:unclear-contradiction",
+   "human-review:unverified-suspect",
+   "truncated"
   ]
  }
 ]

--- a/tools/skill-audit/results/claude-sonnet-5/summary.json
+++ b/tools/skill-audit/results/claude-sonnet-5/summary.json
@@ -1,0 +1,21 @@
+[
+ {
+  "skill": "security",
+  "track": "A",
+  "verdict": "DELETE-candidate",
+  "coverage": 0.8636363636363636,
+  "flags": [
+   "swiftship-referenced"
+  ]
+ },
+ {
+  "skill": "security/privacy-manifests",
+  "track": "A",
+  "verdict": "TRIM",
+  "coverage": 0.7916666666666666,
+  "flags": [
+   "human-review:borderline",
+   "human-review:unverified-suspect"
+  ]
+ }
+]


### PR DESCRIPTION
## What

`tools/skill-audit/` — a re-runnable harness that answers, per skill: **does this skill teach the runtime model anything it doesn't already know?**

- Enumerates the **161 skills** by reusing `check-counts.sh`'s exact counting rule (leaf dirs + `CATEGORY_LEVEL_SKILLS`); category routers are excluded.
- **Bare sessions**: `claude -p --model sonnet --safe-mode --setting-sources "" --strict-mcp-config --tools "" --disable-slash-commands` in an empty cwd. A **mandatory preflight canary** (context probe + leak probe against the local user config) aborts the run if isolation ever regresses.
- **Track A** (92 advisory/workflow skills): derive 8–15 claims with machine-validated verbatim quotes + 3–5 non-leading questions → bare answers → grading with evidence quotes validated as substrings of the stored answers. **The judge never classifies** — verdict math (coverage thresholds) is code.
- **Track B** (63 generators + 6 `product/*-spec` document generators): prose-only grading, 2 calls/skill, **can never emit DELETE** — template value isn't Q&A-testable (compilability stays with `check-swift-templates.sh`).
- **DELETE guards**: Opus second-opinion regrade must agree, and any SwiftShip reference (grep of `commands/*.md` + `CLAUDE.md`) blocks deletion until paired.
- **FIX detection**: grader suspect flags cross-checked against `scripts/api-symbols.txt` + `versions.env`; unverified suspects are human-review flags only (grader knowledge-cutoff protection).
- Resumable per question; results keyed by resolved model id (`results/claude-sonnet-5/`) for `diff --against` across model releases.

## What this PR does NOT do

Nothing is deleted or edited. The output is `AUDIT-REPORT.md` for human approval — deletions/trims land in a separate PR after row-by-row approval.

## Verified

- Preflight isolation canary PASS (bare session sees no user config)
- End-to-end run on `security` (16 calls): `security` → DELETE-candidate (0.86 coverage, Opus agreed, ⚠️ 8 SwiftShip references found → blocked), `security/privacy-manifests` → TRIM (0.79, human-review flags)
- Kill mid-run → resume lost ≤1 call; grade-only state surgery → 3-call re-run; no-op resume → **0 calls**
- Evidence validator hardened against markdown-decoration mismatches (was rejecting 3 real quotes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)