### PR TITLE
ci: bump setup-node to v6 / Node 24 (Node 20 runner deprecation)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -75,9 +75,9 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Install Claude Code CLI
         run: npm install -g @anthropic-ai/claude-code


### PR DESCRIPTION
Fixes the deprecation warning on every plugin-validate run: actions/setup-node@v4 targets Node 20, which GitHub runners now force onto Node 24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)