### PR TITLE
feat: freshness metadata + decay CI (Task 2 of library overhaul)

### DIFF
--- a/.github/workflows/stale-skills.yml
+++ b/.github/workflows/stale-skills.yml
@@ -48,11 +48,13 @@ jobs:
               echo "skip (open issue exists): $cat"
               continue
             fi
-            BODY=$(awk -F'\t' -v c="$cat" '$1==c {printf "- [ ] `%s` (review_by %s)\n", $2, $3}' stale.tsv)
-            gh issue create --title "$TITLE" --label stale-skill --body "$BODY
-
-Re-verify each skill against the current OS generation (\`scripts/versions.env\`), update its content if needed, then bump \`last_verified\` and \`review_by\` (next WWDC + 2 weeks). The blind-test harness (\`tools/skill-audit/\`) can re-test a skill: \`python3 tools/skill-audit/audit.py run --skill <category>/<skill> --force\`.
-
-*Opened automatically by the stale-skills workflow.*"
+            {
+              awk -F'\t' -v c="$cat" '$1==c {printf "- [ ] `%s` (review_by %s)\n", $2, $3}' stale.tsv
+              echo ""
+              echo "Re-verify each skill against the current OS generation (\`scripts/versions.env\`), update its content if needed, then bump \`last_verified\` and \`review_by\` (next WWDC + 2 weeks). The blind-test harness can re-test a skill: \`python3 tools/skill-audit/audit.py run --skill <category>/<skill> --force\`."
+              echo ""
+              echo "_Opened automatically by the stale-skills workflow._"
+            } > /tmp/issue-body.md
+            gh issue create --title "$TITLE" --label stale-skill --body-file /tmp/issue-body.md
             echo "opened: $TITLE"
           done

--- a/.github/workflows/stale-skills.yml
+++ b/.github/workflows/stale-skills.yml
@@ -1,0 +1,58 @@
+name: stale-skills
+
+# Weekly decay sweep: skills past their review_by frontmatter date get ONE
+# rollup issue per category (not one per skill — post-WWDC the whole library
+# expires the same week by design, and 150 issues is noise, not signal).
+# Categories with an open `stale-skill` issue are skipped until it's closed.
+
+on:
+  schedule:
+    - cron: "0 6 * * 1" # Mondays 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Open rollup issues for stale categories
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          chmod +x scripts/check-review-by.sh
+          ./scripts/check-review-by.sh --self-test
+
+          ./scripts/check-review-by.sh --list > stale.tsv
+          if [ ! -s stale.tsv ]; then
+            echo "No stale skills."
+            exit 0
+          fi
+
+          # Ensure the label exists (no-op if it does).
+          gh label create stale-skill \
+            --description "Skills past their review_by date" \
+            --color D93F0B 2>/dev/null || true
+
+          OPEN_TITLES=$(gh issue list --label stale-skill --state open \
+            --json title --jq '.[].title')
+
+          for cat in $(cut -f1 stale.tsv | sort -u); do
+            TITLE="Stale skills: $cat"
+            if printf '%s\n' "$OPEN_TITLES" | grep -qxF "$TITLE"; then
+              echo "skip (open issue exists): $cat"
+              continue
+            fi
+            BODY=$(awk -F'\t' -v c="$cat" '$1==c {printf "- [ ] `%s` (review_by %s)\n", $2, $3}' stale.tsv)
+            gh issue create --title "$TITLE" --label stale-skill --body "$BODY
+
+Re-verify each skill against the current OS generation (\`scripts/versions.env\`), update its content if needed, then bump \`last_verified\` and \`review_by\` (next WWDC + 2 weeks). The blind-test harness (\`tools/skill-audit/\`) can re-test a skill: \`python3 tools/skill-audit/audit.py run --skill <category>/<skill> --force\`.
+
+*Opened automatically by the stale-skills workflow.*"
+            echo "opened: $TITLE"
+          done

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,8 @@ Every SKILL.md must have:
 ---
 name: skill-name
 description: Brief description and when to use it
+last_verified: 2026-07-16   # date content was last checked (bump when you edit)
+review_by: 2027-06-22       # scheduled re-verification, ~2 weeks after next WWDC
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash]
 ---
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,8 +152,18 @@ Every SKILL.md must have:
 name: skill-name
 description: Brief description (1-2 sentences)
 allowed-tools: [Read, Write, Edit]
+last_verified: 2026-07-16          # date the content was last checked against reality
+review_by: 2027-06-22              # scheduled re-verification (~2 weeks after next WWDC)
+os_version: iOS 27 / macOS 27      # only if the skill cites OS/Swift versions
 ---
 ```
+
+`last_verified`/`review_by` are content-freshness dates, not release versions —
+the repo still has no version numbers (every commit to `main` is a release).
+CI requires the two dates (`scripts/check-frontmatter.sh`); a weekly workflow
+opens one rollup issue per category when skills pass `review_by`
+(`.github/workflows/stale-skills.yml`). When you materially edit a skill, bump
+`last_verified` to today.
 
 Followed by:
 

--- a/scripts/check-frontmatter.sh
+++ b/scripts/check-frontmatter.sh
@@ -16,10 +16,17 @@ while IFS= read -r f; do
     fm=$(awk 'NR>1 && /^---$/{exit} NR>1{print}' "$f")
     printf '%s\n' "$fm" | grep -q '^name:'        || { echo "  ✗ $f: missing name:"; fails=$((fails+1)); }
     printf '%s\n' "$fm" | grep -q '^description:' || { echo "  ✗ $f: missing description:"; fails=$((fails+1)); }
+    # Freshness dates (added 2026-07): both required, strict YYYY-MM-DD.
+    # Overdue-ness is NOT checked here (that's check-review-by.sh + the weekly
+    # stale-skills workflow) — presence and format are the PR-blocking contract.
+    for key in last_verified review_by; do
+        printf '%s\n' "$fm" | grep -Eq "^$key: [0-9]{4}-[0-9]{2}-[0-9]{2}$" \
+            || { echo "  ✗ $f: missing or malformed $key: (want YYYY-MM-DD)"; fails=$((fails+1)); }
+    done
 done < <(find skills -name SKILL.md)
 
 if [ "$fails" -eq 0 ]; then
-    echo "✓ All SKILL.md frontmatter valid (name + description present)"
+    echo "✓ All SKILL.md frontmatter valid (name, description, last_verified, review_by)"
     exit 0
 fi
 echo "✗ $fails frontmatter problem(s)"

--- a/scripts/check-review-by.sh
+++ b/scripts/check-review-by.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# Decay tripwire — skills past their `review_by:` frontmatter date.
+#
+# Complements check-freshness.sh: that script catches *provable* rot
+# (recency claims naming stale OS versions, same line, deterministic);
+# review_by is the scheduled human re-verification date every skill carries
+# (default: ~2 weeks after the next WWDC). This script lists what's overdue.
+#
+# NOT wired into validate.yml on purpose: the week after WWDC most of the
+# library goes overdue at once by design — that's a work queue, not a broken
+# PR. The stale-skills workflow turns this into rollup issues weekly.
+#
+# Usage:
+#   ./scripts/check-review-by.sh              # human summary; exit 1 if any overdue
+#   ./scripts/check-review-by.sh --list       # TSV: category<TAB>path<TAB>review_by (exit 0)
+#   ./scripts/check-review-by.sh --self-test  # verify detection logic on fixtures
+#
+# SKILLS_DIR override supported (self-test uses it).
+
+set -u
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SKILLS="${SKILLS_DIR:-$REPO_DIR/skills}"
+TODAY=$(date +%F)
+
+overdue() {
+    # Emits: category<TAB>path<TAB>review_by for every overdue SKILL.md.
+    # YYYY-MM-DD compares correctly as a string — no date parsing needed.
+    find "$SKILLS" -name SKILL.md ! -path "*/_shared/*" | sort | while IFS= read -r f; do
+        rb=$(awk 'NR>1 && /^---$/{exit} /^review_by:/{print $2}' "$f")
+        [ -n "$rb" ] || continue
+        if [[ "$rb" < "$TODAY" ]]; then
+            rel=${f#"$SKILLS"/}
+            printf '%s\t%s\t%s\n' "${rel%%/*}" "$rel" "$rb"
+        fi
+    done
+}
+
+if [ "${1:-}" = "--self-test" ]; then
+    T=$(mktemp -d)
+    mkdir -p "$T/cat-a/expired" "$T/cat-a/fresh" "$T/cat-b/undated"
+    printf -- '---\nname: expired\nreview_by: 2000-01-01\n---\n' > "$T/cat-a/expired/SKILL.md"
+    printf -- '---\nname: fresh\nreview_by: 2999-01-01\n---\n'   > "$T/cat-a/fresh/SKILL.md"
+    printf -- '---\nname: undated\n---\n'                        > "$T/cat-b/undated/SKILL.md"
+    OUT=$(SKILLS_DIR="$T" "$0" --list)
+    rm -rf "$T"
+    echo "$OUT" | grep -q "cat-a	cat-a/expired/SKILL.md	2000-01-01" || { echo "✗ self-test: expired not detected"; exit 1; }
+    [ "$(echo "$OUT" | grep -c .)" -eq 1 ] || { echo "✗ self-test: false positive (fresh/undated flagged)"; exit 1; }
+    echo "✓ check-review-by self-test passed"
+    exit 0
+fi
+
+if [ "${1:-}" = "--list" ]; then
+    overdue
+    exit 0
+fi
+
+LIST=$(overdue)
+if [ -z "$LIST" ]; then
+    echo "✓ No skills past their review_by date"
+    exit 0
+fi
+N=$(printf '%s\n' "$LIST" | grep -c .)
+echo "✗ $N skill(s) past review_by (today: $TODAY):"
+printf '%s\n' "$LIST" | awk -F'\t' '{printf "  %s (review_by %s)\n", $2, $3}'
+exit 1

--- a/skills/app-store/SKILL.md
+++ b/skills/app-store/SKILL.md
@@ -2,6 +2,8 @@
 name: app-store
 description: App Store optimization and marketing skills for descriptions, screenshots, keywords, review responses, and comprehensive promotional strategy. Use when user needs help with App Store presence, ASO, marketing, or customer communication.
 allowed-tools: [Read, Write, Edit, Glob, Grep, AskUserQuestion, WebSearch]
+last_verified: 2026-07-16
+review_by: 2027-06-22
 ---
 
 # App Store Optimization & Marketing Skills

--- a/skills/app-store/ad-attribution/SKILL.md
+++ b/skills/app-store/ad-attribution/SKILL.md
@@ -2,6 +2,9 @@
 name: ad-attribution
 description: Privacy-preserving ad measurement with AdAttributionKit (SKAdNetwork's successor) — install and re-engagement attribution, conversion-value strategy under crowd anonymity, and end-to-end postback testing. Use when running paid acquisition beyond Apple Ads, measuring re-engagement campaigns, designing conversion values, or migrating from SKAdNetwork.
 allowed-tools: [Read, Write, Edit, Glob, Grep]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # Ad Attribution (AdAttributionKit)

--- a/skills/app-store/app-description-writer/SKILL.md
+++ b/skills/app-store/app-description-writer/SKILL.md
@@ -2,6 +2,8 @@
 name: app-description-writer
 description: Generate compelling App Store descriptions that convert browsers into users. Use when writing initial descriptions, improving existing copy, or drafting promotional text and What's New for a major update.
 allowed-tools: [Read, Write, Edit, Glob, Grep, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
 ---
 
 # App Description Writer

--- a/skills/app-store/apple-search-ads/SKILL.md
+++ b/skills/app-store/apple-search-ads/SKILL.md
@@ -2,6 +2,8 @@
 name: apple-search-ads
 description: Apple Search Ads campaign strategy for indie developers — paid acquisition, keyword bidding, budget planning, and ROAS optimization. Use when user asks about running ads, paid user acquisition, or Apple Search Ads campaigns.
 allowed-tools: [Read, Glob, Grep, AskUserQuestion, WebSearch]
+last_verified: 2026-07-16
+review_by: 2027-06-22
 ---
 
 # Apple Search Ads for Indie Developers

--- a/skills/app-store/iap-finalizer/SKILL.md
+++ b/skills/app-store/iap-finalizer/SKILL.md
@@ -2,6 +2,8 @@
 name: iap-finalizer
 description: Take a one-time in-app purchase from MISSING_METADATA to READY_TO_SUBMIT in App Store Connect — set its price schedule and localized display name/description (and optional review screenshot) via the ASC REST API. Use at Phase 6 (Pre-Release), after the IAP is built in-app (Phase 4) and its ASC record exists. NOT for subscriptions, and NOT the same as promoted-iap (which displays IAPs in-app).
 allowed-tools: [Read, Bash, mcp__asc-metadata__list_iap, mcp__asc-metadata__get_iap, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
 ---
 
 # IAP Finalizer

--- a/skills/app-store/keyword-optimizer/SKILL.md
+++ b/skills/app-store/keyword-optimizer/SKILL.md
@@ -2,6 +2,8 @@
 name: keyword-optimizer
 description: Optimize app title, subtitle, and keywords for maximum App Store discoverability. Use when launching a new app, improving search rankings, entering new markets/languages, or safely optimizing ASO for an app with existing traffic.
 allowed-tools: [Read, Write, Edit, Glob, Grep, AskUserQuestion, WebSearch]
+last_verified: 2026-07-16
+review_by: 2027-06-22
 ---
 
 # Keyword Optimizer

--- a/skills/app-store/marketing-strategy/SKILL.md
+++ b/skills/app-store/marketing-strategy/SKILL.md
@@ -2,6 +2,8 @@
 name: marketing-strategy
 description: App Store marketing strategy advisor that analyzes your app and recommends the best promotional features. Orchestrates sub-skills for implementation. Use when planning app promotion, launch strategy, user acquisition, or re-engagement campaigns.
 allowed-tools: [Read, Write, Edit, Glob, Grep, AskUserQuestion, WebSearch]
+last_verified: 2026-07-16
+review_by: 2027-06-22
 ---
 
 # App Store Marketing Strategy

--- a/skills/app-store/originality-check/SKILL.md
+++ b/skills/app-store/originality-check/SKILL.md
@@ -2,6 +2,8 @@
 name: originality-check
 description: Guideline-4.3 anti-spam / originality gate — score whether an app (and each portfolio addition) is meaningfully distinct in function, content, and metadata before you invest or submit. Use at validation/new-app time and again before submission. Protects the whole developer account from 4.3 (spam/duplicate) rejections. NOT rejection-handler (that works an existing rejection) and NOT competitive-analysis (that positions in the market).
 allowed-tools: [Read, Write, WebSearch, Glob, Grep, AskUserQuestion, mcp__asc-metadata__list_apps, mcp__asc-metadata__get_metadata]
+last_verified: 2026-07-16
+review_by: 2027-06-22
 ---
 
 # Originality Check

--- a/skills/app-store/ratings-mechanics/SKILL.md
+++ b/skills/app-store/ratings-mechanics/SKILL.md
@@ -2,6 +2,8 @@
 name: ratings-mechanics
 description: How App Store ratings actually behave — per-storefront isolation (your US stars show nowhere else), the never-reset rule, phased release + manual release as rating protection, and where prompting/replying fit. Use when planning ratings strategy for new markets, considering a ratings reset, setting release options, or diagnosing "why is my rating missing in country X."
 allowed-tools: [Read, Write, Edit, Glob, Grep]
+last_verified: 2026-07-16
+review_by: 2027-06-22
 ---
 
 # Ratings Mechanics

--- a/skills/app-store/rejection-handler/SKILL.md
+++ b/skills/app-store/rejection-handler/SKILL.md
@@ -2,6 +2,9 @@
 name: rejection-handler
 description: Handle App Store rejections, prepare submissions to avoid common rejection reasons, write Resolution Center responses, and navigate the appeal process. Use when user's app was rejected, is preparing for submission, or needs help with App Review.
 allowed-tools: [Read, Glob, Grep, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # App Store Rejection Handler

--- a/skills/app-store/review-response-writer/SKILL.md
+++ b/skills/app-store/review-response-writer/SKILL.md
@@ -2,6 +2,8 @@
 name: review-response-writer
 description: Write professional, empathetic responses to App Store reviews that build trust and turn critics into fans. Use when responding to negative reviews, drafting templates for common review types, or improving review management strategy.
 allowed-tools: [Read, Write, Edit, Glob, Grep, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
 ---
 
 # Review Response Writer

--- a/skills/app-store/screenshot-planner/SKILL.md
+++ b/skills/app-store/screenshot-planner/SKILL.md
@@ -2,6 +2,9 @@
 name: screenshot-planner
 description: Plan compelling App Store screenshot sequences that showcase your app's value. Use when preparing App Store assets, improving screenshot conversion, or drafting screenshot captions for a launch or major update.
 allowed-tools: [Read, Write, Edit, Glob, Grep, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # Screenshot Planner

--- a/skills/app-store/web-presence/SKILL.md
+++ b/skills/app-store/web-presence/SKILL.md
@@ -2,6 +2,8 @@
 name: web-presence
 description: The discovery surfaces outside the App Store app — your apps.apple.com product page ranking on Google, an owned landing page with a Smart App Banner, and the deal-site ecosystem that auto-amplifies price drops. Use when building a landing page, improving Google visibility for an app, planning a price-drop promotion, or auditing off-store discovery.
 allowed-tools: [Read, Write, Edit, Glob, Grep]
+last_verified: 2026-07-16
+review_by: 2027-06-22
 ---
 
 # Web Presence

--- a/skills/apple-intelligence/SKILL.md
+++ b/skills/apple-intelligence/SKILL.md
@@ -2,6 +2,9 @@
 name: apple-intelligence
 description: Apple Intelligence skills for on-device AI features including Foundation Models, Visual Intelligence, App Intents, and intelligent assistants. Use when implementing AI-powered features.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # Apple Intelligence Skills

--- a/skills/apple-intelligence/app-intents/SKILL.md
+++ b/skills/apple-intelligence/app-intents/SKILL.md
@@ -2,6 +2,9 @@
 name: app-intents
 description: App Intents for Siri, Shortcuts, Spotlight, and Apple Intelligence integration including intent modes, interactive snippets, visual intelligence, and entity indexing. Use when implementing Siri integration, App Shortcuts, or Spotlight indexing.
 allowed-tools: [Read, Glob, Grep]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # App Intents

--- a/skills/apple-intelligence/foundation-models/SKILL.md
+++ b/skills/apple-intelligence/foundation-models/SKILL.md
@@ -2,6 +2,9 @@
 name: foundation-models
 description: On-device LLM integration using Apple's Foundation Models framework. Use when implementing AI text generation, structured output, or tool calling.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # Foundation Models

--- a/skills/apple-intelligence/visual-intelligence/SKILL.md
+++ b/skills/apple-intelligence/visual-intelligence/SKILL.md
@@ -2,6 +2,8 @@
 name: visual-intelligence
 description: Integrate your app with iOS Visual Intelligence for camera-based search and object recognition. Use when adding visual search capabilities.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
 ---
 
 # Visual Intelligence

--- a/skills/core-ml/SKILL.md
+++ b/skills/core-ml/SKILL.md
@@ -2,6 +2,9 @@
 name: core-ml
 description: Core ML, Create ML, Vision framework, Natural Language framework, on-device ML integration. Use when user wants image classification, text analysis, object detection, sound classification, model optimization, or custom model integration. Covers Core ML vs Foundation Models decision.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # Core ML Skills

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -1,7 +1,10 @@
 ---
 name: design
-description: Design skills for Apple platform UI — Liquid Glass, animations, UI prototyping, evergreen design principles, UX writing, SF Symbols, and typography. Use when implementing design language features, structuring an app's UX, writing interface copy, or choosing type and iconography.
+description: Design skills for Apple platform UI — Liquid Glass, animations, UI prototyping, UX writing, SF Symbols, and typography. Use when implementing design language features, writing interface copy, or choosing type and iconography.
 allowed-tools: [Read, Write, Edit, Glob, Grep, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # Design Skills

--- a/skills/design/animation-patterns/SKILL.md
+++ b/skills/design/animation-patterns/SKILL.md
@@ -2,6 +2,9 @@
 name: animation-patterns
 description: SwiftUI animation patterns including springs, transitions, PhaseAnimator, KeyframeAnimator, SF Symbol effects, scroll-driven effects, mesh gradients, text renderers, and shader effects. Use when implementing, reviewing, or fixing animation or visual-effect code on iOS/macOS.
 allowed-tools: [Read, Glob, Grep]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # Animation Patterns

--- a/skills/design/liquid-glass/SKILL.md
+++ b/skills/design/liquid-glass/SKILL.md
@@ -2,6 +2,9 @@
 name: liquid-glass
 description: Implement Liquid Glass design using .glassEffect() API for iOS/macOS 26+. Covers SwiftUI, AppKit, UIKit, and WidgetKit. Use when creating modern glass-based UI effects.
 allowed-tools: [Read, Write, Edit, Glob, Grep, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # Liquid Glass Design

--- a/skills/design/sf-symbols/SKILL.md
+++ b/skills/design/sf-symbols/SKILL.md
@@ -2,6 +2,8 @@
 name: sf-symbols
 description: SF Symbols end-to-end — choosing and configuring the 7,000+ system symbols (rendering modes, variable color/draw, gradients), authoring custom symbols that interpolate across weights, and the animation preset vocabulary. Use when picking iconography, building custom symbols, animating symbol state changes, or rendering values as symbols.
 allowed-tools: [Read, Write, Edit, Glob, Grep]
+last_verified: 2026-07-16
+review_by: 2027-06-22
 ---
 
 # SF Symbols

--- a/skills/design/typography/SKILL.md
+++ b/skills/design/typography/SKILL.md
@@ -2,6 +2,8 @@
 name: typography
 description: UI typography on Apple platforms — text styles and Dynamic Type, the San Francisco family (Pro/Rounded/Compact/Mono/New York + width axis), optical sizes, tracking vs kerning, leading adjustments, and custom-font scaling. Use when choosing fonts, building type hierarchy, fixing truncation/legibility, or making custom fonts respect Dynamic Type.
 allowed-tools: [Read, Write, Edit, Glob, Grep]
+last_verified: 2026-07-16
+review_by: 2027-06-22
 ---
 
 # Typography

--- a/skills/design/ui-prototyping/SKILL.md
+++ b/skills/design/ui-prototyping/SKILL.md
@@ -2,6 +2,8 @@
 name: ui-prototyping
 description: Explore multiple *divergent* UI directions for a screen as named Swift #Previews, remix the strongest elements into hybrids, fill them with lived-in sample content and edge-case states, then tune signature animations with a generated tuning panel. Produces real native SwiftUI you carry forward, not throwaway mockups. Use early — after new-app or at the start of any UI-heavy phase, before /apple:plan commits to a single layout. Based on Apple's WWDC method for prototyping with coding agents in Xcode: go wide → remix → make lived-in → tune.
 allowed-tools: [Read, Write, Edit, Bash, Glob, Grep, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
 ---
 
 # UI Prototyping Skill

--- a/skills/design/ux-writing/SKILL.md
+++ b/skills/design/ux-writing/SKILL.md
@@ -2,6 +2,8 @@
 name: ux-writing
 description: Interface copy that works — voice/tone, the PACE framework, alert anatomy, naming features, empty states, error messages, and the small-word edits that measurably improve UX. Distilled from Apple's writing sessions (2017–2026). Use when writing or reviewing any user-facing text — labels, alerts, onboarding, notifications, empty states, paywalls — or naming a feature.
 allowed-tools: [Read, Write, Edit, Glob, Grep]
+last_verified: 2026-07-16
+review_by: 2027-06-22
 ---
 
 # UX Writing

--- a/skills/foundation/SKILL.md
+++ b/skills/foundation/SKILL.md
@@ -2,6 +2,8 @@
 name: foundation
 description: Foundation framework skills — AttributedString patterns for rich text formatting, alignment, selection, and SwiftUI integration. Use when working with styled text or AttributedString APIs.
 allowed-tools: [Read, Glob, Grep]
+last_verified: 2026-07-16
+review_by: 2027-06-22
 ---
 
 # Foundation Skills

--- a/skills/foundation/attributed-string/SKILL.md
+++ b/skills/foundation/attributed-string/SKILL.md
@@ -2,6 +2,9 @@
 name: attributed-string
 description: AttributedString patterns for rich text formatting, alignment, selection, and SwiftUI integration. Use when working with styled text, text editing, or AttributedString APIs.
 allowed-tools: [Read, Glob, Grep]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # AttributedString Patterns

--- a/skills/generators/SKILL.md
+++ b/skills/generators/SKILL.md
@@ -2,6 +2,9 @@
 name: generators
 description: Code generator skills that produce production-ready Swift code for common app components. Use when user wants to add logging, analytics, onboarding, review prompts, networking, authentication, paywalls, settings, persistence, error monitoring, CI/CD pipelines, localization, push notifications, deep linking, testing, accessibility, widgets, feature flags, app icons, image caching, pagination, HTTP caching, share cards, social export, subscription lifecycle, referral systems, watermarks, streak tracking, milestone celebrations, what's new screens, lapsed user re-engagement, usage insights, variable rewards, consent flows, account deletion, permission priming, force updates, state restoration, debug menus, offline queues, feedback forms, announcement banners, quick win sessions, Spotlight indexing, App Clips, screenshot automation, background processing, app extensions, data export, or SwiftUI preview sample data and variant matrices.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # Code Generators

--- a/skills/generators/accessibility-generator/SKILL.md
+++ b/skills/generators/accessibility-generator/SKILL.md
@@ -2,6 +2,8 @@
 name: accessibility-generator
 description: Generate accessibility infrastructure for VoiceOver, Dynamic Type, and accessibility features. Use when improving app accessibility, adding accessibility labels and hints, or auditing compliance.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
 ---
 
 # Accessibility Generator

--- a/skills/generators/account-deletion/SKILL.md
+++ b/skills/generators/account-deletion/SKILL.md
@@ -2,6 +2,9 @@
 name: account-deletion
 description: Generates an Apple-compliant account deletion flow with multi-step confirmation UI, optional data export, configurable grace period, Keychain cleanup, and server-side deletion request. Use when user needs account deletion, right-to-delete, or Apple App Review compliance for account removal.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # Account Deletion Generator

--- a/skills/generators/analytics-setup/SKILL.md
+++ b/skills/generators/analytics-setup/SKILL.md
@@ -2,6 +2,8 @@
 name: analytics-setup
 description: Generates protocol-based analytics infrastructure with swappable providers (TelemetryDeck, Firebase, Mixpanel). Use when user wants to add analytics, track events, or set up telemetry.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
 ---
 
 # Analytics Setup Generator

--- a/skills/generators/announcement-banner/SKILL.md
+++ b/skills/generators/announcement-banner/SKILL.md
@@ -2,6 +2,9 @@
 name: announcement-banner
 description: Generates an in-app announcement banner system with remote configuration, scheduling, deep link actions, and dismiss tracking. Use when user wants in-app banners, promotional notices, maintenance alerts, or contextual announcements.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # Announcement Banner Generator

--- a/skills/generators/app-clip/SKILL.md
+++ b/skills/generators/app-clip/SKILL.md
@@ -2,6 +2,9 @@
 name: app-clip
 description: Generates App Clip targets with invocation URL handling, lightweight experiences, and full app upgrade prompts. Use when user wants NFC/QR/Safari banner invocation, instant app experiences, or App Clip Card setup.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # App Clip Generator

--- a/skills/generators/app-extensions/SKILL.md
+++ b/skills/generators/app-extensions/SKILL.md
@@ -2,6 +2,9 @@
 name: app-extensions
 description: Generates app extension infrastructure for Share Extensions, Action Extensions, Keyboard Extensions, and Safari Web Extensions with data sharing via App Groups. Use when user wants to add a share extension, action extension, keyboard extension, Safari web extension, or any app extension type.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # App Extensions Generator

--- a/skills/generators/app-icon-generator/SKILL.md
+++ b/skills/generators/app-icon-generator/SKILL.md
@@ -2,6 +2,9 @@
 name: app-icon-generator
 description: Generates an app icon for macOS or iOS — a fast CoreGraphics placeholder and/or flat layered source art to finish in Icon Composer (the Liquid Glass / iOS 26+ standard). Produces appearance variants (light/dark/tinted) and installs into the asset catalog. Use when the user wants to create, generate, iterate, or update an app icon.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # App Icon Generator

--- a/skills/generators/app-store-assets/SKILL.md
+++ b/skills/generators/app-store-assets/SKILL.md
@@ -2,6 +2,8 @@
 name: app-store-assets
 description: Comprehensive App Store asset specifications and guidelines for all promotional artwork — app icons, screenshots, app previews, event cards, subscription images, and featuring artwork. Use when preparing assets for App Store Connect upload.
 allowed-tools: [Read, Write, Edit, Glob, Grep, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
 ---
 
 # App Store Assets Generator

--- a/skills/generators/auth-flow/SKILL.md
+++ b/skills/generators/auth-flow/SKILL.md
@@ -2,6 +2,8 @@
 name: auth-flow
 description: Generates authentication infrastructure with Sign in with Apple, biometrics, and Keychain storage. Use when user wants to add authentication, login, or Sign in with Apple.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
 ---
 
 # Auth Flow Generator

--- a/skills/generators/background-processing/SKILL.md
+++ b/skills/generators/background-processing/SKILL.md
@@ -2,6 +2,9 @@
 name: background-processing
 description: Generates background processing infrastructure with BGTaskScheduler, background refresh, background downloads, and silent push handling. Use when user needs background tasks, periodic refresh, background URLSession downloads, or silent push notification processing.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # Background Processing Generator

--- a/skills/generators/ci-cd-setup/SKILL.md
+++ b/skills/generators/ci-cd-setup/SKILL.md
@@ -2,6 +2,8 @@
 name: ci-cd-setup
 description: Generate CI/CD configuration for automated builds, tests, and distribution of iOS/macOS apps. Use when setting up GitHub Actions, Xcode Cloud, or fastlane for continuous integration, TestFlight, or App Store deployment.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
 ---
 
 # CI/CD Setup Generator

--- a/skills/generators/cloudkit-sync/SKILL.md
+++ b/skills/generators/cloudkit-sync/SKILL.md
@@ -2,6 +2,9 @@
 name: cloudkit-sync
 description: Generate CloudKit sync infrastructure using CKSyncEngine with conflict resolution, sharing, and account monitoring. Use when adding iCloud sync to an iOS/macOS app.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # CloudKit Sync Generator

--- a/skills/generators/consent-flow/SKILL.md
+++ b/skills/generators/consent-flow/SKILL.md
@@ -2,6 +2,9 @@
 name: consent-flow
 description: Generates GDPR/CCPA/DPDP privacy consent flows with granular category preferences, consent state persistence, audit logging, and ATT (App Tracking Transparency) integration. Use when user needs privacy consent UI, cookie/tracking consent, or compliance management.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # Consent Flow Generator

--- a/skills/generators/custom-product-pages/SKILL.md
+++ b/skills/generators/custom-product-pages/SKILL.md
@@ -2,6 +2,9 @@
 name: custom-product-pages
 description: Generates Custom Product Page metadata templates with screenshot strategies, keyword targeting, and audience-specific messaging for up to 35 page variants. Use when creating targeted App Store pages for different audiences, ad campaigns, or traffic sources.
 allowed-tools: [Read, Write, Edit, Glob, Grep, AskUserQuestion, WebSearch]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # Custom Product Pages Generator

--- a/skills/generators/data-export/SKILL.md
+++ b/skills/generators/data-export/SKILL.md
@@ -2,6 +2,9 @@
 name: data-export
 description: Generates data export/import infrastructure for JSON, CSV, PDF formats with GDPR data portability, share sheet integration, and file import. Use when user wants data export functionality, CSV/JSON/PDF export, GDPR compliance data portability, import from files, or share sheet for data.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # Data Export Generator

--- a/skills/generators/debug-menu/SKILL.md
+++ b/skills/generators/debug-menu/SKILL.md
@@ -2,6 +2,9 @@
 name: debug-menu
 description: Generates a developer debug menu with feature flag toggles, environment switching, network log viewer, cache clearing, crash trigger, and diagnostic info export. Only included in DEBUG builds. Use when user wants a debug panel, dev tools menu, or shake-to-debug functionality.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # Debug Menu Generator

--- a/skills/generators/deep-linking/SKILL.md
+++ b/skills/generators/deep-linking/SKILL.md
@@ -2,6 +2,8 @@
 name: deep-linking
 description: Generate deep linking infrastructure with URL schemes, Universal Links, and App Intents for Siri/Shortcuts. Use when handling custom URL schemes, Universal Links/Associated Domains, or routing to specific content from external sources.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
 ---
 
 # Deep Linking Generator

--- a/skills/generators/error-monitoring/SKILL.md
+++ b/skills/generators/error-monitoring/SKILL.md
@@ -2,6 +2,9 @@
 name: error-monitoring
 description: Generates protocol-based error/crash monitoring with swappable providers (Sentry, Crashlytics). Use when user wants to add crash reporting, error tracking, or production monitoring.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # Error Monitoring Generator

--- a/skills/generators/feature-flags/SKILL.md
+++ b/skills/generators/feature-flags/SKILL.md
@@ -2,6 +2,9 @@
 name: feature-flags
 description: Generate feature flag infrastructure with local defaults, remote configuration, SwiftUI integration, and debug menu. Use when adding feature flags or A/B testing to iOS/macOS apps.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # Feature Flags Generator

--- a/skills/generators/featuring-nomination/SKILL.md
+++ b/skills/generators/featuring-nomination/SKILL.md
@@ -2,6 +2,8 @@
 name: featuring-nomination
 description: Generates App Store featuring nomination pitches with all required fields, compelling narratives, and Apple editorial angles. Use when submitting your app for App Store editorial featuring or preparing a self-nomination.
 allowed-tools: [Read, Write, Edit, Glob, Grep, AskUserQuestion, WebSearch]
+last_verified: 2026-07-16
+review_by: 2027-06-22
 ---
 
 # Featuring Nomination Generator

--- a/skills/generators/feedback-form/SKILL.md
+++ b/skills/generators/feedback-form/SKILL.md
@@ -2,6 +2,9 @@
 name: feedback-form
 description: Generates an in-app feedback collection form with category selection, text input, optional screenshot attachment, device diagnostics, and smart routing — directing happy users to App Store reviews and unhappy users to support. Use when user wants feedback, bug reports, feature requests, or contact support forms.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # Feedback Form Generator

--- a/skills/generators/force-update/SKILL.md
+++ b/skills/generators/force-update/SKILL.md
@@ -2,6 +2,9 @@
 name: force-update
 description: Generates a minimum version enforcement system with hard-block and soft-prompt update flows, App Store redirect, and remote config or App Store lookup for version checks. Use when user wants force update, mandatory update, or minimum version check.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # Force Update Generator

--- a/skills/generators/http-cache/SKILL.md
+++ b/skills/generators/http-cache/SKILL.md
@@ -2,6 +2,9 @@
 name: http-cache
 description: Generates an HTTP caching layer with Cache-Control parsing, ETag/conditional requests, and offline fallback. Use when user wants to add response caching, offline support, or reduce API calls.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # HTTP Cache Generator

--- a/skills/generators/image-loading/SKILL.md
+++ b/skills/generators/image-loading/SKILL.md
@@ -2,6 +2,9 @@
 name: image-loading
 description: Generates an image loading pipeline with memory/disk caching, deduplication, and a CachedAsyncImage SwiftUI view. Use when user wants image caching, lazy image loading, or a replacement for AsyncImage.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # Image Loading Generator

--- a/skills/generators/in-app-events/SKILL.md
+++ b/skills/generators/in-app-events/SKILL.md
@@ -2,6 +2,8 @@
 name: in-app-events
 description: Generates In-App Event metadata templates for App Store Connect — event names, descriptions, badge types, image specs, and deep link configuration. Use when creating events for App Store visibility, engagement campaigns, or seasonal promotions.
 allowed-tools: [Read, Write, Edit, Glob, Grep, AskUserQuestion, WebSearch]
+last_verified: 2026-07-16
+review_by: 2027-06-22
 ---
 
 # In-App Events Generator

--- a/skills/generators/lapsed-user/SKILL.md
+++ b/skills/generators/lapsed-user/SKILL.md
@@ -2,6 +2,9 @@
 name: lapsed-user
 description: Generates lapsed user detection and re-engagement screens with personalized return experiences, win-back offers, and inactivity tracking. Use when user wants to re-engage inactive users, detect lapsed users, or build return flows.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # Lapsed User Re-Engagement Generator

--- a/skills/generators/live-activity-generator/SKILL.md
+++ b/skills/generators/live-activity-generator/SKILL.md
@@ -2,6 +2,9 @@
 name: live-activity-generator
 description: Generate ActivityKit Live Activity infrastructure with Dynamic Island layouts, Lock Screen presentation, and push-to-update support. Use when adding Live Activities to an iOS app.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # Live Activity Generator

--- a/skills/generators/localization-setup/SKILL.md
+++ b/skills/generators/localization-setup/SKILL.md
@@ -2,6 +2,9 @@
 name: localization-setup
 description: Generate internationalization (i18n) infrastructure for multi-language support in iOS/macOS apps. Use when localizing for multiple languages, adopting String Catalogs (xcstrings), or supporting RTL languages.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # Localization Setup Generator

--- a/skills/generators/logging-setup/SKILL.md
+++ b/skills/generators/logging-setup/SKILL.md
@@ -2,6 +2,9 @@
 name: logging-setup
 description: Generates structured logging infrastructure using os.log/Logger to replace print() statements. Use when user wants to add proper logging, replace print statements, or set up app logging.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # Logging Setup Generator

--- a/skills/generators/milestone-celebration/SKILL.md
+++ b/skills/generators/milestone-celebration/SKILL.md
@@ -2,6 +2,9 @@
 name: milestone-celebration
 description: Generates achievement celebration UI with confetti animations, badge unlocks, progress milestones, haptic feedback, and optional share-to-social. Use when user wants to celebrate achievements, show confetti, display milestone badges, or trigger rewards on key thresholds.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # Milestone Celebration Generator

--- a/skills/generators/networking-layer/SKILL.md
+++ b/skills/generators/networking-layer/SKILL.md
@@ -2,6 +2,9 @@
 name: networking-layer
 description: Generates a protocol-based networking layer with async/await, error handling, and swappable implementations. Use when user wants to add API client, networking, or HTTP layer.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # Networking Layer Generator

--- a/skills/generators/offer-codes-setup/SKILL.md
+++ b/skills/generators/offer-codes-setup/SKILL.md
@@ -2,6 +2,8 @@
 name: offer-codes-setup
 description: Generates offer code distribution strategies and configuration guides for subscription and IAP promotions — including partner campaigns, influencer programs, and email re-engagement. Use when setting up offer codes for distribution.
 allowed-tools: [Read, Write, Edit, Glob, Grep, AskUserQuestion, WebSearch]
+last_verified: 2026-07-16
+review_by: 2027-06-22
 ---
 
 # Offer Codes Setup Generator

--- a/skills/generators/offline-queue/SKILL.md
+++ b/skills/generators/offline-queue/SKILL.md
@@ -2,6 +2,9 @@
 name: offline-queue
 description: Generates an offline operation queue with persistence, automatic retry on connectivity, and conflict resolution. Use when user needs offline-first behavior, queued mutations, or pending operations that sync when back online.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # Offline Queue Generator

--- a/skills/generators/onboarding-generator/SKILL.md
+++ b/skills/generators/onboarding-generator/SKILL.md
@@ -2,6 +2,9 @@
 name: onboarding-generator
 description: Generates multi-step onboarding flows with persistence for iOS/macOS apps. Use when user wants to add onboarding, welcome screens, or first-launch experience.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # Onboarding Generator

--- a/skills/generators/pagination/SKILL.md
+++ b/skills/generators/pagination/SKILL.md
@@ -2,6 +2,9 @@
 name: pagination
 description: Generates pagination infrastructure with offset or cursor-based patterns, infinite scroll, and search support. Use when user wants to add paginated lists, infinite scrolling, or load-more functionality.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # Pagination Generator

--- a/skills/generators/paywall-generator/SKILL.md
+++ b/skills/generators/paywall-generator/SKILL.md
@@ -2,6 +2,9 @@
 name: paywall-generator
 description: Generates StoreKit 2 subscription paywall with modern SwiftUI views. Use when user wants to add subscriptions, paywall, or in-app purchases.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # Paywall Generator

--- a/skills/generators/permission-priming/SKILL.md
+++ b/skills/generators/permission-priming/SKILL.md
@@ -2,6 +2,9 @@
 name: permission-priming
 description: Generates pre-permission priming screens that explain benefits before showing iOS system permission dialogs. Use when user wants to increase permission grant rates, add pre-permission screens, or explain why the app needs access.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # Permission Priming Generator

--- a/skills/generators/persistence-setup/SKILL.md
+++ b/skills/generators/persistence-setup/SKILL.md
@@ -2,6 +2,9 @@
 name: persistence-setup
 description: Generates SwiftData or CoreData persistence layer with optional iCloud sync. Use when user wants to add local storage, data persistence, or cloud sync.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # Persistence Setup Generator

--- a/skills/generators/pre-orders/SKILL.md
+++ b/skills/generators/pre-orders/SKILL.md
@@ -2,6 +2,8 @@
 name: pre-orders
 description: Generates pre-order setup guides and launch timeline templates for App Store pre-orders. Use when planning a pre-order strategy for a new app launch or major update.
 allowed-tools: [Read, Write, Edit, Glob, Grep, AskUserQuestion, WebSearch]
+last_verified: 2026-07-16
+review_by: 2027-06-22
 ---
 
 # Pre-Orders Generator

--- a/skills/generators/preview-data-generator/SKILL.md
+++ b/skills/generators/preview-data-generator/SKILL.md
@@ -2,6 +2,9 @@
 name: preview-data-generator
 description: Generate sample data and a multi-variant #Preview matrix for SwiftUI views — empty/loading/error/loaded states, light/dark, Dynamic Type, locales/RTL, and devices. Use when the user says "add previews", "sample data for previews", "preview my view in different states", "preview data", "prototype this UI", or wants realistic Xcode canvas data without hand-rolling it.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # Preview Data Generator

--- a/skills/generators/product-page-optimization/SKILL.md
+++ b/skills/generators/product-page-optimization/SKILL.md
@@ -2,6 +2,8 @@
 name: product-page-optimization
 description: Generates A/B test plans and optimization checklists for your App Store product page — icon, screenshots, and app previews. Use when running Product Page Optimization tests or improving conversion rates.
 allowed-tools: [Read, Write, Edit, Glob, Grep, AskUserQuestion, WebSearch]
+last_verified: 2026-07-16
+review_by: 2027-06-22
 ---
 
 # Product Page Optimization Generator

--- a/skills/generators/promoted-iap/SKILL.md
+++ b/skills/generators/promoted-iap/SKILL.md
@@ -2,6 +2,9 @@
 name: promoted-iap
 description: Generates Promoted In-App Purchase setup with StoreKit 2 product configuration, paywall integration, and App Store product page display. Use when setting up promoted purchases that appear on the App Store product page.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # Promoted In-App Purchases Generator

--- a/skills/generators/push-notifications/SKILL.md
+++ b/skills/generators/push-notifications/SKILL.md
@@ -2,6 +2,9 @@
 name: push-notifications
 description: Generate push notification infrastructure with APNs registration, handling, and rich notifications. Use when adding push notifications, configuring APNs, notification categories/actions, or rich notifications with images and custom UI.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # Push Notifications Generator

--- a/skills/generators/quick-win-session/SKILL.md
+++ b/skills/generators/quick-win-session/SKILL.md
@@ -2,6 +2,9 @@
 name: quick-win-session
 description: Generates guided first-action flows that help users achieve a meaningful result within 60 seconds to boost retention. Use when user wants quick win onboarding, time-to-value optimization, or first success moments.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # Quick Win Session Generator

--- a/skills/generators/referral-system/SKILL.md
+++ b/skills/generators/referral-system/SKILL.md
@@ -2,6 +2,9 @@
 name: referral-system
 description: Generates referral/invite infrastructure with unique codes, deep link sharing, reward tracking, and fraud prevention. Use when user wants referral codes, invite friends flow, or viral growth mechanics.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # Referral System Generator

--- a/skills/generators/review-prompt/SKILL.md
+++ b/skills/generators/review-prompt/SKILL.md
@@ -2,6 +2,8 @@
 name: review-prompt
 description: Generates smart App Store review prompt infrastructure with configurable conditions and platform detection. Use when user wants to add review prompts, request ratings, or implement StoreKit reviews.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
 ---
 
 # Review Prompt Generator

--- a/skills/generators/screenshot-automation/SKILL.md
+++ b/skills/generators/screenshot-automation/SKILL.md
@@ -2,6 +2,9 @@
 name: screenshot-automation
 description: Generates an automated App Store screenshot pipeline with UI tests for screenshot capture, device framing, localized caption overlays, and multi-size batch export. Use when user wants automated screenshots, App Store screenshot generation, or a fastlane snapshot replacement.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # Screenshot Automation Generator

--- a/skills/generators/settings-screen/SKILL.md
+++ b/skills/generators/settings-screen/SKILL.md
@@ -2,6 +2,8 @@
 name: settings-screen
 description: Generates a complete settings screen for iOS/macOS apps with common sections. Use when user wants to add settings, preferences, or configuration UI.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
 ---
 
 # Settings Screen Generator

--- a/skills/generators/share-card/SKILL.md
+++ b/skills/generators/share-card/SKILL.md
@@ -2,6 +2,9 @@
 name: share-card
 description: Generates shareable card images from app content (achievements, stats, quotes) for social media sharing. Use when user wants to create share images, social cards, shareable content cards, or export app content as images with ShareLink integration.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # Share Card Generator

--- a/skills/generators/social-export/SKILL.md
+++ b/skills/generators/social-export/SKILL.md
@@ -2,6 +2,9 @@
 name: social-export
 description: Generates infrastructure for exporting app content to social platforms (Instagram Stories, TikTok, Twitter/X) with platform-specific formatting, aspect ratios, and metadata. Use when user wants social media export, share to stories, or platform-specific sharing pipelines.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # Social Export Generator

--- a/skills/generators/spotlight-indexing/SKILL.md
+++ b/skills/generators/spotlight-indexing/SKILL.md
@@ -2,6 +2,9 @@
 name: spotlight-indexing
 description: Generates Core Spotlight indexing infrastructure for making app content searchable via system Spotlight with rich attributes and deep link integration. Use when user wants to index content for Spotlight search, Siri suggestions, or system-wide searchability.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # Spotlight Indexing Generator

--- a/skills/generators/state-restoration/SKILL.md
+++ b/skills/generators/state-restoration/SKILL.md
@@ -2,6 +2,9 @@
 name: state-restoration
 description: Generates state preservation and restoration infrastructure for navigation paths, tab selection, scroll positions, and form data across app launches and background termination. Use when user wants to save/restore app state, remember where the user left off, or persist UI state.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # State Restoration Generator

--- a/skills/generators/streak-tracker/SKILL.md
+++ b/skills/generators/streak-tracker/SKILL.md
@@ -2,6 +2,9 @@
 name: streak-tracker
 description: Generates a streak tracking system with timezone-aware day boundaries, streak freeze protection, and streak-at-risk push notifications. Use when user wants daily/weekly engagement streaks, consecutive day tracking, or habit tracking.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # Streak Tracker Generator

--- a/skills/generators/subscription-lifecycle/SKILL.md
+++ b/skills/generators/subscription-lifecycle/SKILL.md
@@ -2,6 +2,9 @@
 name: subscription-lifecycle
 description: Generates StoreKit 2 subscription lifecycle management — grace periods, billing retry, offer codes, win-back offers, upgrade/downgrade paths, and subscription status monitoring. Use when user needs post-purchase subscription state handling beyond the initial paywall.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # Subscription Lifecycle Generator

--- a/skills/generators/subscription-offers/SKILL.md
+++ b/skills/generators/subscription-offers/SKILL.md
@@ -2,6 +2,9 @@
 name: subscription-offers
 description: Generates StoreKit 2 code for all subscription offer types — introductory, promotional, offer codes, and win-back. Includes eligibility checks, offer presentation, and the preferredSubscriptionOffer modifier. Use when adding subscription offers, free trials, or promotional pricing.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # Subscription Offers Generator

--- a/skills/generators/test-generator/SKILL.md
+++ b/skills/generators/test-generator/SKILL.md
@@ -2,6 +2,9 @@
 name: test-generator
 description: Generate test templates for unit tests, integration tests, and UI tests using Swift Testing and XCTest. Use when adding tests to iOS/macOS apps.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # Test Generator

--- a/skills/generators/tipkit-generator/SKILL.md
+++ b/skills/generators/tipkit-generator/SKILL.md
@@ -2,6 +2,9 @@
 name: tipkit-generator
 description: Generate TipKit infrastructure with inline/popover tips, rules, display frequency, and testing utilities. Use when adding contextual tips or feature discovery to an iOS/macOS app.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # TipKit Generator

--- a/skills/generators/usage-insights/SKILL.md
+++ b/skills/generators/usage-insights/SKILL.md
@@ -2,6 +2,9 @@
 name: usage-insights
 description: Generates user-facing usage statistics, activity summaries, and personalized insights dashboards (weekly recaps, year-in-review, Spotify Wrapped-style). Use when user wants to show usage stats, activity insights, or shareable recap screens. Different from analytics-setup which sends data to a backend — this shows insights to the USER on-device.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # Usage Insights Generator

--- a/skills/generators/variable-rewards/SKILL.md
+++ b/skills/generators/variable-rewards/SKILL.md
@@ -2,6 +2,9 @@
 name: variable-rewards
 description: Generates a variable reward system with randomized rewards, daily bonuses, mystery box mechanics, and ethical engagement caps. Use when user wants daily spins, mystery boxes, random rewards, or gamification reward systems.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # Variable Rewards Generator

--- a/skills/generators/watermark-engine/SKILL.md
+++ b/skills/generators/watermark-engine/SKILL.md
@@ -2,6 +2,9 @@
 name: watermark-engine
 description: Generates a watermark overlay system for images and video with configurable positioning, opacity, tiling, and paywall integration for automatic removal on subscription or purchase. Use when user wants to add branding, attribution, or free-tier watermarks to visual content.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # Watermark Engine Generator

--- a/skills/generators/whats-new/SKILL.md
+++ b/skills/generators/whats-new/SKILL.md
@@ -2,6 +2,9 @@
 name: whats-new
 description: Generates a "What's New" / changelog screen shown after app updates with version tracking, feature highlights, and one-time display per version. Use when user wants release notes UI, update notifications, or feature announcements.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # What's New Generator

--- a/skills/generators/widget-generator/SKILL.md
+++ b/skills/generators/widget-generator/SKILL.md
@@ -2,6 +2,9 @@
 name: widget-generator
 description: Generate WidgetKit widgets for iOS/macOS home screen and lock screen with timeline providers, interactive elements, and App Intent configuration. Use when adding widgets to an app.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # Widget Generator

--- a/skills/generators/win-back-offers/SKILL.md
+++ b/skills/generators/win-back-offers/SKILL.md
@@ -2,6 +2,9 @@
 name: win-back-offers
 description: Generates the complete win-back offer flow for churned subscribers — StoreKit Message API handling, eligibility verification, offer sheet presentation, and analytics. Use when implementing win-back campaigns or re-engagement for lapsed subscribers.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # Win-Back Offers Generator

--- a/skills/growth/SKILL.md
+++ b/skills/growth/SKILL.md
@@ -2,6 +2,8 @@
 name: growth
 description: Growth skills for indie Apple developers — user acquisition, analytics interpretation, press/media outreach, community building, and indie business operations. Also covers the stage-by-stage store-growth audit and the post-launch store-signals loop. Use when user asks about growing their app, auditing growth levers, understanding metrics, getting press coverage, or running an indie dev business.
 allowed-tools: [Read, Glob, Grep, AskUserQuestion, WebSearch]
+last_verified: 2026-07-16
+review_by: 2027-06-22
 ---
 
 # Growth Skills

--- a/skills/growth/analytics-interpretation/SKILL.md
+++ b/skills/growth/analytics-interpretation/SKILL.md
@@ -2,6 +2,8 @@
 name: analytics-interpretation
 description: Interpret app metrics and make data-driven decisions. Covers DAU/MAU, retention, LTV, ARPU, App Store Connect analytics, AARRR funnel analysis, cohort analysis, and diagnostic decision trees. Use when user wants to understand their metrics, diagnose problems, or build a data-driven growth plan.
 allowed-tools: [Read, Glob, Grep, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
 ---
 
 # Analytics Interpretation

--- a/skills/growth/community-building/SKILL.md
+++ b/skills/growth/community-building/SKILL.md
@@ -2,6 +2,8 @@
 name: community-building
 description: Build and engage a user community around your indie app. Covers platform selection, building in public strategy, content calendars for solo developers, and converting community members into advocates. Use when user wants to grow social media presence, start building in public, or create a content strategy.
 allowed-tools: [Read, Glob, Grep, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
 ---
 
 # Community Building

--- a/skills/growth/indie-business/SKILL.md
+++ b/skills/growth/indie-business/SKILL.md
@@ -2,6 +2,8 @@
 name: indie-business
 description: Business fundamentals for indie app developers — LLC/entity setup, taxes, Apple Small Business Program, revenue tracking, hiring contractors, and financial planning for sustainability. Use when user asks about business setup, tax implications, hiring, or financial planning for their app business.
 allowed-tools: [Read, Glob, Grep, AskUserQuestion, WebSearch]
+last_verified: 2026-07-16
+review_by: 2027-06-22
 ---
 
 # Indie Business Operations

--- a/skills/growth/press-media/SKILL.md
+++ b/skills/growth/press-media/SKILL.md
@@ -2,6 +2,9 @@
 name: press-media
 description: Get press coverage and media attention for your indie app. Covers press kit preparation, finding journalists/bloggers/YouTubers, pitch timing, embargo strategy, and story angles that get coverage. Use when user wants press coverage, is preparing for a launch, or wants to build a media kit.
 allowed-tools: [Read, Write, Glob, Grep, AskUserQuestion, WebSearch]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # Press & Media Outreach

--- a/skills/growth/store-growth-audit/SKILL.md
+++ b/skills/growth/store-growth-audit/SKILL.md
@@ -2,6 +2,8 @@
 name: store-growth-audit
 description: Stage-by-stage audit of an app's App Store growth machinery against a 54-item P0–P9 playbook — every item scored from an App Store Connect MCP call, a codebase check, or an explicit question to the user, then routed to the skill or command that fixes it. Read-only on App Store Connect. Use for a growth audit or scorecard, a pre-launch growth plan, a quarterly re-audit, or "which growth levers am I missing."
 allowed-tools: [Read, Write, Glob, Grep, AskUserQuestion, mcp__asc-metadata__list_apps, mcp__asc-metadata__get_metadata, mcp__asc-metadata__list_locales, mcp__asc-metadata__get_app_pricing, mcp__asc-metadata__list_price_points, mcp__asc-metadata__get_availability, mcp__asc-metadata__list_iap, mcp__asc-metadata__list_subscription_groups, mcp__asc-metadata__list_subscriptions, mcp__asc-metadata__list_app_events, mcp__asc-metadata__list_experiments, mcp__asc-metadata__list_custom_pages, mcp__asc-metadata__get_analytics_report, mcp__asc-metadata__get_sales_report, mcp__asc-metadata__list_reviews]
+last_verified: 2026-07-16
+review_by: 2027-06-22
 ---
 
 # Store Growth Audit

--- a/skills/growth/store-signals/SKILL.md
+++ b/skills/growth/store-signals/SKILL.md
@@ -2,6 +2,8 @@
 name: store-signals
 description: Close the post-launch loop — turn a live app's App Store signals (reviews, analytics, sales, crashes, listing conversion) into a metric-tagged backlog for the next version, AND verify whether last cycle's changes moved the metric they promised to move. Read-only on App Store Connect; every change is surfaced and routed to another command, never auto-applied. Use before planning the next version, on a monthly cadence, or ~1-2 weeks after shipping to check if a change worked.
 allowed-tools: [Read, Write, Glob, Grep, AskUserQuestion, mcp__asc-metadata__list_apps, mcp__asc-metadata__list_reviews, mcp__asc-metadata__get_review, mcp__asc-metadata__get_analytics_report, mcp__asc-metadata__setup_analytics_reports, mcp__asc-metadata__get_sales_report, mcp__asc-metadata__get_diagnostics, mcp__asc-metadata__get_perf_metrics, mcp__asc-metadata__list_beta_feedback_crashes, mcp__asc-metadata__get_metadata]
+last_verified: 2026-07-16
+review_by: 2027-06-22
 ---
 
 # Store Signals

--- a/skills/ios/SKILL.md
+++ b/skills/ios/SKILL.md
@@ -2,6 +2,9 @@
 name: ios-development
 description: Comprehensive iOS development guidance including Swift best practices, SwiftUI patterns, UI/UX review against HIG, and app planning. Use for iOS code review, best practices, accessibility audits, or planning new iOS apps.
 allowed-tools: [Read, Glob, Grep, WebFetch]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # iOS Development Expert

--- a/skills/ios/accessibility-audit/SKILL.md
+++ b/skills/ios/accessibility-audit/SKILL.md
@@ -2,6 +2,8 @@
 name: accessibility-audit
 description: Run a structured accessibility audit on an iOS/macOS app — automated XCUITest audits, Accessibility Inspector, manual VoiceOver/Dynamic Type passes, and App Store Accessibility Nutrition Label evaluation. Use before release, when preparing Nutrition Label declarations, or for EU Accessibility Act compliance.
 allowed-tools: [Read, Glob, Grep, Bash]
+last_verified: 2026-07-16
+review_by: 2027-06-22
 ---
 
 # Accessibility Audit

--- a/skills/ios/app-planner/SKILL.md
+++ b/skills/ios/app-planner/SKILL.md
@@ -2,6 +2,9 @@
 name: app-planner
 description: Guides you through comprehensive iOS/Swift app planning and analysis. Use for new apps (concept to architecture) or existing apps (audit current state, plan improvements, evaluate tech stack). Covers product planning, technical decisions, UI/UX design, and distribution strategy.
 allowed-tools: [Read, Write, Glob, Grep, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # App Planner Skill

--- a/skills/ios/assistive-access/SKILL.md
+++ b/skills/ios/assistive-access/SKILL.md
@@ -2,6 +2,9 @@
 name: assistive-access
 description: Assistive Access implementation for cognitive accessibility including simplified scenes, navigation icons, runtime detection, and design principles. Use when optimizing apps for Assistive Access mode.
 allowed-tools: [Read, Glob, Grep]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # Assistive Access

--- a/skills/ios/coding-best-practices/SKILL.md
+++ b/skills/ios/coding-best-practices/SKILL.md
@@ -2,6 +2,9 @@
 name: coding-best-practices
 description: Reviews Swift/iOS code for adherence to modern Swift idioms, Apple platform best practices, architecture patterns, and code quality standards. Use when user mentions best practices, code review, clean code, refactoring, or wants to improve code quality.
 allowed-tools: [Read, Glob, Grep]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # Coding Best Practices Skill

--- a/skills/ios/ipad-patterns/SKILL.md
+++ b/skills/ios/ipad-patterns/SKILL.md
@@ -2,6 +2,9 @@
 name: ipad-patterns
 description: iPadOS-specific patterns including Stage Manager, multi-window, drag and drop, keyboard shortcuts, pointer interactions, and Apple Pencil support. Use when building iPad-optimized features.
 allowed-tools: [Read, Glob, Grep]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # iPad Patterns

--- a/skills/ios/migration-patterns/SKILL.md
+++ b/skills/ios/migration-patterns/SKILL.md
@@ -2,6 +2,9 @@
 name: migration-patterns
 description: Migration guides for CoreData to SwiftData, UIKit to SwiftUI, ObservableObject to @Observable, XCTest to Swift Testing, Objective-C to Swift, and StoreKit 1 to StoreKit 2. Use when migrating between Apple framework generations.
 allowed-tools: [Read, Glob, Grep]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # Migration Patterns

--- a/skills/ios/navigation-patterns/SKILL.md
+++ b/skills/ios/navigation-patterns/SKILL.md
@@ -2,6 +2,9 @@
 name: navigation-patterns
 description: SwiftUI navigation architecture patterns including NavigationStack, NavigationSplitView, TabView, programmatic navigation, and custom transitions. Use when reviewing or building navigation, fixing navigation bugs, or architecting app flow.
 allowed-tools: [Read, Glob, Grep]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # Navigation Patterns

--- a/skills/ios/run-device/SKILL.md
+++ b/skills/ios/run-device/SKILL.md
@@ -2,6 +2,9 @@
 name: run-device
 description: Build, install, and launch an iOS app on a physical iPhone or iPad entirely from the command line (no Xcode GUI), using xcodebuild + devicectl. Use when the user wants to run, test, or screenshot their app on a real device without opening Xcode.
 allowed-tools: [Bash, Read]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # Run on a Physical Device (CLI)

--- a/skills/ios/run-simulator/SKILL.md
+++ b/skills/ios/run-simulator/SKILL.md
@@ -2,6 +2,8 @@
 name: run-simulator
 description: Build, install, launch, and screenshot an iOS app in the Simulator to verify a change visually. Use when the user wants to run the app, see a change live, screenshot the running app, or confirm a UI fix actually works (not just that it compiles).
 allowed-tools: [Bash, Read, Glob]
+last_verified: 2026-07-16
+review_by: 2027-06-22
 ---
 
 # Run in Simulator

--- a/skills/ios/ui-review/SKILL.md
+++ b/skills/ios/ui-review/SKILL.md
@@ -2,6 +2,8 @@
 name: ui-review
 description: Review SwiftUI code for iOS/watchOS Human Interface Guidelines compliance, font usage, Dynamic Type support, and accessibility. Use when user mentions UI review, HIG, accessibility audit, font checks, or wants to verify interface design against Apple standards.
 allowed-tools: [Read, Glob, Grep, WebFetch]
+last_verified: 2026-07-16
+review_by: 2027-06-22
 ---
 
 # UI Review Skill

--- a/skills/legal/SKILL.md
+++ b/skills/legal/SKILL.md
@@ -2,6 +2,8 @@
 name: legal
 description: Legal document generation and compliance guidance for indie Apple developers. Covers privacy policies, terms of service, EULAs, GDPR/CCPA/DPDP compliance, and Apple App Store legal requirements. Use when user needs legal documents or compliance guidance.
 allowed-tools: [Read, Glob, Grep, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
 ---
 
 # Legal Document Generation & Compliance

--- a/skills/legal/privacy-policy/SKILL.md
+++ b/skills/legal/privacy-policy/SKILL.md
@@ -2,6 +2,8 @@
 name: privacy-policy
 description: Generate privacy policies, terms of service, and EULAs for Apple platform apps. Detects data collection patterns, third-party SDKs, and generates region-specific legal documents with Apple Privacy Nutrition Label mapping. Use when user needs legal documents or data collection disclosure for App Store submission.
 allowed-tools: [Read, Write, Edit, Glob, Grep, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
 ---
 
 # Privacy Policy & Legal Document Generator

--- a/skills/legal/privacy-publish/SKILL.md
+++ b/skills/legal/privacy-publish/SKILL.md
@@ -2,6 +2,8 @@
 name: privacy-publish
 description: Turn drafted legal docs (privacy policy, terms) into hosted pages and set the App Store Connect Privacy Policy / Support / Marketing URLs via the ASC REST API. Use at Phase 6 / submission, after legal drafts exist. The App Privacy "nutrition label" stays manual (Apple exposes no API) — this prints the exact answers to click.
 allowed-tools: [Read, Bash, AskUserQuestion, mcp__claude-in-chrome__navigate, mcp__claude-in-chrome__computer, mcp__claude-in-chrome__read_page]
+last_verified: 2026-07-16
+review_by: 2027-06-22
 ---
 
 # Privacy Publish

--- a/skills/macos/SKILL.md
+++ b/skills/macos/SKILL.md
@@ -2,6 +2,9 @@
 name: macos-development
 description: Comprehensive macOS development guidance including Swift 6+, SwiftUI, SwiftData, architecture patterns, AppKit bridging, and macOS 26 Tahoe APIs. Use for macOS code review, best practices, UI review, or platform-specific features.
 allowed-tools: [Read, Glob, Grep, WebFetch]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # macOS Development Expert

--- a/skills/macos/app-planner/SKILL.md
+++ b/skills/macos/app-planner/SKILL.md
@@ -2,6 +2,9 @@
 name: app-planner
 description: Plans new macOS apps or analyzes existing projects. Creates comprehensive planning documents covering architecture, features, UI/UX, and tech stack. Use when planning a new macOS app or auditing an existing one.
 allowed-tools: [Read, Write, Glob, Grep, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # App Planner for macOS

--- a/skills/macos/appkit-swiftui-bridge/SKILL.md
+++ b/skills/macos/appkit-swiftui-bridge/SKILL.md
@@ -2,6 +2,9 @@
 name: appkit-swiftui-bridge
 description: Expert guidance for hybrid AppKit-SwiftUI development. Covers NSViewRepresentable, hosting controllers, and state management between frameworks. Use when bridging AppKit and SwiftUI.
 allowed-tools: [Read, Glob, Grep]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # AppKit-SwiftUI Bridge Expert

--- a/skills/macos/architecture-patterns/SKILL.md
+++ b/skills/macos/architecture-patterns/SKILL.md
@@ -2,6 +2,9 @@
 name: architecture-patterns
 description: Deep dive into software architecture for macOS. Covers SOLID principles, design patterns, and modular code organization. Use when designing app architecture or refactoring.
 allowed-tools: [Read, Glob, Grep]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # Architecture Patterns Expert

--- a/skills/macos/coding-best-practices/SKILL.md
+++ b/skills/macos/coding-best-practices/SKILL.md
@@ -2,6 +2,9 @@
 name: coding-best-practices
 description: Reviews macOS Swift 6+ code for modern idioms, SOLID principles, SwiftData patterns, and concurrency best practices. Use when reviewing macOS code quality or asking about best practices.
 allowed-tools: [Read, Glob, Grep]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # Coding Best Practices for macOS Development

--- a/skills/macos/macos-capabilities/SKILL.md
+++ b/skills/macos/macos-capabilities/SKILL.md
@@ -2,6 +2,8 @@
 name: macos-capabilities
 description: Expert guidance on macOS platform capabilities. Covers sandboxing, app extensions, menu bar apps, and background execution. Use when implementing system integration features.
 allowed-tools: [Read, Glob, Grep]
+last_verified: 2026-07-16
+review_by: 2027-06-22
 ---
 
 # macOS Capabilities Expert

--- a/skills/macos/macos-tahoe-apis/SKILL.md
+++ b/skills/macos/macos-tahoe-apis/SKILL.md
@@ -2,6 +2,9 @@
 name: macos-tahoe-apis
 description: Guide to macOS 26 Tahoe APIs and features. Covers Apple Intelligence (FoundationModels), MLX framework, and Continuity. Use when implementing macOS 26 specific features.
 allowed-tools: [Read, Glob, Grep, WebFetch]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # macOS Tahoe APIs

--- a/skills/macos/swiftdata-architecture/SKILL.md
+++ b/skills/macos/swiftdata-architecture/SKILL.md
@@ -2,6 +2,9 @@
 name: swiftdata-architecture
 description: Deep dive into SwiftData design patterns and best practices. Covers schema design, query patterns, repository pattern, and performance optimization. Use when designing data models or improving SwiftData usage.
 allowed-tools: [Read, Glob, Grep]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # SwiftData Architecture Expert

--- a/skills/macos/ui-review-tahoe/SKILL.md
+++ b/skills/macos/ui-review-tahoe/SKILL.md
@@ -2,6 +2,9 @@
 name: ui-review-tahoe
 description: Comprehensive UI/UX review for macOS Tahoe apps. Covers Liquid Glass design, HIG compliance, SwiftUI patterns, and accessibility. Use when reviewing macOS UI or checking HIG compliance.
 allowed-tools: [Read, Glob, Grep, WebFetch]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # UI Review for macOS Tahoe

--- a/skills/mapkit/SKILL.md
+++ b/skills/mapkit/SKILL.md
@@ -2,6 +2,8 @@
 name: mapkit
 description: MapKit and GeoToolbox skills — PlaceDescriptor patterns, geocoding, and cross-service place identifiers with MapKit integration. Use when working with maps, place data, or geocoding.
 allowed-tools: [Read, Glob, Grep]
+last_verified: 2026-07-16
+review_by: 2027-06-22
 ---
 
 # MapKit Skills

--- a/skills/mapkit/geotoolbox/SKILL.md
+++ b/skills/mapkit/geotoolbox/SKILL.md
@@ -2,6 +2,8 @@
 name: geotoolbox
 description: GeoToolbox PlaceDescriptor patterns with MapKit integration for location representation, geocoding, and multi-service place identifiers. Use when working with place descriptors, geocoding, or cross-service location data.
 allowed-tools: [Read, Glob, Grep]
+last_verified: 2026-07-16
+review_by: 2027-06-22
 ---
 
 # GeoToolbox and PlaceDescriptor Patterns

--- a/skills/monetization/SKILL.md
+++ b/skills/monetization/SKILL.md
@@ -2,6 +2,9 @@
 name: monetization
 description: Monetization strategy for iOS/macOS apps. Covers readiness assessment, pricing model selection, tier structuring, free trial strategy, and implementation guidance. Use when deciding what to charge, how to price, or planning monetization end-to-end.
 allowed-tools: [Read, Write, Edit, Glob, Grep, WebSearch, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # Monetization Strategy

--- a/skills/monetization/bundles-and-licensing/SKILL.md
+++ b/skills/monetization/bundles-and-licensing/SKILL.md
@@ -2,6 +2,8 @@
 name: bundles-and-licensing
 description: Revenue beyond the single-app price tag — own-app bundles, Family Sharing as a conversion lever, cross-developer bundles & suites, and institutional licensing via Group Purchases / Apple School & Business Manager. Use when a developer has multiple apps, a subscription worth sharing, complementary indie partners, or school/clinic/business buyers.
 allowed-tools: [Read, Write, Edit, Glob, Grep]
+last_verified: 2026-07-16
+review_by: 2027-06-22
 ---
 
 # Bundles & Licensing

--- a/skills/monetization/external-purchases/SKILL.md
+++ b/skills/monetization/external-purchases/SKILL.md
@@ -2,6 +2,8 @@
 name: external-purchases
 description: US web checkout via the StoreKit External Purchase Link entitlement — currently 0% Apple commission (litigation ongoing), how to ship it safely, and how to architect for a commission flip so a future ruling is a config change, not a rewrite. Use when adding external purchase links, weighing web checkout vs IAP, or planning US-storefront pricing strategy.
 allowed-tools: [Read, Write, Edit, Glob, Grep]
+last_verified: 2026-07-16
+review_by: 2027-06-22
 ---
 
 # External Purchases (US Web Checkout)

--- a/skills/performance/SKILL.md
+++ b/skills/performance/SKILL.md
@@ -2,6 +2,8 @@
 name: performance
 description: Performance profiling and SwiftUI debugging skills — Instruments guidance, hangs, memory issues, slow launches, energy drain, unnecessary re-renders, and view identity problems. Use when an app is slow, janky, or resource-hungry.
 allowed-tools: [Read, Glob, Grep, Bash]
+last_verified: 2026-07-16
+review_by: 2027-06-22
 ---
 
 # Performance Skills

--- a/skills/performance/profiling/SKILL.md
+++ b/skills/performance/profiling/SKILL.md
@@ -2,6 +2,9 @@
 name: performance-profiling
 description: Guide performance profiling with Instruments, diagnose hangs, memory issues, slow launches, and energy drain. Use when reviewing app performance or investigating specific bottlenecks.
 allowed-tools: [Read, Glob, Grep, Bash]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # Performance Profiling

--- a/skills/performance/swiftui-debugging/SKILL.md
+++ b/skills/performance/swiftui-debugging/SKILL.md
@@ -2,6 +2,9 @@
 name: swiftui-debugging
 description: Diagnose SwiftUI performance issues including unnecessary re-renders, view identity problems, and slow body evaluations. Use when SwiftUI views are slow, janky, or re-rendering too often.
 allowed-tools: [Read, Glob, Grep]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # SwiftUI Performance Debugging

--- a/skills/product/SKILL.md
+++ b/skills/product/SKILL.md
@@ -2,6 +2,8 @@
 name: product-development
 description: End-to-end product development for iOS/macOS apps. Covers market research, competitive analysis, PRD generation, architecture specs, UX design, implementation guides, testing, and App Store release. Use for product planning, validation, or generating specification documents.
 allowed-tools: [Read, Write, Glob, Grep, WebFetch, WebSearch, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
 ---
 
 # Product Development Expert

--- a/skills/product/app-namer/SKILL.md
+++ b/skills/product/app-namer/SKILL.md
@@ -2,6 +2,8 @@
 name: app-namer
 description: Turn an app idea into validated, App-Store-ready name candidates. Use when the user says "name my app", "what should I call it", "app name ideas", "help me name this app", "is this name available", or needs to pick a brandable, ownable name before reserving it in App Store Connect.
 allowed-tools: [Read, Write, WebSearch, WebFetch, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
 ---
 
 # App Namer Skill

--- a/skills/product/architecture-spec/SKILL.md
+++ b/skills/product/architecture-spec/SKILL.md
@@ -2,6 +2,9 @@
 name: architecture-spec
 description: Generates technical architecture specification from PRD. Covers architecture pattern, tech stack, data models, and app structure. Use when creating ARCHITECTURE.md or designing system architecture.
 allowed-tools: [Read, Write, Glob, Grep, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # Architecture Spec Skill

--- a/skills/product/beta-testing/SKILL.md
+++ b/skills/product/beta-testing/SKILL.md
@@ -2,6 +2,8 @@
 name: beta-testing
 description: Beta testing strategy for iOS/macOS apps. Covers TestFlight program setup, beta tester recruitment, feedback collection methodology, user interviews, signal-vs-noise interpretation, and go/no-go launch readiness decisions. Use when planning a beta, setting up TestFlight, collecting user feedback, or deciding if ready to launch.
 allowed-tools: [Read, Write, Glob, Grep, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
 ---
 
 # Beta Testing Strategy

--- a/skills/product/competitive-analysis/SKILL.md
+++ b/skills/product/competitive-analysis/SKILL.md
@@ -2,6 +2,8 @@
 name: competitive-analysis
 description: Deep competitive analysis for iOS/macOS apps including feature comparison, pricing analysis, strengths/weaknesses, market positioning, and differentiation opportunities. Use when user asks for competitive analysis, competitor research, feature comparison, market positioning, or wants to understand competition in detail.
 allowed-tools: [Read, Write, WebSearch, WebFetch, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
 ---
 
 # Competitive Analysis Skill

--- a/skills/product/idea-generator/SKILL.md
+++ b/skills/product/idea-generator/SKILL.md
@@ -2,6 +2,9 @@
 name: idea-generator
 description: Brainstorm and rank iOS/macOS app ideas tailored to developer skills. Use when user says "what should I build", "give me app ideas", "I don't know what to build", "brainstorm app ideas", or "help me find an app idea".
 allowed-tools: [Read, Write, WebSearch, WebFetch, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # Idea Generator Skill

--- a/skills/product/implementation-guide/SKILL.md
+++ b/skills/product/implementation-guide/SKILL.md
@@ -2,6 +2,9 @@
 name: implementation-guide
 description: Generates detailed implementation guide with pseudo-code and step-by-step development instructions. Creates IMPLEMENTATION_GUIDE.md from PRD, Architecture, and UX specs. Use when creating development roadmap.
 allowed-tools: [Read, Write, Glob, Grep, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # Implementation Guide Skill

--- a/skills/product/implementation-spec/SKILL.md
+++ b/skills/product/implementation-spec/SKILL.md
@@ -2,6 +2,9 @@
 name: implementation-spec
 description: Master orchestrator that generates all implementation specs (PRD, Architecture, UX, Implementation, Test, Release) from product plan. Use when generating complete specification package.
 allowed-tools: [Read, Write, Glob, Grep, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # Implementation Specification Orchestrator Skill

--- a/skills/product/localization-strategy/SKILL.md
+++ b/skills/product/localization-strategy/SKILL.md
@@ -2,6 +2,9 @@
 name: localization-strategy
 description: Localization and internationalization strategy for iOS/macOS apps. Covers market prioritization, language tier recommendations, minimum viable localization levels, translation workflows, cultural adaptation, localized ASO, and testing. Use when planning localization, expanding to new markets, deciding which languages to support, or planning translation workflow.
 allowed-tools: [Read, Write, Glob, Grep, AskUserQuestion, WebSearch]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # Localization Strategy

--- a/skills/product/market-research/SKILL.md
+++ b/skills/product/market-research/SKILL.md
@@ -2,6 +2,8 @@
 name: market-research
 description: Deep market analysis for iOS/macOS apps including market sizing (TAM/SAM/SOM), growth trends, market maturity, entry barriers, distribution channels, and revenue potential. Use when user asks for market research, market size, market opportunity, growth potential, TAM/SAM/SOM, or market trends.
 allowed-tools: [Read, Write, WebSearch, WebFetch, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
 ---
 
 # Market Research Skill

--- a/skills/product/prd-generator/SKILL.md
+++ b/skills/product/prd-generator/SKILL.md
@@ -2,6 +2,9 @@
 name: prd-generator
 description: Generates comprehensive Product Requirements Document from product plan. Creates PRD.md with features, user stories, acceptance criteria, and success metrics. Use when creating product requirements.
 allowed-tools: [Read, Write, Glob, Grep, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # PRD Generator Skill

--- a/skills/product/product-agent/SKILL.md
+++ b/skills/product/product-agent/SKILL.md
@@ -2,6 +2,8 @@
 name: product-agent
 description: Discover and validate product ideas, analyze markets, scope MVPs, and optimize app store presence for iOS/macOS apps. Use when user asks to discover, validate, assess, scope, or analyze product ideas, market opportunities, or when they mention "product agent", "app idea validation", "should I build this", "MVP", "market analysis", or "ASO".
 allowed-tools: [Read, Write, WebSearch, WebFetch, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
 ---
 
 # Product Agent Skill

--- a/skills/product/release-spec/SKILL.md
+++ b/skills/product/release-spec/SKILL.md
@@ -2,6 +2,9 @@
 name: release-spec
 description: Generates App Store release documentation including submission guide, assets, privacy compliance, and marketing strategy. Creates RELEASE_SPEC.md for app launch. Use when preparing for App Store submission.
 allowed-tools: [Read, Write, Glob, Grep, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # Release Specification Skill

--- a/skills/product/test-spec/SKILL.md
+++ b/skills/product/test-spec/SKILL.md
@@ -2,6 +2,9 @@
 name: test-spec
 description: Generates comprehensive test specification with unit tests, UI tests, accessibility testing, and beta testing plan. Creates TEST_SPEC.md from PRD and implementation specs. Use when creating QA strategy.
 allowed-tools: [Read, Write, Glob, Grep, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # Test Specification Skill

--- a/skills/product/ux-spec/SKILL.md
+++ b/skills/product/ux-spec/SKILL.md
@@ -2,6 +2,9 @@
 name: ux-spec
 description: Generates UI/UX specifications with wireframes and design system. Creates UX_SPEC.md and DESIGN_SYSTEM.md from PRD and Architecture specs. Use when designing app interface and creating design system.
 allowed-tools: [Read, Write, Glob, Grep, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # UX Specification Skill

--- a/skills/release-review/SKILL.md
+++ b/skills/release-review/SKILL.md
@@ -2,6 +2,9 @@
 name: release-review
 description: Senior developer-level release review for macOS/iOS apps. Identifies security, privacy, UX, and distribution issues with actionable fixes. Use when preparing an app for release, want a critical review, or before App Store submission.
 allowed-tools: [Read, Glob, Grep]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # Release Review for Apple Platforms

--- a/skills/security/SKILL.md
+++ b/skills/security/SKILL.md
@@ -2,6 +2,8 @@
 name: security
 description: Security category index for Apple platforms. Routes to the privacy-manifests skill. General secure-storage/biometrics/ATS guidance was retired in the 2026 blind-test audit — current models cover it natively.
 allowed-tools: [Read, Glob, Grep]
+last_verified: 2026-07-16
+review_by: 2027-06-22
 ---
 
 # Security (category index)

--- a/skills/security/privacy-manifests/SKILL.md
+++ b/skills/security/privacy-manifests/SKILL.md
@@ -2,6 +2,8 @@
 name: privacy-manifests
 description: Privacy manifest (PrivacyInfo.xcprivacy) implementation including required reason APIs, tracking domains, third-party SDK declarations, and App Tracking Transparency. Use when preparing apps for App Store privacy requirements.
 allowed-tools: [Read, Glob, Grep]
+last_verified: 2026-07-16
+review_by: 2027-06-22
 ---
 
 # Privacy Manifests

--- a/skills/shared/SKILL.md
+++ b/skills/shared/SKILL.md
@@ -2,6 +2,8 @@
 name: shared
 description: Platform-agnostic skills including skill creation templates and best practices. Use when creating new skills or improving existing ones.
 allowed-tools: [Read, Write, Glob, Grep, Bash]
+last_verified: 2026-07-16
+review_by: 2027-06-22
 ---
 
 # Shared Skills

--- a/skills/shared/skill-auditor/SKILL.md
+++ b/skills/shared/skill-auditor/SKILL.md
@@ -2,6 +2,9 @@
 name: skill-auditor
 description: Audits skills in this repo for consistency, API drift, and structural gaps. Produces a prioritized report grouped by severity (Critical/High/Medium/Low). Use when asked to "audit skills", "check the skill repo for drift", or when planning bulk skill cleanup. Read-only — does not apply fixes.
 allowed-tools: [Read, Glob, Grep, Bash]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # Skill Auditor
@@ -36,9 +39,12 @@ Use `Glob` with pattern `skills/**/SKILL.md` from the repo root. Filter by scope
 
 ### 2. Parse Frontmatter (Cached)
 
-Read the first 15 lines of each `SKILL.md`. Parse:
+Read the first 20 lines of each `SKILL.md`. Parse:
 - Whether `---` frontmatter block exists
 - `name:`, `description:`, `allowed-tools:` field values
+- Freshness keys: `last_verified:`, `review_by:` (dates, required — enforced
+  by `scripts/check-frontmatter.sh`), optional `os_version:`. Overdue
+  `review_by` dates are the stale-skills workflow's job, not a finding here.
 
 Cache this result. Checks C-01, H-01, H-03, L-02 all read from this cache — do not re-read.
 
@@ -230,7 +236,7 @@ The drift heuristic hardcodes "known-current" version constants:
 
 ## Verification
 
-After running the auditor on the full repo, counts should fall within this tolerance band (baseline re-taken 2026-07-11, 165 total `SKILL.md` files scanned — 142 leaf skills + 23 category indexes; the README's "147 skills" counts leaf dirs plus the 5 single-skill categories):
+After running the auditor on the full repo, counts should fall within this tolerance band (baseline re-taken 2026-07-16 after the blind-test audit deletions, 178 total `SKILL.md` files scanned — 155 leaf skills + 23 category indexes; the README's "159 skills" counts leaf dirs plus the 4 single-skill categories):
 
 | Finding | Expected |
 |---|---|

--- a/skills/shared/skill-creator/SKILL.md
+++ b/skills/shared/skill-creator/SKILL.md
@@ -2,6 +2,8 @@
 name: skill-creator
 description: Guides you through creating well-structured Claude Code skills with proper modularization, templates, and best practices. Use when creating new skills or improving existing ones.
 allowed-tools: [Read, Write, Glob, Grep, Bash]
+last_verified: 2026-07-16
+review_by: 2027-06-22
 ---
 
 # Skill Creator
@@ -57,6 +59,8 @@ The main SKILL.md should include:
 name: skill-name
 description: Brief description of what the skill does and when to use it
 allowed-tools: [Read, Write, Edit]
+last_verified: 2026-07-16
+review_by: 2027-06-22
 ---
 ```
 
@@ -64,6 +68,13 @@ allowed-tools: [Read, Write, Edit]
 - `name`: kebab-case skill name (e.g., `code-reviewer`, `ui-audit`)
 - `description`: 1-2 sentences describing the skill and when to use it
 - `allowed-tools`: Array of tools the skill can use
+- `last_verified`: date (YYYY-MM-DD) the content was last checked against
+  reality — set to today when creating; bump on every material edit
+- `review_by`: date (YYYY-MM-DD) of the scheduled re-verification — default
+  to ~2 weeks after the next WWDC (the natural decay event). CI requires both
+  dates; a weekly workflow opens rollup issues when skills pass `review_by`
+- `os_version` (optional): the OS generation the content was verified against
+  (e.g. `iOS 27 / macOS 27`) — add only if the skill cites OS/Swift versions
 
 **Common Tool Combinations:**
 - **Read-only analysis**: `[Read, Glob, Grep]`

--- a/skills/swift/SKILL.md
+++ b/skills/swift/SKILL.md
@@ -2,6 +2,9 @@
 name: swift-development
 description: Swift language patterns and best practices including concurrency, performance, and modern idioms. Use for Swift language-level code review or architecture guidance.
 allowed-tools: [Read, Glob, Grep]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # Swift Development

--- a/skills/swift/concurrency-patterns/SKILL.md
+++ b/skills/swift/concurrency-patterns/SKILL.md
@@ -2,6 +2,9 @@
 name: concurrency-patterns
 description: Swift concurrency patterns including Swift 6.2 approachable concurrency, structured concurrency, actors, continuations, and migration. Use when reviewing or building async code, fixing data race errors, or migrating to Swift 6.
 allowed-tools: [Read, Glob, Grep]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # Swift Concurrency Patterns

--- a/skills/swift/concurrency/SKILL.md
+++ b/skills/swift/concurrency/SKILL.md
@@ -2,6 +2,9 @@
 name: swift-concurrency-updates
 description: Swift 6.2 concurrency updates including default MainActor inference, @concurrent for background work, isolated conformances, and approachable concurrency migration. Use when adopting Swift 6.2 concurrency features or fixing data-race errors.
 allowed-tools: [Read, Glob, Grep]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # Swift 6.2 Concurrency Updates

--- a/skills/swift/memory/SKILL.md
+++ b/skills/swift/memory/SKILL.md
@@ -2,6 +2,9 @@
 name: memory
 description: Swift 6.2 InlineArray and Span types for zero-overhead memory access, fixed-size collections, and safe pointer alternatives. Use when optimizing performance-critical code paths.
 allowed-tools: [Read, Glob, Grep]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # InlineArray and Span

--- a/skills/swiftdata/SKILL.md
+++ b/skills/swiftdata/SKILL.md
@@ -2,6 +2,8 @@
 name: swiftdata
 description: SwiftData skills — class inheritance patterns for hierarchical models, type-based querying, polymorphic relationships, and inheritance-vs-enum decisions. Use when designing SwiftData model hierarchies.
 allowed-tools: [Read, Glob, Grep]
+last_verified: 2026-07-16
+review_by: 2027-06-22
 ---
 
 # SwiftData Skills

--- a/skills/swiftdata/inheritance/SKILL.md
+++ b/skills/swiftdata/inheritance/SKILL.md
@@ -2,6 +2,8 @@
 name: swiftdata-inheritance
 description: SwiftData class inheritance patterns for hierarchical models with type-based querying, polymorphic relationships, and when to choose inheritance vs enums. Use when designing SwiftData model hierarchies.
 allowed-tools: [Read, Glob, Grep]
+last_verified: 2026-07-16
+review_by: 2027-06-22
 ---
 
 # SwiftData Class Inheritance

--- a/skills/swiftui/SKILL.md
+++ b/skills/swiftui/SKILL.md
@@ -2,6 +2,9 @@
 name: swiftui
 description: SwiftUI framework skills — data flow (identity, Observation, state ownership), layout & containers (Layout protocol, lazy-stack performance), AlarmKit, 3D charts, rich text editing, customizable toolbars, and WebKit embedding. Use for SwiftUI state/rendering bugs, custom layouts, scroll performance, or these feature areas.
 allowed-tools: [Read, Glob, Grep]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # SwiftUI Skills

--- a/skills/swiftui/alarmkit/SKILL.md
+++ b/skills/swiftui/alarmkit/SKILL.md
@@ -2,6 +2,9 @@
 name: alarmkit
 description: AlarmKit integration for scheduling alarms and timers with custom UI, Live Activities, and snooze support. Use when implementing alarm or timer features in iOS 26+ apps.
 allowed-tools: [Read, Glob, Grep]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # AlarmKit

--- a/skills/swiftui/charts-3d/SKILL.md
+++ b/skills/swiftui/charts-3d/SKILL.md
@@ -2,6 +2,9 @@
 name: charts-3d
 description: 3D chart visualization with Swift Charts using Chart3D, SurfacePlot, interactive pose control, and surface styling — plus a 2D Swift Charts construction reference (marks, axes, selection, SectorMark, scrollable charts). Use when creating data visualizations with Swift Charts.
 allowed-tools: [Read, Glob, Grep]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # 3D Charts with Swift Charts

--- a/skills/swiftui/data-flow/SKILL.md
+++ b/skills/swiftui/data-flow/SKILL.md
@@ -2,6 +2,9 @@
 name: data-flow
 description: SwiftUI's actual mental model — view identity, lifetime, and dependencies (the Demystify canon), state ownership decision rules, Observation's per-property tracking, body-performance discipline, and the main-actor concurrency contract. Use when state resets mysteriously, views re-render too often, animations glitch between branches, choosing @State vs @Bindable vs plain property, or debugging "why did body run."
 allowed-tools: [Read, Write, Edit, Glob, Grep]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # SwiftUI Data Flow

--- a/skills/swiftui/layout/SKILL.md
+++ b/skills/swiftui/layout/SKILL.md
@@ -2,6 +2,8 @@
 name: layout
 description: SwiftUI layout beyond stacks — the Layout protocol (when custom layout beats GeometryReader), Grid vs lazy grids, custom containers with sections and container values, and lazy-stack/ScrollView performance rules (what breaks laziness, prefetch discipline, scroll APIs). Use when building custom layouts or containers, fixing lazy-stack jank or memory growth, or wiring programmatic/snapping scrolling.
 allowed-tools: [Read, Write, Edit, Glob, Grep]
+last_verified: 2026-07-16
+review_by: 2027-06-22
 ---
 
 # SwiftUI Layout & Containers

--- a/skills/swiftui/text-editing/SKILL.md
+++ b/skills/swiftui/text-editing/SKILL.md
@@ -2,6 +2,9 @@
 name: text-editing
 description: Styled text display and rich text editing in SwiftUI using Text, AttributedString, and TextEditor with formatting controls. Use when implementing rich text editing or styled text display.
 allowed-tools: [Read, Glob, Grep]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # Styled Text Editing

--- a/skills/swiftui/toolbars/SKILL.md
+++ b/skills/swiftui/toolbars/SKILL.md
@@ -2,6 +2,9 @@
 name: toolbars
 description: Modern SwiftUI toolbar patterns including customizable toolbars, search integration, transition effects, and platform-specific behavior. Use when implementing or customizing toolbars in SwiftUI.
 allowed-tools: [Read, Glob, Grep]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # SwiftUI Toolbars

--- a/skills/swiftui/webkit/SKILL.md
+++ b/skills/swiftui/webkit/SKILL.md
@@ -2,6 +2,9 @@
 name: webkit-integration
 description: WebKit integration in SwiftUI using WebView and WebPage for embedding web content, navigation, JavaScript interop, and customization. Use when embedding web content in SwiftUI apps.
 allowed-tools: [Read, Glob, Grep]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # WebKit Integration for SwiftUI

--- a/skills/testing/SKILL.md
+++ b/skills/testing/SKILL.md
@@ -2,6 +2,8 @@
 name: testing
 description: TDD and testing skills for iOS/macOS apps. Covers characterization tests, TDD workflows, test contracts, snapshot tests, and test infrastructure. Use for test-driven development, adding tests to existing code, or building test infrastructure.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
 ---
 
 # Testing & TDD Skills

--- a/skills/testing/characterization-test-generator/SKILL.md
+++ b/skills/testing/characterization-test-generator/SKILL.md
@@ -2,6 +2,8 @@
 name: characterization-test-generator
 description: Generates tests that capture current behavior of existing code before refactoring. Use when you need a safety net before AI-assisted refactoring or modifying legacy code.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
 ---
 
 # Characterization Test Generator

--- a/skills/testing/flow-walkthrough/SKILL.md
+++ b/skills/testing/flow-walkthrough/SKILL.md
@@ -2,6 +2,8 @@
 name: flow-walkthrough
 description: Verify UI *workflow* correctness that a task list, code review, and static screenshots miss. Drives end-to-end user flows in the Simulator via XCUITest with per-step screenshots, statically audits the navigation graph for dead-ends and missing edit paths, and emits a human discoverability checklist. Use after building any phase/slice that adds or changes UI, or when a user reports "I could only figure out the flow by running it."
 allowed-tools: [Read, Write, Edit, Bash, Glob, Grep]
+last_verified: 2026-07-16
+review_by: 2027-06-22
 ---
 
 # Flow Walkthrough Skill

--- a/skills/testing/integration-test-scaffold/SKILL.md
+++ b/skills/testing/integration-test-scaffold/SKILL.md
@@ -2,6 +2,8 @@
 name: integration-test-scaffold
 description: Generate cross-module test harness with mock servers, in-memory stores, and test configuration. Use when testing networking + persistence + business logic together.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
 ---
 
 # Integration Test Scaffold

--- a/skills/testing/snapshot-test-setup/SKILL.md
+++ b/skills/testing/snapshot-test-setup/SKILL.md
@@ -2,6 +2,8 @@
 name: snapshot-test-setup
 description: Set up SwiftUI visual regression testing with swift-snapshot-testing. Generates snapshot test boilerplate and CI configuration. Use for UI regression prevention.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
 ---
 
 # Snapshot Test Setup

--- a/skills/testing/tdd-bug-fix/SKILL.md
+++ b/skills/testing/tdd-bug-fix/SKILL.md
@@ -2,6 +2,8 @@
 name: tdd-bug-fix
 description: Fix bugs using red-green-refactor — reproduce the bug as a failing test first, then fix it. Use when fixing bugs to ensure they never regress.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
 ---
 
 # TDD Bug Fix

--- a/skills/testing/tdd-feature/SKILL.md
+++ b/skills/testing/tdd-feature/SKILL.md
@@ -2,6 +2,8 @@
 name: tdd-feature
 description: Red-green-refactor scaffold for building new features with TDD. Write failing tests first, then implement to pass. Use when building new features test-first.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
 ---
 
 # TDD Feature

--- a/skills/testing/tdd-refactor-guard/SKILL.md
+++ b/skills/testing/tdd-refactor-guard/SKILL.md
@@ -2,6 +2,8 @@
 name: tdd-refactor-guard
 description: Pre-refactor safety checklist. Verifies test coverage exists before AI modifies existing code. Use before asking AI to refactor anything.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
 ---
 
 # TDD Refactor Guard

--- a/skills/testing/test-contract/SKILL.md
+++ b/skills/testing/test-contract/SKILL.md
@@ -2,6 +2,8 @@
 name: test-contract
 description: Generate protocol/interface test suites that any implementation must pass. Define the contract once, test every implementation. Use when designing protocols or swapping implementations.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
 ---
 
 # Test Contract

--- a/skills/testing/test-data-factory/SKILL.md
+++ b/skills/testing/test-data-factory/SKILL.md
@@ -2,6 +2,8 @@
 name: test-data-factory
 description: Generate test fixture factories for your models. Builder pattern and static factories for zero-boilerplate test data. Use when tests need sample data setup.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
 ---
 
 # Test Data Factory

--- a/skills/visionos/SKILL.md
+++ b/skills/visionos/SKILL.md
@@ -2,6 +2,8 @@
 name: visionos
 description: visionOS skills — spatial design (layout ergonomics, eyes-and-hands input, motion comfort, immersion, environments) and widget patterns (mounting styles, glass/paper textures, proximity-aware layouts). Use when designing, building, or reviewing anything for visionOS.
 allowed-tools: [Read, Glob, Grep]
+last_verified: 2026-07-16
+review_by: 2027-06-22
 ---
 
 # visionOS Skills

--- a/skills/visionos/spatial-design/SKILL.md
+++ b/skills/visionos/spatial-design/SKILL.md
@@ -2,6 +2,8 @@
 name: spatial-design
 description: Designing for visionOS — spatial layout and ergonomics (60pt eye targets, field-of-view placement, dynamic scale), eyes-and-hands input with hover rules, motion and visual comfort (the 0.2 Hz rule, vection, depth-cue agreement), immersion strategy, spatial sound, and the video-format decision guide. Use when designing or reviewing any visionOS app, window, volume, or immersive experience.
 allowed-tools: [Read, Write, Edit, Glob, Grep]
+last_verified: 2026-07-16
+review_by: 2027-06-22
 ---
 
 # Spatial Design (visionOS)

--- a/skills/visionos/widgets/SKILL.md
+++ b/skills/visionos/widgets/SKILL.md
@@ -2,6 +2,9 @@
 name: visionos-widgets
 description: visionOS widget patterns including mounting styles, glass/paper textures, proximity-aware layouts, and spatial widget families. Use when creating or adapting widgets for visionOS.
 allowed-tools: [Read, Glob, Grep]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # visionOS Widgets

--- a/skills/watchos/SKILL.md
+++ b/skills/watchos/SKILL.md
@@ -2,6 +2,9 @@
 name: watchOS
 description: watchOS development guidance including SwiftUI for Watch, Watch Connectivity, complications, and watch-specific UI patterns. Use for watchOS code review, best practices, or Watch app development.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion]
+last_verified: 2026-07-16
+review_by: 2027-06-22
+os_version: iOS 27 / macOS 27
 ---
 
 # watchOS Development


### PR DESCRIPTION
Stacked on #52 (base: `overhaul/2-approved-deletions`) — merge that first, then this.

## What

- **Frontmatter**: all 178 SKILL.md files gain `last_verified: 2026-07-16` + `review_by: 2027-06-22` (~2 weeks after WWDC27); `os_version: iOS 27 / macOS 27` added only to the 130 files that cite OS/Swift versions. Dates, not version numbers — the "every commit to main is a release" philosophy stands (noted in CONTRIBUTING).
- **`scripts/check-review-by.sh`** — lists skills past `review_by` (`--list` TSV / `--self-test`). Deliberately **not** in `validate.yml`: the week after WWDC the whole library goes overdue at once by design — that's a work queue, not a broken PR.
- **`.github/workflows/stale-skills.yml`** — weekly cron + `workflow_dispatch`; opens **one rollup issue per category** (checkbox list, `stale-skill` label), skips categories with an open issue. No 150-issue spam.
- **`check-frontmatter.sh`** extended: both dates required, strict `YYYY-MM-DD`.
- **Docs**: CONTRIBUTING, repo CLAUDE.md, and the skill-creator template document the schema; skill-auditor re-baselined (165 → 178 files) and its cached parse covers the new keys.

## Verified locally

- `check-review-by.sh --self-test` ✅; expired-date round-trip (backdate one skill → detected → revert → clean) ✅
- `check-frontmatter.sh` negative test (removed a key → fails; restored → green) ✅
- All existing guards + `claude plugin validate` green (extra frontmatter keys confirmed harmless)
- The workflow's issue-opening path needs a `workflow_dispatch` run on GitHub after merge — backdate one `review_by` on a branch and dispatch to see the rollup issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)