### PR TITLE
feat: design/game-feel — the juice discipline skill (159 → 160 skills)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "apple-skills",
       "source": "./",
-      "description": "159 Apple platform development skills across 23 categories (iOS, macOS, watchOS, visionOS): code generators, product workflow, App Store/ASO, testing and TDD, design, performance, security, and more. Surfaced as 23 category skills that route to the full library.",
+      "description": "160 Apple platform development skills across 23 categories (iOS, macOS, watchOS, visionOS): code generators, product workflow, App Store/ASO, testing and TDD, design, performance, security, and more. Surfaced as 23 category skills that route to the full library.",
       "skills": [
         "./skills"
       ]
@@ -21,7 +21,7 @@
         "source": "url",
         "url": "https://github.com/rshankras/SwiftShip.git"
       },
-      "description": "SwiftShip \u2014 52 /apple:* workflow commands + 6 pinned agents: idea validation, roadmap, plan, build, review, TestFlight, App Store submission, and post-launch growth. Install apple-skills alongside it (its commands read that library)."
+      "description": "SwiftShip \u2014 53 /apple:* workflow commands + 6 pinned agents: idea validation, roadmap, plan, build, review, TestFlight, App Store submission, and post-launch growth. Install apple-skills alongside it (its commands read that library)."
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-skills",
-  "description": "159 Apple platform development skills across 23 categories (iOS, macOS, watchOS, visionOS): code generators, product workflow, App Store/ASO, testing and TDD, design, performance, security, and more. Surfaced as 23 category skills that route to the full library.",
+  "description": "160 Apple platform development skills across 23 categories (iOS, macOS, watchOS, visionOS): code generators, product workflow, App Store/ASO, testing and TDD, design, performance, security, and more. Surfaced as 23 category skills that route to the full library.",
   "author": {
     "name": "Ravi Shankar"
   },

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Four repos, four layers — use one or all:
 
 | Layer | Repo | What it is |
 |---|---|---|
