### PR TITLE
feat(macos-development): enhance SKILL.md description with Tahoe apis/frameworks included

### DIFF
--- a/skills/macos/SKILL.md
+++ b/skills/macos/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: macos-development
-description: Comprehensive macOS development guidance including Swift 6+, SwiftUI, SwiftData, architecture patterns, AppKit bridging, and macOS 26 Tahoe APIs. Use for macOS code review, best practices, UI review, or platform-specific features.
+description: Comprehensive macOS development guidance including Swift 6+, SwiftUI, SwiftData, architecture patterns, AppKit bridging, and macOS 26 Tahoe APIs (mlx, apple intelligence, continuity, xcode). Use for macOS code review, best practices, UI review, platform-specific features, or MLX/on-device inference integration.
 allowed-tools: [Read, Glob, Grep, WebFetch]
 last_verified: 2026-07-16
 review_by: 2027-06-22


### PR DESCRIPTION
Updated the description to include additional topics like MLX and on-device inference integration, that are not obvious with current description, but this SKILL brings useful info! 

Found this issue 4-5 months ago while iterating with some Agents, and I was curious why they didn't load this skill when I was massively working with MLX framework. Iterated with a couple of different AI families and opted for these changes. I have manually added continuity and xcode, but feel free to reshape.

Current workaround is that I keep a "PATCHES.md" that I apply on every update, but I think is worth pushing upstream. So here we are :)