-| Knowledge | **claude-code-apple-skills** ← you are here | 159 skills — how to build right |
-| Workflow | [SwiftShip](https://github.com/rshankras/SwiftShip) | 52 /apple:* commands — spec-driven idea → App Store |
+| Knowledge | **claude-code-apple-skills** ← you are here | 160 skills — how to build right |
+| Workflow | [SwiftShip](https://github.com/rshankras/SwiftShip) | 53 /apple:* commands — spec-driven idea → App Store |
 | Action | [indie-app-autopilot](https://github.com/rshankras/indie-app-autopilot) | 7 agents — GitHub issue → App Store |
 | Integration | [asc-metadata-mcp](https://github.com/rshankras/asc-metadata-mcp) | 65+ MCP tools — live App Store Connect API |
 
@@ -29,7 +29,7 @@ Four repos, four layers — use one or all:
 | **Growth** | 6 | Analytics, store signals, growth audit, press/media, community, indie business |
 | **Swift** | 3 | Concurrency patterns, Swift 6.2, InlineArray/Span |
 | **Apple Intelligence** | 3 | Foundation Models, Visual Intelligence, App Intents |
-| **Design** | 6 | Liquid Glass, animation patterns, UI prototyping, UX writing, SF Symbols, typography |
+| **Design** | 7 | Liquid Glass, animation patterns, game feel (haptics/sound/celebrations), UI prototyping, UX writing, SF Symbols, typography |
 | **Performance** | 2 | Instruments profiling, SwiftUI debugging |
 | **Security** | 1 | Privacy manifests, required reason APIs |
 | **Core ML** | 1 | Vision, NaturalLanguage, model integration |
@@ -43,7 +43,7 @@ Four repos, four layers — use one or all:
 | **Release Review** | 1 | Pre-release audit checklists |
 | **Shared** | 2 | Meta-skills for creating (`skill-creator`) and auditing (`skill-auditor`) skills |
 
-**Total: 159 skills across 23 categories** (single-skill categories count their category file; other index files aren't counted — enforced by `scripts/check-counts.sh` in CI)
+**Total: 160 skills across 23 categories** (single-skill categories count their category file; other index files aren't counted — enforced by `scripts/check-counts.sh` in CI)
 
 ## Quick Start
 
@@ -73,7 +73,7 @@ demand, so only 23 short descriptions sit in context. Update any time with
 always track `main`.
 
 Want the full workflow too? The same marketplace carries
-[SwiftShip](https://github.com/rshankras/SwiftShip) — 52 /apple:* commands:
+[SwiftShip](https://github.com/rshankras/SwiftShip) — 53 /apple:* commands:
 
 ```
 /plugin install apple@indie-apple-stack
@@ -269,6 +269,7 @@ Generate production-ready Swift code that adapts to your project:
 |-------|----------------|
 | `design/liquid-glass` | Liquid Glass implementation + design rules (SwiftUI/AppKit/UIKit, never glass-on-glass, Regular vs Clear) |
 | `design/animation-patterns` | Springs, PhaseAnimator/KeyframeAnimator, transitions (incl. zoom + interruptibility), symbol effects |
+| `design/game-feel` | Game feel ("juice"): event×channel feedback audit, haptic vocabulary design, SFX layers over music |
 | `design/ui-prototyping` | Divergent UI directions as named #Preview variants — go wide, remix, tune |
 | `design/ux-writing` | Interface copy: PACE framework, voice/tone, alert anatomy, feature naming |
 | `design/sf-symbols` | Choosing/configuring symbols, custom-symbol authoring, animation vocabulary |

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -152,7 +152,7 @@ Vague: "Add payments"
 
 ## Skill Categories
 
-**159 skills across 23 categories** — see the
+**160 skills across 23 categories** — see the
 [What's Included table in the README](../README.md#whats-included) for the
 per-category breakdown (kept in sync with the tree by `scripts/check-counts.sh`).
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -192,7 +192,7 @@ Apple docs location: `/Users/ravishankar/Downloads/docs/`
 | growth/ | 6 | analytics-interpretation, press-media, community-building, indie-business, store-signals, store-growth-audit |
 | swift/ | 3 | concurrency-patterns, concurrency, memory |
 | apple-intelligence/ | 3 | foundation-models, visual-intelligence, app-intents |
-| design/ | 6 | liquid-glass, animation-patterns, ui-prototyping, ux-writing, sf-symbols, typography |
+| design/ | 7 | liquid-glass, animation-patterns, game-feel, ui-prototyping, ux-writing, sf-symbols, typography |
 | legal/ | 2 | privacy-policy, privacy-publish |
 | performance/ | 2 | profiling, swiftui-debugging |
 | security/ | 1 | privacy-manifests |
@@ -205,7 +205,7 @@ Apple docs location: `/Users/ravishankar/Downloads/docs/`
 | watchos/ | 1 | watchos (with 4 reference files) |
 | release-review/ | 1 | release-review |
 | shared/ | 2 | skill-creator, skill-auditor |
-| **Total** | **159 across 23 categories** |
+| **Total** | **160 across 23 categories** |
 
 ---
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -143,7 +143,7 @@ Differences:
 
 ## Skill Categories
 
-**159 skills across 23 categories.** The per-category breakdown lives in one
+**160 skills across 23 categories.** The per-category breakdown lives in one
 place — the [What's Included table in the README](../README.md#whats-included)
 — so it can't drift from the tree (`scripts/check-counts.sh` enforces it in CI).
 

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: design
-description: Design skills for Apple platform UI — Liquid Glass, animations, UI prototyping, UX writing, SF Symbols, and typography. Use when implementing design language features, writing interface copy, or choosing type and iconography.
+description: Design skills for Apple platform UI — Liquid Glass, animations, game feel (haptics, sound, celebrations), UI prototyping, UX writing, SF Symbols, and typography. Use when implementing design language features, adding juice/feedback, writing interface copy, or choosing type and iconography.
 allowed-tools: [Read, Write, Edit, Glob, Grep, AskUserQuestion]
-last_verified: 2026-07-16
+last_verified: 2026-07-18
 review_by: 2027-06-22
 os_version: iOS 27 / macOS 27
 ---
@@ -24,6 +24,8 @@ Use this skill when the user:
 - Needs **view transitions**, **matched geometry**, or **hero transitions**
 - Wants **SF Symbol effects** (bounce, pulse, wiggle, breathe)
 - Asks about **animation completions** or **withAnimation**
+- Says the app feels **flat** or wants **juice/game feel** (celebrations, haptics, sound effects)
+- Wants a **feedback audit** — do events reach the user on the right channels?
 - Needs UX structure help: navigation clarity, discoverability, information architecture
 - Is writing or reviewing interface copy, alerts, or feature names
 - Asks about SF Symbols usage/authoring, fonts, Dynamic Type, or type hierarchy
@@ -46,6 +48,9 @@ SwiftUI animation patterns for iOS 13–18+.
 - View transitions, matched geometry, navigation transitions
 - SF Symbol effects
 - Animation completions, transactions, timing curves
+
+### game-feel/
+Game feel ("juice") as a discipline — the event×channel feedback audit, haptic vocabulary design (Core Haptics service architecture), and sound-effect layers that coexist with music. Routes to animation-patterns for motion technique and generators/milestone-celebration for generated code.
 
 ### ui-prototyping/
 Explore divergent UI directions for a screen as named, runnable Swift `#Preview` variants — compare, remix, and tune before committing to one design.

--- a/skills/design/game-feel/SKILL.md
+++ b/skills/design/game-feel/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: game-feel
+description: Game feel ("juice") for Apple apps — celebration choreography, haptic vocabulary design, sound-effect layers, and the event×channel feedback audit. Use when big moments fall flat, when designing haptics or SFX, or when auditing whether every meaningful event actually reaches the user.
+allowed-tools: [Read, Glob, Grep]
+last_verified: 2026-07-18
+review_by: 2027-06-22
+os_version: iOS 26 / macOS 26
+---
+
+# Game Feel (Juice)
+
+Makes an app's meaningful moments *land* — through coordinated motion, haptics, and sound. Animation technique lives in `design/animation-patterns`; confetti/badge generation lives in `generators/milestone-celebration`. This skill is the **discipline layer**: which events deserve feedback, on which channels, and how to verify nothing important is silent.
+
+## When This Skill Activates
+
+Use this skill when the user:
+- Says the app feels **flat**, **lifeless**, or "lacks juice/polish/delight"
+- Wants **celebrations** designed (winners, streaks, reveals, score changes)
+- Asks to design or review **haptics** (vocabulary, Core Haptics, `.sensoryFeedback`)
+- Asks about **sound effects**, buzzers, countdown ticks, or fanfares
+- Wants a **feedback audit** — do the right events fire the right channels?
+- Is building a **party/group game** where the phone is shared, passed, or watched at a distance
+
+## Core Principles
+
+### 1. Channels have different reach — match the channel to the audience
+
+| Channel | Who perceives it |
+|---------|------------------|
+| Haptics | Only the person **holding** the device |
+| Screen motion | Whoever is **looking** at the screen |
+| Audio | The whole **room** |
+| Torch / flash | The whole room, even in noise |
+
+A single-user utility can lean on haptics. A shared-phone or room-facing app (party games, kitchen timers, presentations) **must** put its signature moments on a room-scale channel. The most common juice failure: all feedback is haptic, and the phone is lying on a table.
+
+### 2. Feedback scales with rarity
+
+Tick < action confirmed < success < round complete < **winner**. If the rarest event (winning) fires the same pattern as a routine one (round end), the app has no climax. Reserve the biggest pattern, the confetti burst, and the fanfare for the rarest event.
+
+### 3. Escalation must agree across channels
+
+If the timer's ring turns amber at 10s and red at 5s, the haptic tier and any audio tick must escalate at the *same* thresholds. Cross-channel disagreement reads as broken, not layered.
+
+### 4. Single-owner rule
+
+Exactly **one** code layer fires feedback for a given event. When an engine *and* a view-store both react to "music stopped", the user gets a double-buzz. Decide the owner (usually the layer closest to the state machine) and make the other layer silent.
+
+### 5. Juice amplifies meaning — it never decorates
+
+Every effect must be attached to an event the user cares about. Ambient/always-on effects (background particles, looping glows) are *texture*, not feedback — keep them static or slow, and never let them compete with event feedback.
+
+### 6. Every channel needs an accessibility story
+
+- Motion → gate large-scale motion on Reduce Motion, with a static equivalent
+- Haptics → user-facing toggle (the system provides no global haptics setting for Core Haptics)
+- Sound → mute toggle independent of system volume; a deliberate, documented silent-switch policy
+
+## Decision Tree
+
+```
+What do you need?
+│
+├─ Which events should have feedback, and on which channels?
+│  └─ → feedback-audit.md (event×channel matrix + three-lens audit)
+│
+├─ Design or review haptics (vocabulary, service architecture, APIs)
+│  └─ → haptic-design.md
+│
+├─ Add a sound-effect layer (assets, latency, AVAudioSession coexistence)
+│  └─ → sound-design.md
+│
+├─ HOW to animate a celebration/transition you've already decided on
+│  └─ → design/animation-patterns (springs, transitions, symbol effects)
+│
+├─ Generate confetti / badge / milestone UI code
+│  └─ → generators/milestone-celebration
+│
+└─ Animated SF Symbols for feedback moments
+   └─ → design/sf-symbols (preset vocabulary)
+```
+
+## Review Checklist
+
+When reviewing an app's game feel, verify:
+
+- [ ] **Signature moments hit ≥2 channels** (e.g. winner = motion + haptic + sound)
+- [ ] **Room-facing events use a room-scale channel** (audio, display-size motion, torch)
+- [ ] **Rarity gradient exists** — the rarest event has visibly/audibly the biggest feedback
+- [ ] **No channel disagreement** — escalation thresholds match across visual/haptic/audio
+- [ ] **Single owner per event** — no double-fire from two layers
+- [ ] **Score/number changes animate** (`.contentTransition(.numericText())`) — values never teleport
+- [ ] **State changes transition** — no hard cuts between phases of a flow
+- [ ] **Reduce Motion parity** — every gated effect has a static equivalent conveying the same information
+- [ ] **User controls exist** — haptics toggle; mute toggle if there's an SFX layer
+- [ ] **Loading/waiting states have anticipation** — determinate progress or a live effect, not a bare spinner at a climactic moment
+
+## Reference Files
+
+| File | Content |
+|------|---------|
+| [feedback-audit.md](feedback-audit.md) | Event×channel matrix method, three-lens audit (runnable subagent prompts), scoring rubric, output format |
+| [haptic-design.md](haptic-design.md) | API decision table, semantic-vocabulary service architecture, pattern design rules, lifecycle, pitfalls |
+| [sound-design.md](sound-design.md) | Minimal SFX kit, asset formats and latency, AVAudioSession coexistence with music, silent-switch policy, pitfalls |
+
+## Related Skills
+
+- `design/animation-patterns` — the *how* of every motion technique
+- `design/sf-symbols` — symbol effect vocabulary for feedback glyphs
+- `generators/milestone-celebration` — production confetti/badge/celebration code
+- `ios/accessibility-audit` — Reduce Motion and assistive-tech verification
+
+## References
+
+- [Human Interface Guidelines — Playing haptics](https://developer.apple.com/design/human-interface-guidelines/playing-haptics)
+- [Human Interface Guidelines — Playing audio](https://developer.apple.com/design/human-interface-guidelines/playing-audio)
+- [Human Interface Guidelines — Motion](https://developer.apple.com/design/human-interface-guidelines/motion)
+- [Core Haptics](https://developer.apple.com/documentation/corehaptics)

--- a/skills/design/game-feel/feedback-audit.md
+++ b/skills/design/game-feel/feedback-audit.md
@@ -1,0 +1,74 @@
+# Feedback Audit
+
+A systematic method for answering: *does every meaningful event actually reach its audience?* Produces an event×channel matrix, a scored report, and a tiered fix list.
+
+## Step 1 — Build the event×channel matrix
+
+List every meaningful event in the app (per mode/flow if the app has modes). For each, record what fires on each channel — **from the code, not from memory** — and who must perceive the event.
+
+| Event | Audience | Visual motion | Haptic | Audio | Verdict |
+|-------|----------|--------------|--------|-------|---------|
+| Round starts | holder | — | — | — | 🔴 silent everywhere |
+| Correct answer | room | — | `.correct` | — | 🟠 room can't perceive it |
+| Timer final 5s | room | ring → red | `.timerUrgent` | — | 🟡 visual+haptic, no audio |
+| Music stops (freeze) | room | ember flash + torch | `.roundEnd` | (music cut = the cue) | ✅ multi-channel |
+| Winner declared | room | — | `.roundEnd` | — | 🔴 climax = routine pattern |
+
+Verdict rules:
+- **Signature events need ≥2 channels**; room-audience events need ≥1 room-scale channel (audio, display-size motion, torch)
+- 🔴 = signature/room event with zero or wrong-reach feedback, or climax reusing a routine pattern
+- 🟠 = meaningful event on one channel only, or channel escalations disagreeing
+- 🟡 = adequate but flat (static where motion is expected; generic where signature is expected)
+- ✅ = channels match audience and rarity
+
+## Step 2 — The three-lens code sweep
+
+Run three *parallel, read-only* audits (subagents if available; sequential passes otherwise). Facts with `file:line` evidence only — no quality judgments until synthesis. Explicit "NOT FOUND" beats silence.
+
+**Lens 1 — Haptics + sound inventory.** Find the haptics mechanism (Core Haptics service? `.sensoryFeedback`? scattered generators?) and describe its architecture: central or ad hoc, lifecycle handling, injection seams, capability gating. Map every fire-site to its event, per mode. Then find every sound-effect mechanism and bundled audio asset (search for player APIs *and* `.caf/.wav/.m4a` files); report the AVAudioSession category/options and interruption handling; report user-facing toggles. List events that fire nothing.
+
+**Lens 2 — Motion inventory.** Find every animation API use (`withAnimation`, `.animation`, `.transition`, `.contentTransition`, `phaseAnimator`, `keyframeAnimator`, `matchedGeometryEffect`, `.symbolEffect`, `TimelineView`, custom `Animatable`). Summarize the vocabulary: which curves/durations, shared tokens or scattered literals. Inspect each celebration moment (winner, score change, reveal, elimination): what actually moves? Check every timer/progress visualization for stepping vs. interpolation. Verify Reduce Motion gates on all large-scale motion and list ungated cases. Check loading states at climactic moments for bare spinners.
+
+**Lens 3 — Cohesion + reach.** Which screens carry the app's design system vs. stock chrome (stock empty-state views, default button styles, system-typography islands)? For each *room-facing* screen: are the primary readouts at display scale? Cross-check channel escalation thresholds (visual color changes vs. haptic tiers vs. audio ticks) for agreement. Flag double-fire owners (two layers reacting to one event).
+
+## Step 3 — Score and report
+
+Rate each dimension; anchor every score to matrix rows and lens evidence:
+
+| Dimension | Poor (1–3) | Adequate (5–6) | Excellent (8–10) |
+|-----------|-----------|----------------|------------------|
+| Feedback coverage | Signature events silent | Most events on one channel | Matrix full; channels match audience |
+| Rarity gradient | Winner = routine pattern | Some differentiation | Climaxes unmistakably biggest |
+| Motion craft | Hard cuts, jumping numbers | Standard transitions | Choreographed, tokenized, interruptible |
+| Haptic design | Scattered presets | Central service, generic patterns | Semantic vocabulary, tuned tiers |
+| Sound design | None where room needs it | Minimal kit, session-correct | Rarity-scaled kit, deliberate policies |
+| Accessibility parity | Ungated motion, no toggles | Reduce Motion gated | Static equivalents + haptic/mute toggles |
+
+## Output Format
+
+```
+## Game-Feel Audit — [App]
+
+### Scorecard
+| Dimension | Score | Evidence |
+
+### Event×Channel Matrix
+[the matrix, worst rows first]
+
+### Findings
+🔴 Critical: [silent signature moments, wrong-reach feedback]
+🟠 High: [single-channel signature events, double-fires, escalation disagreement]
+🟡 Medium: [flat-but-present feedback, stock islands]
+🟢 Low: [tokenization, minor polish]
+
+### Fix tiers
+Tier 1 — wiring (hours): missing haptic events, numericText, symbol effects
+Tier 2 — celebration moments (day): confetti burst, reveals, transitions
+Tier 3 — sound layer (day + assets + policy decisions): see sound-design.md
+```
+
+Tier 3 always requires **user decisions** (silent-switch policy, asset sourcing) — surface them, never assume.
+
+## Honest limits
+
+A code audit verifies *existence and wiring*, not *feel*. Intensity curves, animation timing, loudness balance, and torch visibility are device-only judgments — end every audit report by scheduling a device pass. The Simulator plays no haptics and its audio timing lies.

--- a/skills/design/game-feel/haptic-design.md
+++ b/skills/design/game-feel/haptic-design.md
@@ -1,0 +1,98 @@
+# Haptic Design
+
+Designing a haptic *vocabulary* — semantic, distinct, and centrally owned — rather than sprinkling generator calls through views.
+
+## API Decision Table
+
+| Need | API | Notes |
+|------|-----|-------|
+| Simple state-driven feedback in SwiftUI | `.sensoryFeedback(_:trigger:)` (iOS 17+) | Declarative; fine for `.success`, `.selection`, `.impact` on value changes |
+| One-off imperative feedback, UIKit-style | `UIImpactFeedbackGenerator` etc. | Call `prepare()` first; limited to system presets |
+| A custom vocabulary of distinct patterns | **Core Haptics** (`CHHapticEngine`) | The right choice once you have ≥4 semantic events; full intensity/sharpness control |
+| Designer-authored waveforms | AHAP files + `CHHapticPatternPlayer` | Only worth it for signature audio-haptic sync moments |
+
+Rule of thumb: the moment you catch yourself choosing between `.success` and `.impact(weight:)` for *game* events, you've outgrown presets — build a Core Haptics vocabulary.
+
+## The Semantic-Vocabulary Architecture
+
+One central service owns the engine; game code speaks in *meanings*, never in patterns:
+
+```swift
+enum HapticEvent {
+    case start          // round/session begins
+    case correct        // success tap
+    case pass           // skip / failure tap
+    case reveal         // content shown (card, letter, dare)
+    case timerPulse     // gentle urgency (e.g. 10s left)
+    case timerUrgent    // hard urgency (e.g. 5s left)
+    case stop           // the signature interrupt (music stop, freeze, catch)
+    case roundEnd       // round complete, score committed
+    case winner         // the rarest, biggest pattern
+}
+
+@MainActor @Observable
+final class HapticsService {
+    private var engine: CHHapticEngine?
+    private let supportsHaptics =
+        CHHapticEngine.capabilitiesForHardware().supportsHaptics
+
+    func fire(_ event: HapticEvent) {
+        guard supportsHaptics else { return }          // silent no-op on Simulator/iPad
+        startEngineIfNeeded()                          // lazy start on first use
+        // build CHHapticPattern from events(for: event), play it
+    }
+}
+```
+
+Architecture rules (each prevents a real failure):
+
+- **Lazy engine start** on first `fire`, not in `init` — engine start is not free and may race app launch.
+- **Capability-gate once** (`capabilitiesForHardware().supportsHaptics`) so every call site can fire blindly; no availability checks leak into views.
+- **Handle `stoppedHandler` / `resetHandler`** by nulling the engine so the *next* fire restarts it — the system stops engines freely (audio interruptions, thermal).
+- **Stop the engine on background** (`scenePhase` change) and let lazy-start recover on foreground — a running engine in background wastes power and can be killed out from under you.
+- **Inject as an optional seam** (`haptics: HapticsService? = nil` in stores/engines) — unit tests pass `nil`; previews pass a throwaway.
+- Views get it via `@Environment`; only *stores/engines* fire game events (see single-owner rule in SKILL.md).
+
+## Vocabulary Design Rules
+
+1. **Name events by meaning, not by pattern** — `.correct`, not `.doubleTapLight`. The pattern can be retuned later without touching call sites.
+2. **Signature moments get signature patterns.** The freeze/stop moment of a music game, the spin of a wheel, the winner — each needs its *own* event. Reusing `.roundEnd` for the winner erases the climax (rarity gradient, SKILL.md).
+3. **Escalation tiers are pattern *pairs*** — `.timerPulse` and `.timerUrgent` should be the same shape at different intensity/sharpness so they read as "the same thing, more urgent", and their thresholds must match the visual escalation exactly.
+4. **Continuous events for continuous moments.** A spin deserves a `.hapticContinuous` with an intensity ramp (parameter curves), not repeated transients. Transients are for instants.
+5. **Cover every event in the domain, then stop.** Draw up the event×channel matrix (feedback-audit.md) first; if an event isn't in the matrix, it doesn't get a haptic.
+
+## Pattern Sketches (starting points, tune on device)
+
+| Event | Shape |
+|-------|-------|
+| `.start` | One medium transient (intensity 0.6, sharpness 0.4) — "we've begun" |
+| `.correct` | One crisp transient (0.8, 0.7) |
+| `.pass` | One soft dull transient (0.5, 0.25) |
+| `.timerPulse` | Light transient (0.4, 0.3) each second |
+| `.timerUrgent` | Same cadence, harder (0.8, 0.6) |
+| `.stop` | Heavy transient + 0.3s continuous rumble tail — unmistakable |
+| `.roundEnd` | Two transients 150ms apart |
+| `.winner` | Three ascending transients + continuous swell — the biggest thing you play |
+
+## Pitfalls
+
+#### ❌ Double-fire
+Engine fires on "music stopped" *and* the store fires on the same state change → user feels a stutter-buzz. One owner per event.
+
+#### ❌ Preset semantics for game events
+`UINotificationFeedbackGenerator().notificationOccurred(.success)` for a winner — it's the same buzz every form in iOS uses. Signature moments deserve custom patterns.
+
+#### ❌ No user toggle
+Core Haptics ignores any system setting — there is no global "haptics off" that covers you. Ship a settings toggle; store it in the service, not in every call site.
+
+#### ❌ Testing feel in the Simulator
+The Simulator plays **no haptics at all**. Pattern *code* can be unit-tested (event → pattern mapping), but intensity/sharpness tuning is device-only work — schedule it.
+
+#### ✅ Do
+Centralize; speak semantics; gate once; tune the rarest events to be the biggest; give users an off switch.
+
+## References
+
+- [HIG — Playing haptics](https://developer.apple.com/design/human-interface-guidelines/playing-haptics)
+- [Core Haptics documentation](https://developer.apple.com/documentation/corehaptics)
+- [CHHapticEngine](https://developer.apple.com/documentation/corehaptics/chhapticengine)

--- a/skills/design/game-feel/sound-design.md
+++ b/skills/design/game-feel/sound-design.md
@@ -47,6 +47,15 @@ The session category is a *policy decision*; make it deliberately and write it d
 #### ❌ The classic mistake
 Activating a fresh `.playback` session just to play a ding — it **stops the user's background music**. If their music should keep playing, you want `.ambient` + `.mixWithOthers`, activated once, not per sound.
 
+#### ⚠️ "Set the category once" fails when another component also sets it
+If any other part of the app sets an *exclusive* category later (a music
+engine claiming the room for its own playback is the common case), your
+once-set mixing option is gone — and the next SFX play activates the stale
+exclusive session, pausing the user's music. Field-proven fix: **re-assert
+your category+options immediately before every play** (cheap), and never
+call `setActive(false)` from the SFX layer — session activation belongs to
+whichever component owns the room's audio.
+
 #### Silent-switch policy
 `.playback` ignores the ringer switch; `.ambient` respects it. For a game whose *product* is the room hearing the buzzer, playing through the switch during an active session is the defensible choice (players opted into a loud activity) — but pair it with an in-app mute. For everything else, respect the switch. Either way: **document the choice** where reviewers will look, because it *will* be questioned.
 

--- a/skills/design/game-feel/sound-design.md
+++ b/skills/design/game-feel/sound-design.md
@@ -1,0 +1,80 @@
+# Sound Design (SFX Layer)
+
+A sound-effect layer distinct from music playback: what to ship, how to play it with near-zero latency, and how to coexist with music — the host's or your own.
+
+## Why sound is not optional for room-facing apps
+
+Haptics reach only the holder; screen motion reaches only whoever is looking. When the phone is passed around, lying flat, or facing away (party games, timers, group activities), **audio is the only channel the room perceives**. A time-up moment that is haptic-only is *silent* to everyone but one person. If the app has any moment the room must notice, that moment needs a sound (or torch).
+
+## The minimal kit
+
+Resist a sound per event. Four to six mastered effects cover a whole app:
+
+| Sound | Fires on | Character |
+|-------|----------|-----------|
+| Tick | Final-seconds countdown | Short, quiet, pitch-stable |
+| Buzzer | Time up / failure | Unmistakable, ~0.5s |
+| Ding | Success / correct | Bright, ~0.3s |
+| Reveal | Content shown (card, wheel lands) | Soft whoosh/pop |
+| Fanfare | Winner — the rarest event | The only "big" sound, 1–2s |
+
+Master all effects to consistent perceived loudness; the fanfare may peak louder. Same rarity gradient as haptics: routine sounds small, rare sounds big.
+
+## Asset format and latency
+
+| Player | Latency | Use for | Caveats |
+|--------|---------|---------|---------|
+| `AVAudioPlayer` (preloaded + `prepareToPlay()`) | Low | The default for SFX | Allocate **once per sound at startup**, not per play |
+| `AVAudioEngine` + `AVAudioPlayerNode` | Lowest | Overlapping/rapid-fire SFX, pitch variation | More setup; buffers stay scheduled |
+| `AudioServicesPlaySystemSound` | Low | Fire-and-forget UI blips | No volume control, no session control — avoid for games |
+| `AVPlayer` | High (streaming-class) | **Never** for SFX | Built for media, spins up per item |
+
+- **Format: `.caf` containing PCM (or IMA4)** — decodes with effectively zero spin-up. Compressed formats (MP3/AAC) add decoder latency to the first play.
+- Convert anything with the built-in tool: `afconvert input.wav output.caf -d ima4 -f caff`
+- Keep effects short (≤2s) and small; they live in the app bundle, not remote config.
+
+## Coexisting with music — the AVAudioSession decision
+
+The session category is a *policy decision*; make it deliberately and write it down.
+
+| Situation | Category / options | Result |
+|-----------|-------------------|--------|
+| SFX over **your own** in-app music | One `.playback` session; mix SFX at engine level | Music and SFX share the session you already own |
+| SFX while **the user's** music plays (Apple Music, Spotify) | `.ambient` + `.mixWithOthers` | Effects layer over their music without stopping it |
+| SFX must be *heard over* their music | add `.duckOthers` | Their music dips during your effect — use sparingly |
+| Quiet utility app | `.ambient` (default respects silent switch) | Effects mute with the ringer switch |
+
+#### ❌ The classic mistake
+Activating a fresh `.playback` session just to play a ding — it **stops the user's background music**. If their music should keep playing, you want `.ambient` + `.mixWithOthers`, activated once, not per sound.
+
+#### Silent-switch policy
+`.playback` ignores the ringer switch; `.ambient` respects it. For a game whose *product* is the room hearing the buzzer, playing through the switch during an active session is the defensible choice (players opted into a loud activity) — but pair it with an in-app mute. For everything else, respect the switch. Either way: **document the choice** where reviewers will look, because it *will* be questioned.
+
+## User control
+
+- **In-app mute toggle for SFX**, independent of the haptics toggle and of music volume. Store it in the sound service; check it at fire time.
+- If music and SFX both exist, two volumes (or music/SFX toggles) beat one master switch.
+- Never gate SFX on Reduce Motion — unrelated setting. There is no system "reduce sounds" to honor; your toggle *is* the accessibility story.
+
+## VoiceOver interplay
+
+Game-critical announcements (whose turn, what happened) should be **VoiceOver announcements**, not just SFX — a buzzer conveys *that* something happened, never *what*. Post `AccessibilityNotification.Announcement` alongside the sound. If effects talk over speech, add `.interruptSpokenAudioAndMixWithOthers` to the options and test with VoiceOver live.
+
+## Service shape
+
+Mirror the haptics architecture (haptic-design.md): one `@Observable` service, semantic events (often the *same* enum the haptics service uses — one `fire(event:)` fanning out to both), preloaded players keyed by event, capability/no-op seams for tests, mute state persisted. Game code fires meaning; the service decides channels.
+
+## Pitfalls
+
+#### ❌ Allocating `AVAudioPlayer` per play — first-play latency and dropped sounds under rapid fire
+#### ❌ MP3 assets for latency-critical effects — decoder spin-up on first play
+#### ❌ Killing the user's music with a needless `.playback` activation
+#### ❌ No mute toggle — the only recourse is deleting the app
+#### ❌ SFX as the sole conveyance of game state — pair with VoiceOver announcements
+#### ✅ Preload `.caf` PCM at startup, one session policy chosen deliberately, mute toggle, rarity-scaled loudness
+
+## References
+
+- [HIG — Playing audio](https://developer.apple.com/design/human-interface-guidelines/playing-audio)
+- [AVAudioSession category/options](https://developer.apple.com/documentation/avfaudio/avaudiosession)
+- [AVAudioEngine](https://developer.apple.com/documentation/avfaudio/avaudioengine)


### PR DESCRIPTION
## What

Adds `skills/design/game-feel/` — the discipline layer for game feel ("juice") that the library was missing. The library already taught *how* to animate (`design/animation-patterns`) and generates celebration code (`generators/milestone-celebration`); this skill covers **which events deserve feedback, on which channels, and how to verify nothing important is silent**:

- `SKILL.md` — channel-reach model (haptics reach the holder; audio/torch reach the room), rarity gradient, cross-channel escalation agreement, single-owner rule, review checklist
- `feedback-audit.md` — the event×channel matrix method + a three-lens code sweep (runnable subagent prompts) + scoring rubric + output format
- `haptic-design.md` — API decision table, semantic-vocabulary Core Haptics service architecture, pattern design rules, lifecycle pitfalls
- `sound-design.md` — minimal SFX kit, .caf/latency guidance, AVAudioSession coexistence with music, silent-switch policy, user-control rules

## Field-tested before merge

The skill was exercised end-to-end on a real app (Antics) the same day it was written: audit → three fix tiers → device verification. Two findings were folded back in:
- a device-only bug the audit's method predicted (an anticipation-floor case) validated the audit checklist
- the second commit corrects `sound-design.md`'s "set the category once" advice with the field-proven re-assert-per-play pattern (an exclusive category set later by a music engine would otherwise pause the user's own music)

## Bookkeeping

- `design/SKILL.md` router + activation triggers updated
- Counts registered everywhere `check-counts.sh` enforces: README (table + listings), plugin.json, marketplace.json, docs/USAGE, QUICK_START, ROADMAP
- Cross-repo count bumped to 53 for the paired SwiftShip command
- All validators green (`check-counts`, `check-frontmatter`, `check-freshness`, `check-review-by`, `check-marketplace-compat`, `check-api-symbols`)

## Merge order

**Merge this PR before** rshankras/SwiftShip's `feat/apple-juice-command` — that PR's `/apple:juice` command reads this skill's files, and SwiftShip CI resolves skill references against this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)